### PR TITLE
1904 tabs itteration nesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log
 .yarn/cache/
 coverage/
 /.yarn
+.cache
 
 # Ignore npm's package lock, we use yarn
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docker-up": "docker compose up -d",
     "docker-install": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn install\"",
     "docker-run": "yarn docker-up && yarn docker-install && docker exec -it undrr-mangrove-client-1 bash -c \"yarn run storybook --ci\"",
+    "docker-storybook": "NODE_ENV=development storybook dev -p 6006",
     "docker-build": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run build\"",
     "docker-build-storybook": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run build-storybook\"",
     "docker-lint": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run lint:check\"",

--- a/stories/Components/Tab/Tab.jsx
+++ b/stories/Components/Tab/Tab.jsx
@@ -9,14 +9,16 @@ export function Tab({ tabdata, variant }) {
     <div className={`mg-tabs ${variant === 'stacked' ? 'mg-tabs--stacked' : 'mg-tabs--horizontal'}`}>
       <ul className="mg-tabs__list" data-mg-js-tabs>
         {tabdata.map((tab, index) => (
-          <li key={index} className="mg-tabs__item">
-            <a className="mg-tabs__link" href={`#mg-tabs__section-${tab.text_id}`}>{tab.text}</a>
-              <div className="mg-tabs-content" data-mg-js-tabs-content>
-                <section className="mg-tabs__section" id={`mg-tabs__section-${tab.text_id}`}>
-                  {tab.data}
-                </section>
-              </div>
-          </li>
+          <>
+            <li key={index} className="mg-tabs__item">
+              <a className="mg-tabs__link" href={`#mg-tabs__section-${tab.text_id}`}>{tab.text}</a>
+            </li>
+            <li className="mg-tabs-content" data-mg-js-tabs-content>
+              <section className="mg-tabs__section" id={`mg-tabs__section-${tab.text_id}`}>
+                {tab.data}
+              </section>
+            </li>
+          </>
         ))}
       </ul>
     </div>

--- a/stories/Components/Tab/Tab.mdx
+++ b/stories/Components/Tab/Tab.mdx
@@ -65,5 +65,5 @@ The stacked tabs variant displays the tabs vertically in an accordion-like layou
 
 - 2.0 
   - Add `mg-tabs--stacked` and `mg-tabs--horizontal` variants.
-  - The structure has changes so the tab content is inside the parent li. This should be a non-breaking change.
+  - The structure has changes so the tab content is inside the parent li. For existing tabs implementations this should be a non-breaking change, however for vanilla HTML versions a change will only be needed to take advantage of the stacked variant. Consult the HTML in the example story.
 - 1.0 — Released component

--- a/stories/Components/Tab/Tab.stories.jsx
+++ b/stories/Components/Tab/Tab.stories.jsx
@@ -18,7 +18,7 @@ const getCaptionForLocale = (locale) => {
             data: "The Sendai Framework is the global roadmap for reducing human and economic loss as a direct result of disasters.",
           },
           {
-            text: "Tab title 3",
+            text: "Tab title 3 i am a bit longer and go on and on",
             text_id: "tab-3",
             data: "Midterm Review of the Sendai Framework - Register your interest for consultations on the Political Declaration.",
           },
@@ -102,7 +102,7 @@ const getCaptionForLocale = (locale) => {
             data: "The Sendai Framework is the global roadmap for reducing human and economic loss as a direct result of disasters.",
           },
           {
-            text: "Tab title 3",
+            text: "Tab title 3 i am a bit longer and on and on",
             text_id: "tab-3",
             data: "Midterm Review of the Sendai Framework - Register your interest for consultations on the Political Declaration.",
           },

--- a/stories/Components/Tab/tab.scss
+++ b/stories/Components/Tab/tab.scss
@@ -1,9 +1,3 @@
-// testing
-// .mg-tabs {
-//   background: red;
-//   padding: 20px;
-// }
-
 .mg-tabs__list {
   background: $mg-color-tabbar-background;
   width: 100%;
@@ -54,18 +48,14 @@
 // With the introdcution of stacked and horizontal tabs we changed
 // the html structure so that the content is grouped under the li.
 // We scopped the css changes to ensure backwards compatibility.
-.mg-tabs--stacked {
-
-  // .mg-tabs--horizontal {
+.mg-tabs--stacked,
+  .mg-tabs--horizontal {
   .mg-tabs-content {
-
-    // display: none;
-    .mg-tabs__section {
-      padding: $mg-spacing-150;
-    }
+    padding-left: 0; // unset the li style padding
+    display: grid;
   }
 
-  .mg-tabs__link.is-active+.mg-tabs-content {
+  .mg-tabs__link.is-active + .mg-tabs-content {
     display: block;
   }
 }
@@ -77,40 +67,58 @@
       "tabs"
       "section";
     grid-template-columns: 1fr;
-    /* Single column layout */
     grid-template-rows: auto 1fr;
-    /* Adjust row heights as needed */
-    gap: $mg-spacing-150;
-    /* Adjust the gap as needed */
     position: relative;
-
+  }
+  .mg-tabs__section {
+    padding: $mg-spacing-150;
   }
 }
 
 .mg-tabs--horizontal {
+  @media (min-width: $mg-breakpoint-mobile) {
+    .mg-tabs__list {
+      display: grid;
+      min-width: 800px;
+      grid-template-areas:
+        "a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a"
+        "b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b";
+    }
 
-  .mg-tabs__list {
-    display: grid;
-    // grid-template-rows: auto 1fr;
-    grid-template-columns: minmax(100px, 300px);
-    // grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    // width: 100%;
-    // height: 100%;
+    .mg-tabs__item {
+      grid-row: 1;
+      display: flex;
+    }
+
+    .mg-tabs__link {
+      width: max-content; // force the tab title to be one line and not squisshed by min-content
+      display: flex;
+      flex-grow: 1;
+    }
+
+    .mg-tabs-content {
+      width: 100%;
+      height: 100%;
+      grid-row: 2;
+      grid-column: 1 / -1;
+      grid-area: b;
+
+      list-style-type: none;
+    }
   }
-
-  .mg-tabs__item {
-    grid-row: 1;
-    display: flex;
+  // for smaller screens it mimics stacked tabs
+  @media (max-width: $mg-breakpoint-mobile) {
+    .mg-tabs--horizontal {
+      .mg-tabs-content {
+        padding-left: 0; // unset the li style padding
+        display: grid;
+      }
+    
+      .mg-tabs__link.is-active + .mg-tabs-content {
+        display: block;
+      }
+    }
   }
-
-  .mg-tabs-content {
-    width: 100%;
-    height: 100%;
-    grid-row: 2;
-    grid-column: auto / span 30;
-    list-style-type: none;
-  }
-
   // edge case with css grid and not selecting even though not visible
   .mg-tabs-content:has([hidden]) {
     display: none;
@@ -165,7 +173,7 @@
 
 [dir="rtl"] {
   .mg-tabs {
-    >ul {
+    > ul {
       padding-right: 0;
 
       @include devicebreak(medium) {

--- a/stories/Components/Tab/tab.scss
+++ b/stories/Components/Tab/tab.scss
@@ -54,27 +54,66 @@
 // With the introdcution of stacked and horizontal tabs we changed
 // the html structure so that the content is grouped under the li.
 // We scopped the css changes to ensure backwards compatibility.
-.mg-tabs--stacked,
-.mg-tabs--horizontal {
+.mg-tabs--stacked {
+
+  // .mg-tabs--horizontal {
   .mg-tabs-content {
-    display: none;
+
+    // display: none;
     .mg-tabs__section {
       padding: $mg-spacing-150;
     }
   }
 
-  .mg-tabs__link.is-active + .mg-tabs-content {
+  .mg-tabs__link.is-active+.mg-tabs-content {
     display: block;
   }
 }
 
-.mg-tabs--horizontal {
-  position: relative;
+.mg-tabs--stacked {
+  .mg-tabs__list {
+    display: grid;
+    grid-template-areas:
+      "tabs"
+      "section";
+    grid-template-columns: 1fr;
+    /* Single column layout */
+    grid-template-rows: auto 1fr;
+    /* Adjust row heights as needed */
+    gap: $mg-spacing-150;
+    /* Adjust the gap as needed */
+    position: relative;
 
-  .mg-tabs__section {
-    position: absolute;
-    left: 0;
-    width: calc(100% - $mg-spacing-150 * 2);
+  }
+}
+
+.mg-tabs--horizontal {
+
+  .mg-tabs__list {
+    display: grid;
+    // grid-template-rows: auto 1fr;
+    grid-template-columns: minmax(100px, 300px);
+    // grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    // width: 100%;
+    // height: 100%;
+  }
+
+  .mg-tabs__item {
+    grid-row: 1;
+    display: flex;
+  }
+
+  .mg-tabs-content {
+    width: 100%;
+    height: 100%;
+    grid-row: 2;
+    grid-column: auto / span 30;
+    list-style-type: none;
+  }
+
+  // edge case with css grid and not selecting even though not visible
+  .mg-tabs-content:has([hidden]) {
+    display: none;
   }
 }
 
@@ -126,7 +165,7 @@
 
 [dir="rtl"] {
   .mg-tabs {
-    > ul {
+    >ul {
       padding-right: 0;
 
       @include devicebreak(medium) {

--- a/stories/Components/Tab/tab.scss
+++ b/stories/Components/Tab/tab.scss
@@ -102,10 +102,10 @@
       grid-row: 2;
       grid-column: 1 / -1;
       grid-area: b;
-
       list-style-type: none;
     }
   }
+
   // for smaller screens it mimics stacked tabs
   @media (max-width: $mg-breakpoint-mobile) {
     .mg-tabs--horizontal {
@@ -119,6 +119,7 @@
       }
     }
   }
+
   // edge case with css grid and not selecting even though not visible
   .mg-tabs-content:has([hidden]) {
     display: none;

--- a/stories/assets/js/tabs.js
+++ b/stories/assets/js/tabs.js
@@ -88,9 +88,11 @@ export function mgTabs(scope, activateDeepLinkOnLoad) {
     firstTab.setAttribute("aria-selected", "true");
     firstTab.classList.add("is-active");
   });
+
+  // Initially reveal the first tab panel
   Array.prototype.forEach.call(panelsList, (panel) => {
-    // Initially reveal the first tab panel
-    let firstPanel = panel.querySelectorAll(".mg-tabs__section")[0];
+    let parentTabSet = panel.closest(".mg-tabs__list");
+    let firstPanel = parentTabSet.querySelectorAll(".mg-tabs__section")[0];
     firstPanel.hidden = false;
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19494,11 +19494,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=d69c25"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/dc4bec403cd33a204b655b1152a096a08e7bad2c931cb59ef8ff26b6f2aa541bf98f09fc157958a60c921b1983a8dde9a85b692f9de60fa8f574fd131e3ae4dd
+  checksum: 10/00504c01ee42d470c23495426af07512e25e6546bce7e24572e72a9ca2e6b2e9bea63de4286c3cfea644874da1467dcfca23f4f98f7caf20f8b03c0213bb6837
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This revises the previous update to the tabs restructure to further flatten nesting. The tabs and contents are now peer elements allowing for a pure CSS gridlayout

```
<li tab-1 label>
<li tab-1 contents>
<li tab-2 label>
<li tab-2 contents>
<li tab-3 label>
<li tab-3 contents>
```

We are still non-disruptive to "v1" tabs.