### PR TITLE
Enhancement: gutenberg build

### DIFF
--- a/stories/assets/scss/style-gutenberg.scss
+++ b/stories/assets/scss/style-gutenberg.scss
@@ -1,0 +1,22 @@
+/**
+ * This is a "temporary" solution to ease the development
+ * of our prototype Gutenberg components.
+ * It should be removed once the Mangrove library is fully
+ * theme aware and in sync with UNDRR themes.
+ *
+ * See also:
+ * https://git.un.org/undrr/web-backlog/-/issues/611
+ * https://git.un.org/undrr/web-backlog/-/issues/545
+ */
+
+@import './variables';
+@import './breakpoints';
+@import './mixins';
+@import './grid';
+// @import './base';
+
+// We only bring in a limited set of components needed for gutenberg
+// @import './components';
+@import '../../Components/UIcomponents/Buttons/CtaButton/buttons';
+@import '../../Components/UIcomponents/Cards/Card/card';
+@import '../../Components/UIcomponents/Hero/hero';


### PR DESCRIPTION
This is done to support https://git.un.org/undrr/web-backlog/-/issues/611 by creating a CSS build that provides only what is needed for Gutenberg -- and to do so without breaking the existing UNDRR themes.

Compiled version will be available at unisdr.github.io/undrr-mangrove/css/style-gutenberg.css