### PR TITLE
Enhancement optimize build and dist

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -33,8 +33,8 @@ jobs:
         run: yarn run lint:check
       - name: Build Storybook
         run: |
-          yarn run build-storybook
-          mv docs-build _site
+          yarn run build
+          mv docs-build-temp _site
       - name: Build bundle
         run: |
          yarn run build

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn-error.log
 /storybook-static
 /docs
 /docs-build
+/docs-build-temp
 /stories/assets/css/style*.css
 /stories/assets/css/style*.css.map
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,6 @@ build:
 	@docker ps | grep undrr-mangrove-client-1 > /dev/null && \
 	docker exec -it undrr-mangrove-client-1 bash -c "yarn run build"
 
-build-storybook:
-	@docker ps | grep undrr-mangrove-client-1 > /dev/null && \
-	docker exec -it undrr-mangrove-client-1 bash -c "yarn run build-storybook"
-
 lint:
 	@docker ps | grep undrr-mangrove-client-1 > /dev/null && \
     docker exec -it undrr-mangrove-client-1 bash -c "yarn run lint:check"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ yarn docker-install
 # Build the project for release inside the Docker container
 yarn docker-build
 
-# Build Storybook and SASS inside the Docker container
-yarn docker-build-storybook
-
 # Lint the codebase inside the Docker container
 yarn docker-lint
 ```
@@ -54,9 +51,6 @@ make install
 
 # Run Storybook locally
 make run
-
-# Build Storybook and SASS
-make build-storybook
 
 # Lint the codebase
 make lint
@@ -86,9 +80,6 @@ docker exec -it undrr-mangrove-client-1 bash -c "yarn run storybook --ci"
 
 # Build the project for release (default mode is production)
 docker exec -it undrr-mangrove-client-1 bash -c "yarn run build"
-
-# Build Storybook and SASS
-docker exec -it undrr-mangrove-client-1 bash -c "yarn run build-storybook"
 
 # Lint the codebase
 docker exec -it undrr-mangrove-client-1 bash -c "yarn run lint"
@@ -124,6 +115,14 @@ yarn test:coverage
 
 We do not yet make the compiled assets available directly; see:
 https://gitlab.com/undrr/web-backlog/-/issues/545
+
+Provisional assets are available in the `dist` directory:
+
+- `dist/components`: the compiled Storybook components
+    - example: `dist/components/ShareButtons.js`
+- `dist/assets`: the compiled static assets ... jpg, css, web fonts, etc.
+    - example: `dist/assets/css/style-preventionweb.css`
+    - `dist/assets/fonts/mangrove-icon-set/font/mangrove-icon-set.woff2`
 
 ## Credit
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "Mangrove design System for UNDRR",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress",
+    "build": "NODE_ENV=production yarn run scss && storybook build -o docs-build-temp --loglevel verbose && webpack --progress",
     "dev": "NODE_ENV=development yarn run storybook",
     "storybook": "NODE_ENV=development storybook dev -p 6006",
-    "build-storybook": "NODE_ENV=production yarn run scss && storybook build -o docs-build --loglevel verbose",
     "scss": "sass ./stories/assets/scss:./stories/assets/css --silence-deprecation import",
     "scss-watch": "sass --watch ./stories/assets/scss:./stories/assets/css --silence-deprecation import",
     "lint": "yarn run lint:css && yarn run lint:js",
@@ -22,7 +21,6 @@
     "docker-run": "yarn docker-up && yarn docker-install && docker exec -it undrr-mangrove-client-1 bash -c \"yarn run storybook --ci\"",
     "docker-storybook": "NODE_ENV=development storybook dev -p 6006",
     "docker-build": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run build\"",
-    "docker-build-storybook": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run build-storybook\"",
     "docker-lint": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn run lint:check\"",
     "docker-update": "docker exec -it undrr-mangrove-client-1 bash -c \"yarn upgrade-interactive\""
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = [
     mode: packMode,
     entry: webpackEntry("js"),
     output: {
-      path: path.resolve(__dirname, "docs"),
+      path: path.resolve(__dirname, "dist"),
       filename: "[name].min.js",
       libraryTarget: "umd",
     },
@@ -69,7 +69,7 @@ module.exports = [
       "react-dom": "react-dom",
     },
     output: {
-      path: path.resolve(__dirname, "dist"),
+      path: path.resolve(__dirname, "dist/components"),
       filename: "[name].js",
       library: {
         type: "module",


### PR DESCRIPTION
Heads up @zechtz @robertopanzeri -- the tl;dr is that `build-storybook` is gone and to just run `build`.

---

As mentioned in the readme (https://github.com/unisdr/undrr-mangrove?tab=readme-ov-file#compiled-assets) we've avoided making compiled assets available until https://gitlab.com/undrr/web-backlog/-/issues/545 gets further along.

However the current build process is very obtuse and confusing.

This optimises things:

1. Gets rid of the two confusing `build` and `build-storybook` commands. these should always be done together and `build` now does both
2. Optimises the local build folders
3. Consolidates all assets in `/dist`
4. Provisional assets are available from github (see revised readme)

