### PR TITLE
Feature: sass themeing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ yarn-error.log
 /storybook-static
 /docs
 /docs-build
-/stories/assets/css/style.css
-/stories/assets/css/style.css.map
+/stories/assets/css/style*.css
+/stories/assets/css/style*.css.map
 .DS_Store
 .scannerwork
 .vscode/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --progress",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o docs-build --loglevel verbose",
-    "scss": "sass --watch ./stories/assets/scss/style.scss ./stories/assets/css/style.css",
+    "scss": "sass --watch ./stories/assets/scss/style.scss:./stories/assets/css/style.css ./stories/assets/scss/style-preventionweb.scss:./stories/assets/css/style-preventionweb.css",
     "lint": "npm run lint:css && npm run lint:js",
     "lint:css": "stylelint ./stories/**/*.scss --fix",
     "lint:js": "eslint --ignore-pattern '*.mdx' --ignore-pattern '**/Table.jsx' ./stories --fix"

--- a/stories/assets/scss/_variables-preventionweb.scss
+++ b/stories/assets/scss/_variables-preventionweb.scss
@@ -1,0 +1,16 @@
+// we import the default _variables.scss so we only need to override any settings specific to PW
+@import './variables';
+
+//PW Specific colors
+$pw-color-primary: #0a6969;
+
+//PW-COLORS HOVER
+$mg-color-hover-primary: $pw-color-primary;
+
+//PW-COMPONENT COLORS
+$mg-color-label: $mg-color-neutral-0;
+$mg-color-label--hover: $mg-color-neutral-0;
+$mg-color-button-background: $sendai-orange;
+$mg-color-button-background--hover: $sendai-orange-900;
+
+/* variables end */

--- a/stories/assets/scss/style-preventionweb.scss
+++ b/stories/assets/scss/style-preventionweb.scss
@@ -1,0 +1,79 @@
+@import './normalize';
+@import './variables-preventionweb';
+@import './mixins';
+@import './grid';
+@import './typography';
+@import './base';
+
+//Atom
+@import '../../Atom/BaseTypography/Abbr/abbr';
+@import '../../Atom/BaseTypography/Blockquote/blockquote';
+@import '../../Atom/BaseTypography/Cite/cite';
+@import '../../Atom/BaseTypography/Code/code';
+@import '../../Atom/BaseTypography/Mark/mark';
+@import '../../Atom/BaseTypography/Quotation/quotation';
+@import '../../Atom/BaseTypography/Small/small';
+@import '../../Atom/Cards/CardThumbnail/card-thumbnail';
+@import '../../Atom/Cards/PublicationThumbnail/publication-thumbnail';
+@import '../../Atom/Colors/color';
+@import '../../Atom/Icons/icons';
+@import '../../Atom/Images/AuthorImage/author-image';
+@import '../../Atom/Images/Image/image';
+@import '../../Atom/Images/ImageCaptionCredit/image-caption-credit';
+@import '../../Atom/Images/ImageCredit/image-credit';
+@import '../../Atom/Layout/Grid/grid';
+@import '../../Atom/Layout/Spacing/spacing';
+@import '../../Atom/Navigation/Breadcrumb/breadcrumb';
+@import '../../Atom/Navigation/LanguageSwitcherRow/language-switcher-row';
+@import '../../Atom/Navigation/MenuItems/menu-items';
+@import '../../Atom/Navigation/ProgressBarNavigation/progress-bar-navigation';
+@import '../../Atom/Navigation/SidebarFirstLevel/sidebar-first-level';
+@import '../../Atom/ReachElement/Details/details';
+@import '../../Atom/ReachElement/Figcaption/figcaption';
+@import '../../Atom/Table/table';
+@import '../../Atom/Video/video';
+
+//Components
+@import '../../Components/Forms/Checkbox/checkbox';
+@import '../../Components/Forms/Dropdowns/CustomSelect/custom-select';
+@import '../../Components/Forms/Dropdowns/Multiselect/multi-select';
+@import '../../Components/Forms/InputFields/input-fields';
+@import '../../Components/Forms/Radio/radio';
+@import '../../Components/Forms/Select/select';
+@import '../../Components/Navigationcomponents/Breadcrumbs/breadcrumbs';
+@import '../../Components/Navigationcomponents/Pagination/pagination';
+@import '../../Components/Navigationcomponents/Sidebar/sidebar';
+@import '../../Components/UIcomponents/Accordion/accordion';
+@import '../../Components/UIcomponents/Buttons/Chips/Chips';
+@import '../../Components/UIcomponents/Buttons/CtaButton/buttons';
+@import '../../Components/UIcomponents/Buttons/CtaLink/cta-link';
+@import '../../Components/UIcomponents/Cards/Card/card';
+@import '../../Components/UIcomponents/Cards/StatsCards/stats-cards';
+
+@import '../../Components/UIcomponents/Hero/hero';
+
+
+@import '../../Components/UIcomponents/LanguageSwitcher/language-switcher';
+@import '../../Components/UIcomponents/Tab/tab';
+
+//Molecules
+
+@import '../../Molecules/ImageCaption/image-caption';
+@import '../../Molecules/SidebarData/sidebar-data';
+@import '../../Molecules/Text/CtaBlock/cta-block';
+@import '../../Molecules/Text/BlockquoteComponent/blockquotecomp';
+@import '../../Molecules/Text/HeadingBig/headingbig';
+@import '../../Molecules/Text/Page/page';
+
+@import '../../Molecules/Text/SmallCopy/smallcopy';
+@import '../../Molecules/Text/Tertiary/tertiary';
+
+//Organism
+
+
+//Patterns
+
+
+//Utilities
+@import '../../Utilities/Loader/loader';
+


### PR DESCRIPTION
This is my thinking on how we can handle site-level theming.

- `_variables.scss` the default and a common import to all other themes
- `_variables-sitename.scss` the site-specific theme, that imports `_variables.scss` to do most of the heav lifting
- `style-sitename.scss` the main sass file per theme, we could make this reuse the main `style.scss` easily, but each theme having its own master Sass file allows us to do things like include or exclude any components on a site theme level

Next would be to see how well this method integrates with https://github.com/etchteam/storybook-addon-css-variables-theme