### PR TITLE
docs: add getting started guides for multiple integration approaches

### DIFF
--- a/stories/Components/TableOfContents/TableOfContents.jsx
+++ b/stories/Components/TableOfContents/TableOfContents.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { mgTableOfContents } from "./js/TableOfContentsVanillaJs";
 
-export default function TableOfContents({ tocData, showNumbers = false }) {
+export default function TableOfContents({ tocData, showNumbers = false, title = "On this page" }) {
   const ListComponent = showNumbers ? "ol" : "ul";
 
   const contentRef = useRef(null);
@@ -15,11 +15,11 @@ export default function TableOfContents({ tocData, showNumbers = false }) {
 
   return (
     <div ref={contentRef}>
-      <section data-mg-table-of-contents data-mg-table-of-contents-title="Title name can be optionally passed" className="mg-table-of-contents" ref={tocRef}>
+      <section className="mg-table-of-contents" data-mg-table-of-contents data-mg-table-of-contents-title={title} ref={tocRef}>
         <ListComponent>
           {tocData.map((item, index) => (
             <li key={index}>
-             <a href={`#${item.id}`}>{item.text}</a>
+              <a href={`#${item.id}`}>{item.text}</a>
             </li>
           ))}
         </ListComponent>
@@ -31,4 +31,5 @@ export default function TableOfContents({ tocData, showNumbers = false }) {
 TableOfContents.defaultParameters = {
   tocData: [],
   showNumbers: false,
+  title: "On this page",
 };

--- a/stories/Components/TableOfContents/TableOfContents.mdx
+++ b/stories/Components/TableOfContents/TableOfContents.mdx
@@ -72,7 +72,7 @@ To use the TableOfContents component in your React application:
 
 #### DOM Scraping
 
-It is possible to populate the Table of Contents by scraping a section. 
+It is possible to populate the Table of Contents by scraping a section.
 
 1. Import `stories\Components\TableOfContents\js\TableOfContentsVanillaJs.js`
 
@@ -89,7 +89,7 @@ It is possible to populate the Table of Contents by scraping a section.
     <h2 id="section-3">Section 3</h2>
     <p>Content for section 3...</p>
     <h2 id="section-4" class="mg-table-of-contents--exclude">Section 4</h2>
-    <p>excluded with .mg-table-of-contents--exclude</p>        
+    <p>excluded with .mg-table-of-contents--exclude</p>
     <h3 id="section-5">Sub-section 5</h3>
     <p>Skipped as it is a h3</p>
     <h2 id="section-6">Section 6</h2>
@@ -128,6 +128,7 @@ Ensure that the sections referenced in the TableOfContents have proper heading t
 
 ### Changelog
 
+- 1.3: Support the passing of the name of the title for React usage.
 - 1.2:
     - Add ability to pass title (`data-mg-table-of-contents-title="Title name can be optionally passed"`, can be hidden by passing `hidden`)
     - Remove excesive CSS, this can instead be added at the page level

--- a/stories/Documentation/Accessibility.mdx
+++ b/stories/Documentation/Accessibility.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/blocks';
 
 <Meta
-  title="Getting started/Accessibility"
+  title="Getting started/Best practices/Accessibility"
   parameters={{
     viewMode: "docs",
     previewTabs: {
@@ -18,3 +18,121 @@ All patterns are perceivable, operable, and understandable to users, even when u
 
 Please find additional information about accessibility in the links below:
 Visit W3C WCAG for more detail https://www.w3.org/TR/WCAG21/
+
+
+### 1. Semantic HTML
+
+**✅ Use proper HTML elements**
+```html
+<!-- Good: Semantic button -->
+<button class="mg-cta-button mg-cta-button--primary">
+  <span class="mg-cta-button__text">Submit Report</span>
+</button>
+
+<!-- Good: Semantic navigation -->
+<nav class="mg-breadcrumb" aria-label="Breadcrumb">
+  <ol class="mg-breadcrumb__list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/reports">Reports</a></li>
+    <li aria-current="page">Current Report</li>
+  </ol>
+</nav>
+```
+
+**❌ Avoid div-based interactive elements**
+```html
+<!-- Avoid: Non-semantic clickable div -->
+<div class="mg-cta-button" onclick="handleClick()">Submit</div>
+```
+
+### 2. ARIA Labels and Descriptions
+
+**Form Fields**
+```jsx
+<InputFields
+  type="email"
+  element="input"
+  labelText="Email Address"
+  helpText="We'll never share your email with anyone"
+  errorText="Please enter a valid email address"
+  id="email"
+  aria-describedby="email-help email-error"
+  required
+/>
+```
+
+**Interactive Elements**
+```jsx
+<CtaButton
+  label="Download"
+  Type="Primary"
+  aria-label="Download the Global Assessment Report PDF (2.3MB)"
+  onClick={handleDownload}
+/>
+```
+
+**Loading States**
+```jsx
+<div aria-live="polite" aria-busy={isLoading}>
+  {isLoading ? 'Loading reports...' : `Found ${reports.length} reports`}
+</div>
+```
+
+### 3. Keyboard Navigation
+
+**Focus Management**
+```jsx
+function Modal({ isOpen, onClose, children }) {
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      modalRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    <div
+      className="mg-modal"
+      role="dialog"
+      aria-modal="true"
+      ref={modalRef}
+      tabIndex={-1}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+**Skip Links**
+```html
+<a href="#main-content" class="mg-skip-link">Skip to main content</a>
+<nav class="mg-navigation">...</nav>
+<main id="main-content" class="mg-main">...</main>
+```
+
+### 4. Color and Contrast
+
+**Sufficient Contrast**
+```scss
+// Ensure WCAG AA compliance (4.5:1 for normal text)
+$mg-text-color: #212529;        // High contrast on white
+$mg-text-muted: #6c757d;        // 4.5:1 contrast ratio
+$mg-link-color: #0066cc;        // Accessible blue
+$mg-error-color: #dc3545;       // High contrast red
+```
+
+**Don't rely solely on color**
+```jsx
+// Good: Color + icon + text
+<div className="mg-alert mg-alert--error">
+  <span className="mg-icon mg-icon--error" aria-hidden="true">⚠️</span>
+  <span className="mg-alert__text">Error: Please check your input</span>
+</div>
+
+// Avoid: Color only
+<div className="mg-alert mg-alert--error">
+  Please check your input
+</div>
+```

--- a/stories/Documentation/BestPractices.mdx
+++ b/stories/Documentation/BestPractices.mdx
@@ -1,0 +1,334 @@
+import { Meta, Source } from '@storybook/blocks';
+import TableOfContents from '../Components/TableOfContents/TableOfContents';
+
+<Meta
+  title="Getting started/Best practices"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }}
+/>
+
+# Best practices
+
+<TableOfContents
+  tocData={[
+    { id: "performance-best-practices", text: "Performance Best Practices" },
+    { id: "accessibility-best-practices", text: "Accessibility Best Practices" },
+    { id: "architecture-best-practices", text: "Architecture Best Practices" },
+    { id: "development-best-practices", text: "Development Best Practices" },
+    { id: "styling-best-practices", text: "Styling Best Practices" },
+    { id: "progressive-enhancement", text: "Progressive Enhancement" },
+    { id: "related-resources", text: "Related Resources" }
+  ]}
+  showNumbers={false}
+/>
+
+Follow these guidelines to get the most out of Mangrove while building maintainable, accessible, and performant applications.
+
+## 🏗️ Architecture Best Practices
+
+### 1. Component Organization
+
+**File Structure**
+```
+src/
+├── components/
+│   ├── ui/                    # Mangrove wrapper components
+│   │   ├── Button/
+│   │   │   ├── Button.jsx
+│   │   │   ├── Button.test.jsx
+│   │   │   └── Button.stories.jsx
+│   │   └── Card/
+│   │       ├── Card.jsx
+│   │       └── Card.test.jsx
+│   ├── features/              # Domain-specific components
+│   │   ├── ReportCard/
+│   │   ├── ContactForm/
+│   │   └── StatsOverview/
+│   └── layouts/               # Page layouts
+│       ├── Header/
+│       ├── Footer/
+│       └── MainLayout/
+├── hooks/                     # Custom hooks
+├── utils/                     # Utility functions
+└── styles/                    # Global styles
+    ├── base/                  # Base styles
+    ├── components/            # Component overrides
+    └── themes/                # Theme variants
+```
+
+**Wrapper Components**
+```jsx
+// components/ui/Button/Button.jsx
+import React from 'react';
+import { CtaButton } from '@unisdr/undrr-mangrove';
+
+const Button = ({
+  children,
+  variant = 'primary',
+  size = 'medium',
+  loading = false,
+  ...props
+}) => {
+  return (
+    <CtaButton
+      label={children}
+      Type={variant === 'primary' ? 'Primary' : 'Secondary'}
+      State={loading ? 'Disabled' : 'Active'}
+      For_Primary={variant === 'primary' ? 'Arrow' : 'No Arrow'}
+      {...props}
+    />
+  );
+};
+
+export default Button;
+```
+
+### 2. State Management
+
+**Local State with useState**
+```jsx
+function ContactForm() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    message: ''
+  });
+
+  const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleInputChange = useCallback((field) => (e) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: e.target.value
+    }));
+
+    // Clear error when user starts typing
+    if (errors[field]) {
+      setErrors(prev => ({
+        ...prev,
+        [field]: ''
+      }));
+    }
+  }, [errors]);
+
+  // ... rest of component
+}
+```
+
+**Global State with Context**
+```jsx
+// contexts/ThemeContext.jsx
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('light');
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => prev === 'light' ? 'dark' : 'light');
+  }, []);
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+};
+```
+
+### 3. Error Handling
+
+**Error Boundaries**
+```jsx
+class MangroveErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Mangrove component error:', error, errorInfo);
+    // Log to error reporting service
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="mg-alert mg-alert--error">
+          <h3 className="mg-heading mg-heading--4">Something went wrong</h3>
+          <p className="mg-paragraph">
+            We're sorry, but there was an error loading this component.
+          </p>
+          <CtaButton
+            label="Reload Page"
+            Type="Secondary"
+            onClick={() => window.location.reload()}
+          />
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+```
+
+**Graceful Degradation**
+```jsx
+function ReportCard({ report }) {
+  const [imageError, setImageError] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <VerticalCard
+      data={[{
+        ...report,
+        imgback: imageError ? '/images/fallback-report.jpg' : report.image,
+        onImageError: () => setImageError(true),
+        onImageLoad: () => setLoading(false)
+      }]}
+      variant="primary"
+    />
+  );
+}
+```
+
+## 🎨 Styling Best Practices
+
+### 1. CSS Custom Properties
+
+**Theme Variables**
+```css
+:root {
+  /* Mangrove overrides */
+  --mg-primary-color: #0066cc;
+  --mg-secondary-color: #28a745;
+  --mg-font-family-base: 'Inter', 'Roboto', sans-serif;
+
+  /* Custom variables */
+  --org-brand-blue: #003366;
+  --org-brand-green: #228b22;
+  --org-shadow-subtle: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+[data-theme="dark"] {
+  --mg-primary-color: #4d9fff;
+  --mg-background-color: #1a1a1a;
+  --mg-text-color: #ffffff;
+}
+```
+
+**Component-Specific Variables**
+```scss
+.mg-custom-card {
+  // Use Mangrove variables
+  padding: var(--mg-spacing-4);
+  border-radius: var(--mg-border-radius);
+  box-shadow: var(--mg-shadow-sm);
+
+  // Define component-specific variables
+  --card-hover-transform: translateY(-2px);
+  --card-transition-duration: 0.2s;
+
+  transition: transform var(--card-transition-duration) ease;
+
+  &:hover {
+    transform: var(--card-hover-transform);
+  }
+}
+```
+
+## 📱 Progressive Enhancement
+
+### 1. JavaScript Enhancement
+
+**Base Functionality Without JS**
+```html
+<!-- Works without JavaScript -->
+<form action="/submit-contact" method="POST" class="mg-form">
+  <input type="text" name="name" class="mg-form__input" required>
+  <textarea name="message" class="mg-form__textarea" required></textarea>
+  <button type="submit" class="mg-cta-button mg-cta-button--primary">
+    Send Message
+  </button>
+</form>
+```
+
+**Enhanced with JavaScript**
+```jsx
+function ContactForm() {
+  const [isEnhanced, setIsEnhanced] = useState(false);
+
+  useEffect(() => {
+    // Enable enhanced features after hydration
+    setIsEnhanced(true);
+  }, []);
+
+  return (
+    <form onSubmit={isEnhanced ? handleEnhancedSubmit : undefined}>
+      <InputFields
+        type="text"
+        name="name"
+        labelText="Name"
+        required
+      />
+      {isEnhanced && (
+        <div className="mg-form__validation">
+          Real-time validation enabled
+        </div>
+      )}
+      <CtaButton
+        label={isEnhanced ? 'Send Message' : 'Send Message (Enhanced)'}
+        Type="Primary"
+        type="submit"
+      />
+    </form>
+  );
+}
+```
+
+### 2. Graceful Fallbacks
+
+**Image Fallbacks**
+```jsx
+<VerticalCard
+  data={[{
+    title: "Report Title",
+    imgback: "report-image.webp",
+    imgFallback: "report-image.jpg",
+    onImageError: handleImageError
+  }]}
+/>
+```
+
+**Font Fallbacks**
+```css
+.mg-heading {
+  font-family:
+    'Inter',           /* Custom font */
+    'Roboto',          /* Mangrove fallback */
+    -apple-system,     /* System font */
+    BlinkMacSystemFont,
+    sans-serif;        /* Generic fallback */
+}
+```

--- a/stories/Documentation/Browsersupport.mdx
+++ b/stories/Documentation/Browsersupport.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/blocks';
 
 <Meta
-  title="Getting started/Browser support"
+  title="Getting started/Best practices/Browser support"
   parameters={{
     viewMode: "docs",
     previewTabs: {

--- a/stories/Documentation/GettingStarted.mdx
+++ b/stories/Documentation/GettingStarted.mdx
@@ -1,0 +1,211 @@
+import { Meta, Source } from '@storybook/blocks';
+import TableOfContents from '../Components/TableOfContents/TableOfContents';
+
+<Meta
+  title="Getting started/Intro/Getting started guide"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }}
+/>
+
+# Getting started with Mangrove
+
+<TableOfContents
+  tocData={[
+    { id: "what-is-mangrove", text: "What is Mangrove?" },
+    { id: "quick-start", text: "Quick Start (30 seconds)" },
+    { id: "integration-approaches", text: "Integration Approaches" },
+    { id: "architecture-overview", text: "Architecture Overview" },
+    { id: "key-principles", text: "Key Principles" },
+    { id: "common-use-cases", text: "Common Use Cases" },
+    { id: "next-steps", text: "Next Steps" },
+    { id: "need-help", text: "Need Help?" }
+  ]}
+  showNumbers={false}
+/>
+
+Welcome to UNDRR Mangrove - the component library that brings consistency, accessibility, and speed to UNDRR web development.
+
+## What is Mangrove?
+
+Mangrove is UNDRR's component library that provides:
+- ✅ **Pre-built, tested components** ready for production
+- ✅ **Consistent design** across all UNDRR projects
+- ✅ **Accessibility built-in** with WCAG 2.1 AA compliance
+- ✅ **Framework flexibility** - works with any tech stack
+- ✅ **Copy-paste ready** code snippets
+- ✅ **Comprehensive documentation** with live examples
+
+## Quick start (30 seconds)
+
+The fastest way to get started:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
+  <!-- or choose a site specific theme -->
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-mcr.css">
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-irp.css">
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-preventionweb.css">
+</head>
+<body>
+  <!-- 2. Use any component -->
+  <button class="mg-cta-button mg-cta-button--primary">
+    <span class="mg-cta-button__text">Get Started</span>
+    <span class="mg-cta-button__icon" aria-hidden="true">→</span>
+  </button>
+</body>
+</html>
+```
+
+## Integration approaches
+
+Choose the approach that best fits your project:
+
+### 🎯 Approach 1: Vanilla HTML/CSS (Simplest)
+**Best for**: Static sites, existing projects, quick prototypes
+
+- Include CSS files via CDN
+- Copy HTML structures from component docs
+- Zero JavaScript required for most components
+
+[→ See Vanilla HTML/CSS Guide](/?path=/docs/getting-started-vanilla-html-css--docs)
+
+### 🎨 Approach 2: Sass Integration
+**Best for**: Custom themes, design system extensions
+
+- Import Sass files into your build process
+- Customize variables and mixins
+- Build your own theme variants
+
+[→ See Sass Integration Guide](/?path=/docs/getting-started-sass-integration--docs)
+
+### ⚛️ Approach 3: React Components (Full Power)
+**Best for**: React applications, dynamic interfaces
+
+- Import React components directly
+- Full TypeScript support
+- Props-based customization
+- Built-in state management
+
+[→ See React Integration Guide](/?path=/docs/getting-started-react-integration--docs)
+
+## Architecture overview
+
+Mangrove follows a loose [atomic design](https://atomicdesign.bradfrost.com/) methodology:
+
+```
+🔬 Atoms (Building Blocks)
+├── Typography (headings, paragraphs, links)
+├── Colors (brand palette, semantic colors)
+├── Icons (consistent iconography)
+└── Layout (grid, spacing, containers)
+
+🧩 Components (Functional Units)
+├── Buttons (CTAs, chips, share buttons)
+├── Forms (inputs, selects, checkboxes)
+├── Cards (content cards, stats cards)
+├── Navigation (breadcrumbs, menus)
+└── Charts (bar charts, scatter plots)
+
+🏗️ Molecules (Component Groups)
+├── Header navigation
+├── Footer sections
+└── Content blocks
+
+🌐 Organisms (Page Sections)
+├── Site header
+├── Page footer
+└── Content layouts
+```
+
+## Key principles
+
+### Framework Agnostic
+Works with any technology stack - React, Vue, Angular, plain HTML, WordPress, Drupal, etc.
+
+### CSS Namespace
+All styles use the `mg-` prefix to prevent conflicts:
+```css
+.mg-button { /* Mangrove button */ }
+.mg-card { /* Mangrove card */ }
+.mg-form__input { /* Mangrove form input */ }
+```
+
+### Semantic HTML
+Components use proper HTML elements for accessibility:
+```html
+<button class="mg-cta-button">Button</button>
+<nav class="mg-breadcrumb">Navigation</nav>
+<main class="mg-content">Main content</main>
+```
+
+### Progressive Enhancement
+Components work without JavaScript, enhanced with JS where beneficial.
+
+## Common use cases
+
+### 📄 Marketing Pages
+```html
+<!-- Hero section with CTA -->
+<section class="mg-hero">
+  <div class="mg-container">
+    <h1 class="mg-heading mg-heading--1">Building Resilient Communities</h1>
+    <p class="mg-paragraph mg-paragraph--large">Disaster risk reduction starts here.</p>
+    <button class="mg-cta-button mg-cta-button--primary">
+      <span class="mg-cta-button__text">Learn More</span>
+    </button>
+  </div>
+</section>
+```
+
+### 📊 Data Dashboards
+```jsx
+import { BarChart, StatsCards } from '@unisdr/undrr-mangrove';
+
+function Dashboard() {
+  return (
+    <div className="mg-grid">
+      <StatsCards data={statsData} />
+      <BarChart data={chartData} />
+    </div>
+  );
+}
+```
+
+### 📝 Forms & Applications
+```html
+<form class="mg-form">
+  <div class="mg-form__group">
+    <label class="mg-form__label" for="email">Email Address</label>
+    <input class="mg-form__input" type="email" id="email" required>
+  </div>
+  <button class="mg-cta-button mg-cta-button--primary" type="submit">
+    Submit Application
+  </button>
+</form>
+```
+
+## Next steps
+
+1. **Choose your integration approach** from the guides above
+2. **Browse the component library** to see what's available
+3. **Check out [Real-world Examples](/?path=/docs/getting-started-examples--docs)** for complete page layouts
+4. **Read [Best Practices](/?path=/docs/getting-started-best-practices--docs)** for optimal implementation
+5. **Join the community** - report issues, request features, contribute
+
+## Need help?
+
+- 📖 **Documentation**: Browse components in the sidebar
+- 🐛 **Issues**: [Report bugs on GitLab](https://gitlab.com/undrr/web-backlog/-/issues)
+- 💬 **Questions**: Contact the UNDRR development team
+- 🔄 **Updates**: Follow [releases on GitHub](https://github.com/unisdr/undrr-mangrove/releases)
+
+---
+
+**Ready to build?** Start with one of the integration guides above! 🚀

--- a/stories/Documentation/Howtouse.mdx
+++ b/stories/Documentation/Howtouse.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks';
 
 <Meta
-  title="Getting started/How to use our design system?"
+  title="Getting started/Intro/How to use our design system?"
   parameters={{
     viewMode: "docs",
     previewTabs: {
@@ -10,7 +10,7 @@ import { Meta } from '@storybook/blocks';
   }}
 />
 
-# How to Use Mangrove
+# How to use Mangrove
 
 This guide explains how to use the UNDRR Mangrove component library in your projects.
 
@@ -20,7 +20,7 @@ There are two main ways to use Mangrove components:
 
 ### 1. Direct HTML/CSS/JS Integration
 
-* Include the base styling CSS file in your project 
+* Include the base styling CSS file in your project
 * Browse the component catalog and select what you need
 * Check the component's documentation page
 * Copy the HTML structure from the component's code tab
@@ -47,12 +47,10 @@ Include the appropriate CSS file based on your project needs:
 
 ```html
 <!-- Base styling -->
-<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-gutenberg.css">
+<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
 
-<!-- Theme-specific styling (choose one) -->
+<!-- Or theme-specific styling (choose one) -->
 <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-preventionweb.css">
-<!-- or -->
-<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-undrr.css">
 ```
 
 ## Development Setup

--- a/stories/Documentation/Intro.mdx
+++ b/stories/Documentation/Intro.mdx
@@ -1,4 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
+import { linkTo } from '@storybook/addon-links';
 
 <Meta
   title="Getting started/Intro"
@@ -12,19 +13,7 @@ import { Meta, Source } from '@storybook/blocks';
 
 # Welcome
 
-The purpose of this project is to act as a test to see if it is a suitable base for UNDRR's needs.
-
-By unifying design elements into reusable components, development is simplified, accelerated and more reliable. Serving the interests of the organisation and users.
-
-## 🚨 Pre-alpha warning 🚨
-
-This project is under active development and at the moment provides no useful resources. [Internal notes on the project can be seen in the GitLab Wiki](https://git.un.org/undrr/web-backlog/-/wikis/Mangrove:-the-UNDRR-Component-library).
-
-## 🏗️ Work in Progress
-
-Please note that this design system is currently a work in progress. We are in the process of fully evolving it from the UNDP design system. As such, some components and features may be subject to change or refinement. 
-
-## Purpose
+By unifying design elements into reusable components, development is simplified, accelerated and more reliable. Serving the interests of the organization and users. This project is under active development. [Internal notes on the project can be seen in the GitLab Wiki](https://git.un.org/undrr/web-backlog/-/wikis/Mangrove:-the-UNDRR-Component-library).
 
 This project stops short of being a full design system and instead focus on providing usable components that are informed by the UNDRR brand guidelines and project styles.
 
@@ -32,20 +21,40 @@ These components offer consistency, documentation and portability to speed quali
 
 If there is a Component or Pattern that you need, or you have any other feedback, question or comment please contact us in the issue queue.
 
+---
+
+## Getting started
+
+👉 **<a href="javascript:void(0)" onClick={linkTo('getting-started-intro-getting-started-guide', 'docs')}>Start with the Getting Started Guide</a>** for a complete overview and quick setup.
+
+**🎯 <a href="javascript:void(0)" onClick={linkTo('getting-started-vanilla-html-and-css', 'docs')}>Vanilla HTML/CSS Guide</a>**
+For static sites, legacy projects, or when you want minimal dependencies. Just add CSS files and copy HTML structures.
+
+**🎨 <a href="javascript:void(0)" onClick={linkTo('getting-started-sass-integration', 'docs')} >Sass Integration Guide</a>**
+Take control of styling with custom themes, variable overrides, and build process integration.
+
+**⚛️ <a href="javascript:void(0)" onClick={linkTo('getting-started-react-integration', 'docs')} >React Integration Guide</a>**
+Full React components with TypeScript integrations, props-based customization, and modern development patterns.
+
+**📋 <a href="javascript:void(0)" onClick={linkTo('getting-started-best-practices', 'docs')} >Best Practices</a>**
+Performance optimization, accessibility guidelines, and development best practices.
+
+---
+
 ## Process
 
-The Guide is a living document created to meet the needs of UNDRR's front-end developers and designers. If there is a Component or Pattern that you need, or you have any other feedback, question or comment please contact us.
+If there is a Component or Pattern that you need, or you have any other feedback, question or comment please contact us.
 
-Components can be created and are also subject to updates and removal. These changes are documented -- if you'd like to request a new component, get in touch \[contact form to come].
+Components can be created and are also subject to updates and removal. These changes are documented -- if you'd like to request a new component, [get in touch](https://github.com/unisdr/undrr-mangrove).
 
 ## Structure
 
 Mangrove uses a loose [atomic design](https://atomicdesign.bradfrost.com/chapter-2/) approach, but major concepts are split as follows:
 
-* Getting started: high level information on what Mangrove is, and what you should and shouldn't do
-* Design decisions: colours, spacing, typography and so on.
-* Components: the bread and butter of cards, buttons and so on.
-* Templates (to come): high-level organisms that show a whole section layout or page
+* **Getting started**: High level information on what Mangrove is, and comprehensive onboarding guides for different use cases
+* **Design decisions**: Colours, spacing, typography and foundational design elements
+* **Components**: The bread and butter of cards, buttons, forms, and interactive elements
+* **Templates** (to come): High-level organisms that show a whole section layout or page
 
 ## Codebase
 
@@ -53,4 +62,53 @@ Code is available [on GitHub](https://github.com/unisdr/undrr-mangrove) and thro
 
 Developers are encouraged to consume the project through the remotely available CSS to help ensure "up-to-date-ness".
 
-* URLs to come
+### Quick Start URLs
+
+**CSS Files (for HTML/CSS approach):**
+```html
+<!-- Theme styles (choose one) -->
+<!-- UNDRR global style -->
+<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
+<!-- or -->
+<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-preventionweb.css">
+```
+
+**npm Package (for React/build process integration):**
+
+(This is not yet available but to come. Status: June 2025)
+
+```bash
+npm install @unisdr/undrr-mangrove
+```
+
+## Need Help?
+
+- 📖 **Start here**: <a href="javascript:void(0)" onClick={linkTo('getting-started-intro-getting-started-guide', 'docs')} >Getting Started Guide</a>
+- 🧱 **Browse Components**: Explore the component library in the sidebar
+- 💬 **Questions**: Contact the UNDRR development team
+- 🐛 **Issues**: [Report bugs on GitLab](https://gitlab.com/undrr/web-backlog/-/issues)
+- 📈 **Updates**: Follow [releases on GitHub](https://github.com/unisdr/undrr-mangrove/releases)
+```
+
+The key changes I made:
+
+1. **Added import**: `import { linkTo } from '@storybook/addon-links';`
+
+2. **Converted story titles to IDs**: Storybook converts titles like "Getting started/React Integration" to story IDs like "getting-started-react-integration"
+
+3. **Replaced hardcoded URLs with linkTo buttons**: Each link now uses `linkTo(storyId, 'docs')` with proper styling to maintain the appearance
+
+4. **Added inline styles**: To make the buttons look like links while maintaining the original formatting
+
+The story ID format follows Storybook's convention:
+- Spaces become hyphens
+- Slashes become hyphens
+- Everything is lowercase
+- Special characters are removed
+
+This approach is much more robust because:
+- ✅ No hardcoded paths that can break
+- ✅ Type-safe story references
+- ✅ Automatic updates if stories are renamed
+- ✅ Works consistently across Storybook versions
+- ✅ Better development experience

--- a/stories/Documentation/ReactIntegration.mdx
+++ b/stories/Documentation/ReactIntegration.mdx
@@ -1,0 +1,831 @@
+import { Meta, Source } from '@storybook/blocks';
+import TableOfContents from '../Components/TableOfContents/TableOfContents';
+
+<Meta
+  title="Getting started/React Integration"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }}
+/>
+
+# React Integration Guide
+
+<TableOfContents
+  tocData={[
+    { id: "quick-setup", text: "Quick Setup" },
+    { id: "complete-react-app-example", text: "Complete React App Example" },
+    { id: "typescript-integration", text: "TypeScript Integration" },
+    { id: "component-api-reference", text: "Component API Reference" },
+    { id: "hooks-utilities", text: "Hooks & Utilities" },
+    { id: "integration-with-frameworks", text: "Integration with Popular Frameworks" },
+    { id: "custom-component-creation", text: "Custom Component Creation" },
+    { id: "performance-optimization", text: "Performance Optimization" },
+    { id: "testing", text: "Testing" },
+    { id: "next-steps", text: "Next Steps" }
+  ]}
+  showNumbers={false}
+/>
+
+Get the full power of Mangrove with React components - perfect for dynamic applications with TypeScript support and props-based customization.
+
+## Quick Setup
+
+### 1. Install Mangrove
+
+(This is not yet available but to come. Status: June 2025)
+
+```bash
+# Install via npm
+npm install @unisdr/undrr-mangrove
+
+# Or via yarn
+yarn add @unisdr/undrr-mangrove
+
+# Peer dependencies (if not already installed)
+npm install react react-dom
+```
+
+### 2. Import Components
+
+```jsx
+// Individual component imports (recommended)
+import { CtaButton } from '@unisdr/undrr-mangrove/components/CtaButton';
+import { VerticalCard } from '@unisdr/undrr-mangrove/components/VerticalCard';
+import { InputFields } from '@unisdr/undrr-mangrove/components/InputFields';
+
+// Or import multiple components
+import {
+  CtaButton,
+  VerticalCard,
+  InputFields,
+  Breadcrumbs,
+  StatsCards
+} from '@unisdr/undrr-mangrove';
+```
+
+### 3. Include Styles
+
+**Option A: Import CSS in your main file**
+```jsx
+// src/index.js or src/App.js
+import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+```
+
+**Option B: Import in CSS file**
+```css
+/* src/styles/main.css */
+@import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+@import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+```
+
+**Option C: Sass integration** (see [Sass Integration Guide](/?path=/docs/getting-started-sass-integration--docs))
+
+## Complete React App Example
+
+Here's a full React application using Mangrove components:
+
+```jsx
+// App.jsx
+import React, { useState } from 'react';
+import {
+  CtaButton,
+  VerticalCard,
+  InputFields,
+  Breadcrumbs,
+  StatsCards,
+  Accordion,
+  Pagination
+} from '@unisdr/undrr-mangrove';
+
+// Import styles
+import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+
+function App() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    message: ''
+  });
+
+  // Sample data
+  const breadcrumbData = [
+    { label: 'Home', link: '/' },
+    { label: 'Resources', link: '/resources' },
+    { label: 'Reports', link: '/resources/reports' },
+    { label: 'Current Report', link: '#', active: true }
+  ];
+
+  const statsData = [
+    {
+      number: '195',
+      label: 'UN Member States',
+      description: 'Working together on disaster risk reduction'
+    },
+    {
+      number: '2.3B',
+      label: 'People Reached',
+      description: 'Through capacity building programs'
+    },
+    {
+      number: '158',
+      label: 'Countries Supported',
+      description: 'With technical assistance and funding'
+    }
+  ];
+
+  const cardData = [
+    {
+      contenttile: 'REPORT',
+      title: 'Global Assessment Report on Disaster Risk Reduction 2024',
+      summaryText: 'This comprehensive report examines global progress in reducing disaster risk and building resilience across communities worldwide.',
+      button: 'Read Report',
+      link: '/reports/gar-2024',
+      imgalt: 'Global Assessment Report Cover',
+      imgback: 'https://via.placeholder.com/300x200?text=GAR+2024'
+    },
+    {
+      contenttile: 'TOOLKIT',
+      title: 'Community Resilience Planning Toolkit',
+      summaryText: 'Practical tools and guidelines for local governments and communities to develop effective disaster risk reduction strategies.',
+      button: 'Download Toolkit',
+      link: '/toolkits/resilience-planning',
+      imgalt: 'Toolkit Cover',
+      imgback: 'https://via.placeholder.com/300x200?text=Toolkit'
+    }
+  ];
+
+  const accordionData = [
+    {
+      id: 1,
+      title: 'What is disaster risk reduction?',
+      content: 'Disaster risk reduction (DRR) is the practice of reducing disaster risks through
+      systematic efforts to analyze and manage the causal factors of disasters.'
+    },
+    {
+      id: 2,
+      title: 'How can communities prepare for disasters?',
+      content: 'Communities can prepare through early warning systems, emergency planning, infrastructure improvements, and education programs.'
+    },
+    {
+      id: 3,
+      title: 'What role does climate change play?',
+      content: 'Climate change increases the frequency and intensity of many disasters, making adaptation and mitigation strategies crucial.'
+    }
+  ];
+
+  const handleFormSubmit = (e) => {
+    e.preventDefault();
+    console.log('Form submitted:', formData);
+    // Handle form submission
+    alert('Thank you for your message! We will get back to you soon.');
+    setFormData({ name: '', email: '', message: '' });
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  return (
+    <div className="mg-app">
+      {/* Header Section */}
+      <header className="mg-section">
+        <div className="mg-container">
+          <Breadcrumbs data={breadcrumbData} />
+
+          <div className="mg-hero__content">
+            <h1 className="mg-heading mg-heading--1">
+              Building Resilient Communities Together
+            </h1>
+            <p className="mg-paragraph mg-paragraph--large">
+              Reducing disaster risk through science, policy, and partnerships for sustainable development.
+            </p>
+
+            <div className="mg-hero__actions">
+              <CtaButton
+                label="Explore Our Work"
+                Type="Primary"
+                For_Primary="Arrow"
+                onClick={() => console.log('Explore clicked')}
+              />
+              <CtaButton
+                label="Latest Reports"
+                Type="Secondary"
+                onClick={() => console.log('Reports clicked')}
+              />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Stats Section */}
+      <section className="mg-section mg-section--gray">
+        <div className="mg-container">
+          <h2 className="mg-heading mg-heading--2 mg-text-center">Global Impact</h2>
+          <StatsCards data={statsData} />
+        </div>
+      </section>
+
+      {/* Content Cards */}
+      <section className="mg-section">
+        <div className="mg-container">
+          <h2 className="mg-heading mg-heading--2">Latest Reports & Resources</h2>
+
+          <div className="mg-grid mg-grid--2-cols">
+            {cardData.map((card, index) => (
+              <VerticalCard
+                key={index}
+                data={[card]}
+                variant="primary"
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <section className="mg-section mg-section--light">
+        <div className="mg-container">
+          <h2 className="mg-heading mg-heading--2">Frequently Asked Questions</h2>
+          <Accordion data={accordionData} />
+        </div>
+      </section>
+
+      {/* Contact Form */}
+      <section className="mg-section mg-section--primary">
+        <div className="mg-container">
+          <div className="mg-grid mg-grid--2-cols mg-grid--gap-large">
+            <div className="mg-content">
+              <h2 className="mg-heading mg-heading--2 mg-text-white">Get Involved</h2>
+              <p className="mg-paragraph mg-paragraph--large mg-text-white">
+                Join the global effort to build more resilient communities. Contact us to learn about partnership opportunities.
+              </p>
+            </div>
+
+            <form onSubmit={handleFormSubmit} className="mg-form mg-form--white">
+              <InputFields
+                type="text"
+                element="input"
+                placeholder="Enter your full name"
+                labelText="Full Name"
+                id="name"
+                value={formData.name}
+                onChange={handleInputChange}
+                State="Active"
+                required
+              />
+
+              <InputFields
+                type="email"
+                element="input"
+                placeholder="Enter your email address"
+                labelText="Email Address"
+                id="email"
+                value={formData.email}
+                onChange={handleInputChange}
+                State="Active"
+                required
+              />
+
+              <InputFields
+                type="text"
+                element="textarea"
+                placeholder="Tell us about your interest in disaster risk reduction..."
+                labelText="Message"
+                id="message"
+                value={formData.message}
+                onChange={handleInputChange}
+                State="Active"
+                rows={4}
+                required
+              />
+
+              <CtaButton
+                label="Send Message"
+                Type="Secondary"
+                For_Primary="Arrow"
+                type="submit"
+                style={{ width: '100%' }}
+              />
+            </form>
+          </div>
+        </div>
+      </section>
+
+      {/* Pagination Example */}
+      <section className="mg-section">
+        <div className="mg-container">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={10}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default App;
+```
+
+## TypeScript Integration
+
+Mangrove can be integrated with TypeScript:
+
+```tsx
+// App.tsx
+import React, { useState, FormEvent, ChangeEvent } from 'react';
+import {
+  CtaButton,
+  VerticalCard,
+  InputFields,
+  StatsCards,
+  CtaButtonProps,
+  VerticalCardProps,
+  StatsCardsProps
+} from '@unisdr/undrr-mangrove';
+
+interface FormData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+interface CardData {
+  contenttile: string;
+  title: string;
+  summaryText: string;
+  button: string;
+  link: string;
+  imgalt: string;
+  imgback: string;
+}
+
+const App: React.FC = () => {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    message: ''
+  });
+
+  const statsData: StatsCardsProps['data'] = [
+    {
+      number: '195',
+      label: 'UN Member States',
+      description: 'Working together on disaster risk reduction'
+    }
+  ];
+
+  const cardData: CardData[] = [
+    {
+      contenttile: 'REPORT',
+      title: 'Global Assessment Report',
+      summaryText: 'Comprehensive disaster risk analysis...',
+      button: 'Read Report',
+      link: '/reports/gar-2024',
+      imgalt: 'Report Cover',
+      imgback: 'https://via.placeholder.com/300x200'
+    }
+  ];
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    console.log('Form submitted:', formData);
+  };
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleButtonClick = (): void => {
+    console.log('Button clicked');
+  };
+
+  return (
+    <div className="mg-app">
+      <section className="mg-section">
+        <div className="mg-container">
+          <h1 className="mg-heading mg-heading--1">TypeScript Integration</h1>
+
+          <StatsCards data={statsData} />
+
+          <div className="mg-grid mg-grid--2-cols">
+            {cardData.map((card, index) => (
+              <VerticalCard
+                key={index}
+                data={[card]}
+                variant="primary"
+              />
+            ))}
+          </div>
+
+          <CtaButton
+            label="Get Started"
+            Type="Primary"
+            For_Primary="Arrow"
+            onClick={handleButtonClick}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default App;
+```
+
+## Component API Reference
+
+### CtaButton Component
+
+```jsx
+<CtaButton
+  label="Button Text"           // Required: Button text
+  Type="Primary"               // "Primary" | "Secondary"
+  State="Active"               // "Active" | "Disabled"
+  For_Primary="Arrow"          // "Arrow" | "No Arrow" (for primary buttons)
+  onClick={handleClick}        // Click event handler
+  className="custom-class"     // Additional CSS classes
+  style={{ margin: '10px' }}  // Inline styles
+  disabled={false}             // Boolean to disable button
+  type="button"                // "button" | "submit" | "reset"
+/>
+```
+
+### VerticalCard Component
+
+```jsx
+<VerticalCard
+  data={[{
+    contenttile: "CATEGORY",
+    title: "Card Title",
+    summaryText: "Card description text...",
+    button: "Read More",
+    link: "/article/link",
+    imgalt: "Image description",
+    imgback: "path/to/image.jpg",
+    share: "Social Share Button",  // Optional
+    label1: "Label 1",             // Optional
+    label2: "Label 2"              // Optional
+  }]}
+  variant="primary"              // "primary" | "secondary" | "tertiary" | "quaternary"
+  className="custom-card"        // Additional CSS classes
+/>
+```
+
+### InputFields Component
+
+```jsx
+<InputFields
+  type="text"                    // Input type: "text" | "email" | "password" | "tel" | etc.
+  element="input"                // "input" | "textarea"
+  placeholder="Enter text..."    // Placeholder text
+  labelText="Field Label"        // Label text
+  errorText="Error message"      // Error message text
+  helpText="Help text"           // Help/hint text
+  State="Active"                 // "Active" | "Focus" | "Error" | "Disabled"
+  id="field-id"                  // Unique ID for the field
+  value={fieldValue}             // Controlled value
+  onChange={handleChange}        // Change event handler
+  required={true}                // Required field
+  disabled={false}               // Disabled state
+  rows={4}                       // For textarea element
+/>
+```
+
+### StatsCards Component
+
+```jsx
+<StatsCards
+  data={[
+    {
+      number: "195",
+      label: "Member States",
+      description: "Working together globally"
+    },
+    {
+      number: "2.3B",
+      label: "People Reached",
+      description: "Through our programs"
+    }
+  ]}
+  variant="default"              // Optional variant
+  className="custom-stats"       // Additional CSS classes
+/>
+```
+
+### Breadcrumbs Component
+
+```jsx
+<Breadcrumbs
+  data={[
+    { label: 'Home', link: '/' },
+    { label: 'Reports', link: '/reports' },
+    { label: 'Current Page', link: '#', active: true }
+  ]}
+  separator="/"                  // Custom separator
+  className="custom-breadcrumb"  // Additional CSS classes
+/>
+```
+
+## Hooks & Utilities
+
+### useMangroveTheme Hook
+
+```jsx
+import { useMangroveTheme } from '@unisdr/undrr-mangrove/hooks';
+
+function MyComponent() {
+  const { theme, setTheme, toggleTheme } = useMangroveTheme();
+
+  return (
+    <div>
+      <p>Current theme: {theme}</p>
+      <CtaButton
+        label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+        onClick={toggleTheme}
+        Type="Secondary"
+      />
+    </div>
+  );
+}
+```
+
+### useMangroveBreakpoint Hook
+
+```jsx
+import { useMangroveBreakpoint } from '@unisdr/undrr-mangrove/hooks';
+
+function ResponsiveComponent() {
+  const { isMobile, isTablet, isDesktop, breakpoint } = useMangroveBreakpoint();
+
+  return (
+    <div>
+      {isMobile && <p>Mobile view</p>}
+      {isTablet && <p>Tablet view</p>}
+      {isDesktop && <p>Desktop view</p>}
+      <p>Current breakpoint: {breakpoint}</p>
+    </div>
+  );
+}
+```
+
+## Integration with Popular Frameworks
+
+### Next.js Integration
+
+```jsx
+// pages/_app.js
+import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;
+```
+
+```jsx
+// pages/index.js
+import { CtaButton, VerticalCard } from '@unisdr/undrr-mangrove';
+
+export default function Home() {
+  return (
+    <div className="mg-container">
+      <h1 className="mg-heading mg-heading--1">Welcome to UNDRR</h1>
+      <CtaButton label="Get Started" Type="Primary" />
+    </div>
+  );
+}
+```
+
+### Create React App Integration
+
+```jsx
+// src/index.js
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+// Import Mangrove styles
+import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+```
+
+### Vite Integration
+
+```jsx
+// src/main.jsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+// Import Mangrove styles
+import '@unisdr/undrr-mangrove/dist/css/style-gutenberg.css';
+import '@unisdr/undrr-mangrove/dist/css/style-undrr.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+```
+
+## Custom Component Creation
+
+Build your own components using Mangrove as a foundation:
+
+```jsx
+// components/CustomNewsCard.jsx
+import React from 'react';
+import { CtaButton } from '@unisdr/undrr-mangrove';
+import './CustomNewsCard.scss';
+
+const CustomNewsCard = ({
+  title,
+  excerpt,
+  category,
+  date,
+  author,
+  image,
+  link,
+  featured = false
+}) => {
+  return (
+    <article className={`mg-news-card ${featured ? 'mg-news-card--featured' : ''}`}>
+      {image && (
+        <div className="mg-news-card__image">
+          <img src={image} alt={title} className="mg-news-card__img" />
+        </div>
+      )}
+
+      <div className="mg-news-card__content">
+        <div className="mg-news-card__meta">
+          <span className="mg-label mg-label--primary">{category}</span>
+          <time className="mg-news-card__date">{date}</time>
+        </div>
+
+        <h3 className="mg-heading mg-heading--3 mg-news-card__title">
+          <a href={link}>{title}</a>
+        </h3>
+
+        <p className="mg-paragraph mg-news-card__excerpt">{excerpt}</p>
+
+        <div className="mg-news-card__footer">
+          <span className="mg-news-card__author">By {author}</span>
+          <CtaButton
+            label="Read More"
+            Type="Secondary"
+            For_Primary="Arrow"
+            onClick={() => window.location.href = link}
+          />
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default CustomNewsCard;
+```
+
+## Performance Optimization
+
+### Tree Shaking
+
+Import only the components you need:
+
+```jsx
+// ✅ Good - Only imports what you need
+import { CtaButton } from '@unisdr/undrr-mangrove/components/CtaButton';
+import { VerticalCard } from '@unisdr/undrr-mangrove/components/VerticalCard';
+
+// ❌ Avoid - Imports entire library
+import * as Mangrove from '@unisdr/undrr-mangrove';
+```
+
+### Dynamic Imports
+
+Load components only when needed:
+
+```jsx
+import React, { lazy, Suspense } from 'react';
+
+// Lazy load heavy components
+const Charts = lazy(() => import('@unisdr/undrr-mangrove/components/Charts'));
+const MapComponent = lazy(() => import('@unisdr/undrr-mangrove/components/Map'));
+
+function Dashboard() {
+  return (
+    <div>
+      <Suspense fallback={<div>Loading charts...</div>}>
+        <Charts data={chartData} />
+      </Suspense>
+
+      <Suspense fallback={<div>Loading map...</div>}>
+        <MapComponent markers={mapData} />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+### CSS Optimization
+
+```jsx
+// Option 1: Import only the CSS you need
+import '@unisdr/undrr-mangrove/dist/css/components/buttons.css';
+import '@unisdr/undrr-mangrove/dist/css/components/cards.css';
+
+// Option 2: Use CSS-in-JS with styled-components
+import styled from 'styled-components';
+import { CtaButton } from '@unisdr/undrr-mangrove';
+
+const StyledButton = styled(CtaButton)`
+  margin: 20px 0;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+`;
+```
+
+## Testing
+
+### Unit Testing with Jest
+
+```jsx
+// __tests__/App.test.jsx
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CtaButton } from '@unisdr/undrr-mangrove';
+
+test('renders CTA button with correct text', () => {
+  const handleClick = jest.fn();
+
+  render(
+    <CtaButton
+      label="Test Button"
+      Type="Primary"
+      onClick={handleClick}
+    />
+  );
+
+  const button = screen.getByRole('button', { name: /test button/i });
+  expect(button).toBeInTheDocument();
+
+  fireEvent.click(button);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+});
+```
+
+### Storybook Integration
+
+```jsx
+// stories/CustomComponent.stories.jsx
+import { CustomNewsCard } from '../components/CustomNewsCard';
+
+export default {
+  title: 'Custom/NewsCard',
+  component: CustomNewsCard,
+  argTypes: {
+    featured: { control: 'boolean' },
+    category: { control: 'text' }
+  }
+};
+
+export const Default = {
+  args: {
+    title: 'Climate Resilience in Small Island States',
+    excerpt: 'New research shows innovative approaches...',
+    category: 'Research',
+    date: '2024-03-15',
+    author: 'Dr. Jane Smith',
+    link: '/articles/climate-resilience',
+    featured: false
+  }
+};
+```
+
+## Next Steps
+
+- **Explore Components**: Browse the component library for more React examples
+- **TypeScript Setup**: Configure your project with TypeScript for better development experience
+- **Custom Themes**: Create your own theme using [Sass Integration](/?path=/docs/getting-started-sass-integration--docs)
+- **Performance**: Implement code splitting and lazy loading for better performance
+
+Need help? Check out [Best Practices](/?path=/docs/getting-started-best-practices--docs) or [Real-world Examples](/?path=/docs/getting-started-examples--docs)!

--- a/stories/Documentation/SassIntegration.mdx
+++ b/stories/Documentation/SassIntegration.mdx
@@ -1,0 +1,666 @@
+import { Meta, Source } from '@storybook/blocks';
+import TableOfContents from '../Components/TableOfContents/TableOfContents';
+
+<Meta
+  title="Getting started/Sass Integration"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }}
+/>
+
+# Sass Integration Guide
+
+Take full control of Mangrove styling by integrating Sass files directly into your build process. Perfect for custom themes and design system extensions.
+
+<TableOfContents
+  title="On this page"
+  tocData={[
+    { id: "quick-setup", text: "Quick Setup" },
+    { id: "available-sass-files", text: "Available Sass Files" },
+    { id: "customization-examples", text: "Customization Examples" },
+    { id: "building-custom-components", text: "Building Custom Components" },
+    { id: "theme-creation", text: "Theme Creation" },
+    { id: "build-scripts", text: "Build Scripts" },
+    { id: "best-practices", text: "Best Practices" },
+    { id: "next-steps", text: "Next Steps" }
+  ]}
+  showNumbers={false}
+/>
+
+## Quick Setup
+
+### 1. Install Mangrove
+
+**Via npm/yarn**
+
+(This is not yet available but to come. Status: June 2025)
+
+```bash
+# Install as a dependency
+npm install @unisdr/undrr-mangrove
+
+# Or with yarn
+yarn add @unisdr/undrr-mangrove
+```
+
+**Via Git Submodule** (For direct access)
+```bash
+# Add as a submodule
+git submodule add https://github.com/unisdr/undrr-mangrove.git src/sass/mangrove
+
+# Update submodule
+git submodule update --init --recursive
+```
+
+### 2. Import Sass Files
+
+Create your main Sass file (`src/sass/main.scss`):
+
+```scss
+// 1. Import Mangrove variables first (for customization)
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/variables";
+
+// 2. Override variables here (optional)
+$mg-primary-color: #0066cc;
+$mg-secondary-color: #ff6b35;
+$mg-font-family-base: "Roboto", Arial, sans-serif;
+
+// 3. Import Mangrove core styles
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/mixins";
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/base";
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/layout";
+
+// 4. Import component styles you need
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+@import "~@unisdr/undrr-mangrove/stories/Components/Cards/Card/card";
+@import "~@unisdr/undrr-mangrove/stories/Components/Forms/InputFields/input-fields";
+
+// 5. Add your custom styles
+@import "custom/components";
+@import "custom/layouts";
+```
+
+### 3. Configure Your Build Tool
+
+**Webpack Configuration**
+```javascript
+// webpack.config.js
+const path = require('path');
+
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.scss$/,
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                includePaths: [
+                  path.resolve(__dirname, 'node_modules'),
+                  path.resolve(__dirname, 'src/sass')
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+**Vite Configuration**
+```javascript
+// vite.config.js
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        additionalData: `@import "@unisdr/undrr-mangrove/stories/assets/scss/variables";`,
+        includePaths: ['node_modules']
+      }
+    }
+  }
+})
+```
+
+**Gulp Task**
+```javascript
+// gulpfile.js
+const gulp = require('gulp');
+const sass = require('gulp-sass')(require('sass'));
+
+gulp.task('sass', function() {
+  return gulp.src('src/sass/**/*.scss')
+    .pipe(sass({
+      includePaths: ['node_modules']
+    }).on('error', sass.logError))
+    .pipe(gulp.dest('dist/css'));
+});
+```
+
+## Available Sass Files
+
+### Core Foundation
+```scss
+// Essential variables and mixins
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/variables";
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/mixins";
+
+// Base styles and typography
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/base";
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/_typography";
+
+// Layout systems
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/layout";
+@import "~@unisdr/undrr-mangrove/stories/Atom/Layout/Grid/grid";
+```
+
+### Component Categories
+```scss
+// Buttons
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/Chips/chips";
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/ShareButtons/share-buttons";
+
+// Forms
+@import "~@unisdr/undrr-mangrove/stories/Components/Forms/InputFields/input-fields";
+@import "~@unisdr/undrr-mangrove/stories/Components/Forms/Select/select";
+@import "~@unisdr/undrr-mangrove/stories/Components/Forms/Checkbox/checkbox";
+
+// Content Components
+@import "~@unisdr/undrr-mangrove/stories/Components/Cards/Card/card";
+@import "~@unisdr/undrr-mangrove/stories/Components/Cards/StatsCards/stats-cards";
+@import "~@unisdr/undrr-mangrove/stories/Components/Accordion/accordion";
+
+// Navigation
+@import "~@unisdr/undrr-mangrove/stories/Components/Breadcrumbs/breadcrumbs";
+@import "~@unisdr/undrr-mangrove/stories/Components/Pagination/pagination";
+@import "~@unisdr/undrr-mangrove/stories/Components/MegaMenu/mega-menu";
+```
+
+## Customization Examples
+
+### 1. Custom Color Palette
+
+```scss
+// Override Mangrove colors before importing components
+// Use actual Mangrove color variables
+
+// Primary brand colors (override blue shades)
+$mg-color-blue-900: #003366;  // Custom primary blue
+$mg-color-blue-800: #1a519c;  // Slightly lighter
+$mg-color-blue-700: #3372a7;  // Active state
+
+// Secondary colors (override orange shades)
+$mg-color-orange-900: #ff8c42;  // Custom orange
+$mg-color-orange-800: #ff6b35;  // Hover state
+
+// Interactive colors
+$mg-color-interactive: $mg-color-blue-900;
+$mg-color-interactive-active: $mg-color-blue-700;
+
+// Text and neutral colors
+$mg-color-text: $mg-color-neutral-800;
+$mg-color-neutral-400: #808080;  // Custom gray
+
+// Component-specific color overrides
+$mg-color-button-background: $mg-color-interactive;
+$mg-color-button-background--hover: $mg-color-interactive-active;
+$mg-color-hero: $mg-color-interactive;
+$mg-color-label: $mg-color-interactive;
+```
+
+### 2. Typography Customization
+
+```scss
+// Import Google Fonts
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+// Override font families
+$mg-font-family: 'Inter', 'Roboto', Arial, sans-serif;
+$mg-font-family-condensed: 'Inter', 'Roboto Condensed', Arial, sans-serif;
+
+// Override font sizes (Mangrove uses rem units)
+$mg-font-size-100: 0.875rem;  // 14px - small text
+$mg-font-size-200: 1rem;      // 16px - body text
+$mg-font-size-300: 1.125rem;  // 18px - large body
+$mg-font-size-400: 1.25rem;   // 20px - small heading
+$mg-font-size-500: 1.5rem;    // 24px - medium heading
+$mg-font-size-600: 2rem;      // 32px - large heading
+$mg-font-size-800: 2.5rem;    // 40px - extra large
+$mg-font-size-900: 3rem;      // 48px - huge
+$mg-font-size-1000: 3.5rem;   // 56px - massive
+
+// Override body and label sizes
+$mg-font-body: $mg-font-size-300;
+$mg-font-label: $mg-font-size-200;
+$mg-font-line-height-500: 1.4em;
+
+// Button typography
+$mg-font-size-button: $mg-font-size-200;
+```
+
+### 3. Spacing & Layout
+
+```scss
+// Override Mangrove spacing variables
+$mg-spacing-0: 0;
+$mg-spacing-25: 0.125rem;  // 2px
+$mg-spacing-50: 0.25rem;   // 4px
+$mg-spacing-75: 0.5rem;    // 8px
+$mg-spacing-100: 0.75rem;  // 12px
+$mg-spacing-150: 1rem;     // 16px - base spacing
+$mg-spacing-175: 1.25rem;  // 20px
+$mg-spacing-200: 1.5rem;   // 24px
+$mg-spacing-250: 2rem;     // 32px
+$mg-spacing-300: 2.5rem;   // 40px
+$mg-spacing-350: 3rem;     // 48px
+$mg-spacing-400: 4rem;     // 64px
+$mg-spacing-500: 5rem;     // 80px
+$mg-spacing-600: 6rem;     // 96px
+$mg-spacing-800: 8rem;     // 128px
+$mg-spacing-1000: 10rem;   // 160px
+
+// Container and layout overrides
+$mg-container-spacer: $mg-spacing-200;  // Container padding
+
+// Button styling
+$mg-padding-button: $mg-spacing-100 $mg-spacing-200;
+$mg-radius-button: $mg-spacing-50;  // Rounded corners
+$mg-border-width-button: 2px;
+
+// Component borders and radii
+$mg-radius-label: $mg-spacing-25;
+$mg-radius-tab: $mg-spacing-50;
+
+// Breakpoints (Mangrove uses px values)
+$mg-breakpoint-mobile: 576px;    // Small devices
+$mg-breakpoint-tablet: 768px;    // Medium devices
+$mg-breakpoint-desktop: 992px;   // Large devices
+$mg-breakpoint-desktop-wide: 1200px;  // Extra large devices
+```
+
+### 4. Component-Specific Overrides
+
+```scss
+// Hero component customization
+$mg-color-hero: $mg-color-blue-900;
+$mg-color-hero--secondary: $mg-color-orange-900;
+$mg-color-hero--tertiary: $mg-color-neutral-700;
+$mg-color-hero--quaternary: $mg-color-red-900;
+$mg-opacity-hero: 0.9;
+$mg-spacing-hero-overlay: $mg-spacing-100;
+
+// Tab component styling
+$mg-color-tabbar-background: $mg-color-blue-50;
+$mg-color-tab-background: $mg-color-neutral-0;
+$mg-color-tab-border: $mg-color-neutral-300;
+$mg-color-tab-border--active: $mg-color-interactive;
+$mg-color-tab-background--hover: $mg-color-blue-50;
+$mg-radius-tab: $mg-spacing-50;
+$mg-padding-tab: $mg-spacing-100 $mg-spacing-200;
+$mg-color-text-tab: $mg-color-neutral-600;
+$mg-color-text-tab--hover: $mg-color-interactive;
+$mg-color-text-tab-active: $mg-color-interactive;
+
+// Button component styling
+$mg-color-button: $mg-color-white;
+$mg-color-button--hover: $mg-color-white;
+$mg-color-text-button: $mg-color-white;
+$mg-border-color-button: $mg-color-interactive;
+
+// Author image radius (for profile pictures)
+$author-image-radius: 50%;  // Circular images
+```
+
+## Building Custom Components
+
+### Component Structure
+
+Follow Mangrove's BEM-inspired naming convention:
+
+```scss
+// custom/components/_news-card.scss
+.mg-news-card {
+  display: flex;
+  flex-direction: column;
+  background: white;
+  border-radius: var(--mg-border-radius);
+  box-shadow: var(--mg-shadow-sm);
+  overflow: hidden;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--mg-shadow-lg);
+  }
+
+  &__image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+  }
+
+  &__content {
+    padding: var(--mg-spacing-4);
+    flex: 1;
+  }
+
+  &__category {
+    @include mg-label-base;
+    background: var(--mg-color-primary);
+    color: white;
+    margin-bottom: var(--mg-spacing-2);
+  }
+
+  &__title {
+    @include mg-heading-3;
+    margin-bottom: var(--mg-spacing-3);
+
+    a {
+      color: inherit;
+      text-decoration: none;
+
+      &:hover {
+        color: var(--mg-color-primary);
+      }
+    }
+  }
+
+  &__excerpt {
+    @include mg-paragraph-base;
+    color: var(--mg-color-text-muted);
+    margin-bottom: var(--mg-spacing-4);
+  }
+
+  &__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--mg-spacing-3);
+    font-size: var(--mg-font-size-sm);
+    color: var(--mg-color-text-light);
+  }
+
+  &__date {
+    &::before {
+      content: "📅 ";
+      margin-right: var(--mg-spacing-1);
+    }
+  }
+
+  &__author {
+    &::before {
+      content: "✍️ ";
+      margin-right: var(--mg-spacing-1);
+    }
+  }
+
+  // Variants
+  &--featured {
+    border-top: 4px solid var(--mg-color-primary);
+
+    .mg-news-card__title {
+      color: var(--mg-color-primary);
+    }
+  }
+
+  &--urgent {
+    border-left: 4px solid var(--mg-color-danger);
+
+    .mg-news-card__category {
+      background: var(--mg-color-danger);
+    }
+  }
+}
+```
+
+### Using Mangrove Mixins
+
+Leverage existing Mangrove mixins for consistency:
+
+```scss
+// Available mixins
+@mixin mg-button-base {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--mg-spacing-3) var(--mg-spacing-4);
+  border: none;
+  border-radius: var(--mg-border-radius);
+  font-family: inherit;
+  font-size: var(--mg-font-size-base);
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+@mixin mg-card-base {
+  background: white;
+  border-radius: var(--mg-border-radius);
+  box-shadow: var(--mg-shadow-sm);
+  overflow: hidden;
+}
+
+@mixin mg-form-control {
+  width: 100%;
+  padding: var(--mg-spacing-3);
+  border: 1px solid var(--mg-color-border);
+  border-radius: var(--mg-border-radius);
+  font-family: inherit;
+  font-size: var(--mg-font-size-base);
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: var(--mg-color-primary);
+    box-shadow: 0 0 0 2px rgba(var(--mg-color-primary-rgb), 0.2);
+  }
+}
+
+// Use in your components
+.my-custom-button {
+  @include mg-button-base;
+  background: var(--mg-color-secondary);
+  color: white;
+}
+
+.my-custom-card {
+  @include mg-card-base;
+  padding: var(--mg-spacing-6);
+}
+
+.my-custom-input {
+  @include mg-form-control;
+}
+```
+
+## Theme Creation
+
+Create a complete custom theme by extending Mangrove:
+
+```scss
+// themes/_my-organization.scss
+
+// 1. Define brand colors using Mangrove's color system
+// Override the blue color scale for your primary brand
+$mg-color-blue-900: #1a5f7a;  // Primary brand color
+$mg-color-blue-800: #2d6f8a;  // Slightly lighter
+$mg-color-blue-700: #40809a;  // Active states
+$mg-color-blue-600: #5390aa;  // Hover states
+$mg-color-blue-500: #66a0ba;  // Light accents
+
+// Override orange scale for secondary colors
+$mg-color-orange-900: #57a773;  // Secondary brand color
+$mg-color-orange-800: #6ab783;  // Lighter secondary
+$mg-color-orange-700: #7dc793;  // Secondary accents
+
+// Custom accent colors (using red scale)
+$mg-color-red-900: #f4a261;   // Accent color
+$mg-color-red-800: #f5b071;   // Light accent
+
+// 2. Update interactive colors to use your brand
+$mg-color-interactive: $mg-color-blue-900;
+$mg-color-interactive-active: $mg-color-blue-700;
+
+// 3. Override component-specific variables
+$mg-color-button-background: $mg-color-interactive;
+$mg-color-button-background--hover: $mg-color-interactive-active;
+$mg-color-hero: $mg-color-interactive;
+$mg-color-hero--secondary: $mg-color-orange-900;
+$mg-color-hero--tertiary: $mg-color-neutral-700;
+$mg-color-label: $mg-color-interactive;
+
+// 4. Custom spacing for brand identity
+$mg-spacing-150: 1.2rem;      // Slightly tighter spacing
+$mg-spacing-200: 1.8rem;      // Custom section spacing
+$mg-radius-button: $mg-spacing-75;  // More rounded buttons
+$mg-radius-label: $mg-spacing-50;   // Rounded labels
+
+// 5. Typography adjustments
+$mg-font-family: 'Your-Brand-Font', 'Roboto', sans-serif;
+$mg-font-size-button: $mg-font-size-250;  // Larger button text
+
+// 6. Create custom component variants
+.mg-hero--branded {
+  background: linear-gradient(135deg,
+    #{$mg-color-blue-900} 0%,
+    #{$mg-color-orange-900} 100%
+  );
+
+  .mg-hero__title {
+    color: $mg-color-white;
+    text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  }
+}
+
+.mg-cta-button--branded {
+  background: $mg-color-red-900;
+  border-color: $mg-color-red-900;
+
+  &:hover {
+    background: $mg-color-red-800;
+    border-color: $mg-color-red-800;
+    transform: translateY(-1px);
+  }
+}
+
+.mg-card--branded {
+  border-top: 3px solid $mg-color-interactive;
+
+  &:hover {
+    border-top-color: $mg-color-orange-900;
+  }
+}
+
+// 7. Dark mode support using Mangrove variables
+[data-theme="dark"] {
+  --mg-color-bg: #{$mg-color-neutral-800};
+  --mg-color-text: #{$mg-color-neutral-0};
+  --mg-color-border: #{$mg-color-neutral-400};
+  --mg-color-interactive: #{$mg-color-blue-700};
+}
+```
+
+## Build Scripts
+
+### Package.json Scripts
+
+```json
+{
+  "scripts": {
+    "sass": "sass src/sass/main.scss:dist/css/style.css --watch",
+    "sass:build": "sass src/sass/main.scss:dist/css/style.css --style=compressed",
+    "sass:dev": "sass src/sass/main.scss:dist/css/style.css --watch --source-map",
+    "build": "npm run sass:build && npm run js:build",
+    "dev": "concurrently \"npm run sass:dev\" \"npm run js:dev\""
+  }
+}
+```
+
+### PostCSS Integration
+
+```javascript
+// postcss.config.js
+module.exports = {
+  plugins: [
+    require('autoprefixer'),
+    require('cssnano')({
+      preset: 'default',
+    }),
+  ],
+}
+```
+
+## Best Practices
+
+### 1. Import Order
+Always import in this order to ensure proper cascading:
+
+```scss
+// 1. External dependencies
+@import "normalize.css";
+
+// 2. Mangrove variables (for overriding)
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/variables";
+
+// 3. Your variable overrides
+@import "variables/colors";
+@import "variables/typography";
+@import "variables/spacing";
+
+// 4. Mangrove mixins and base
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/mixins";
+@import "~@unisdr/undrr-mangrove/stories/assets/scss/base";
+
+// 5. Mangrove components (only what you need)
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+
+// 6. Your custom components
+@import "components/news-card";
+@import "components/hero-banner";
+```
+
+### 2. Selective Imports
+Only import components you actually use:
+
+```scss
+// Instead of importing everything
+// @import "~@unisdr/undrr-mangrove/stories/**/*";
+
+// Import selectively
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+@import "~@unisdr/undrr-mangrove/stories/Components/Cards/Card/card";
+@import "~@unisdr/undrr-mangrove/stories/Components/Forms/InputFields/input-fields";
+```
+
+### 3. Variable Overrides
+Override variables before importing components:
+
+```scss
+// ❌ Wrong - too late to override
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+$mg-button-primary-bg: #custom-color;
+
+// ✅ Correct - override before import
+$mg-button-primary-bg: #custom-color;
+@import "~@unisdr/undrr-mangrove/stories/Components/Buttons/CtaButton/cta-button";
+```
+
+## Next Steps
+
+- **Explore Variables**: Check `/stories/assets/scss/_variables.scss` for all customizable options
+- **Study Components**: Look at existing component Sass files for patterns
+- **Build Tools**: Set up your preferred build process with Sass compilation
+- **Custom Theme**: Create your organization's unique theme extension
+
+Need help? Check out the [React Integration Guide](/?path=/docs/getting-started-react-integration--docs) or [Best Practices](/?path=/docs/getting-started-best-practices--docs)!

--- a/stories/Documentation/VanillaHtmlCss.mdx
+++ b/stories/Documentation/VanillaHtmlCss.mdx
@@ -1,0 +1,339 @@
+import { Meta, Source } from '@storybook/blocks';
+
+<Meta
+  title="Getting started/Vanilla HTML and CSS"
+  parameters={{
+    viewMode: "docs",
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }}
+/>
+
+# Vanilla HTML/CSS Integration
+
+The simplest way to use Mangrove - perfect for static sites, legacy projects, or when you want minimal dependencies.
+
+## To do
+
+- [ ] Add in guidance on using react precompiled components
+
+## Quick setup
+
+### 1. Include CSS files
+
+Add these `<link>` tags to your HTML `<head>`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My UNDRR Site</title>
+
+  <!-- UNDRR Theme (Choose one) -->
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
+
+  <!-- Alternative: Prevention Web Theme -->
+  <!-- <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-preventionweb.css"> -->
+</head>
+<body>
+  <!-- Your content here -->
+</body>
+</html>
+```
+
+### 2. Copy HTML Structures
+
+Browse the component library, click the "HTML" tab, and copy the markup:
+
+```html
+<!-- Example: Primary Button -->
+<a class="mg-button mg-button-primary" role="button" href="#">
+  Download Report
+</a>
+```
+
+## Complete Page Example
+
+Here's a full page using only Mangrove CSS classes:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mangrove Page Template Example</title>
+  <link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
+</head>
+<body>
+  <div class="page-template-example mg-container mg-container--spacer">
+
+    <!-- Placeholder for Global Header -->
+    <section>
+      The Global header is yet to be implemented in Storybook. Refer to UNDRR.org.
+    </section>
+
+    <!-- Placeholder for MegaMenu -->
+    <nav class="mg-mega-menu">
+      <!-- Example MegaMenu structure -->
+      <div class="mg-mega-menu__section">
+        <h2 class="mg-mega-menu__title">Section 1</h2>
+        <div class="mg-mega-menu__banner">
+          <div class="mg-mega-menu__banner-heading">Analytics by country</div>
+          <div class="mg-mega-menu__banner-description">Gaze upon statistics in wonder...</div>
+        </div>
+        <ul class="mg-mega-menu__items">
+          <li class="mg-mega-menu__item">Item 1</li>
+          <li class="mg-mega-menu__item">Item 2</li>
+        </ul>
+      </div>
+      <div class="mg-mega-menu__section">
+        <h2 class="mg-mega-menu__title">Section 2</h2>
+        <div class="mg-mega-menu__banner">
+          <div class="mg-mega-menu__banner-heading">Analytics by region</div>
+          <div class="mg-mega-menu__banner-description">Gaze upon statistics in wonder...</div>
+        </div>
+        <ul class="mg-mega-menu__items">
+          <li class="mg-mega-menu__item">Item 1</li>
+          <li class="mg-mega-menu__item">Item 2</li>
+        </ul>
+      </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <section class="mg-hero mg-hero--primary">
+      <div class="mg-hero__content">
+        <h1 class="mg-heading mg-heading--1 mg-hero__title">
+          Custom title<br>with&nbsp;line breaks and spaces
+        </h1>
+        <p class="mg-paragraph mg-paragraph--large mg-hero__subtitle">
+          This is custom summary text.<br>&nbsp;Another line.
+        </p>
+        <div class="mg-hero__actions">
+          <a href="/#" class="mg-cta-button mg-cta-button--primary">
+            <span class="mg-cta-button__text">Custom primary</span>
+          </a>
+          <a href="/#" class="mg-cta-button mg-cta-button--secondary">
+            <span class="mg-cta-button__text">Custom secondary</span>
+          </a>
+        </div>
+        <div class="mg-hero__image">
+          <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="Hero background" />
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab Section -->
+    <section class="mg-tabs">
+      <ul class="mg-tabs__list">
+        <li class="mg-tabs__tab mg-tabs__tab--active" id="tab-1">Tab title 1</li>
+        <li class="mg-tabs__tab" id="tab-2">Tab title 2</li>
+        <li class="mg-tabs__tab" id="tab-3">Tab title 3 i am a bit longer and on and on</li>
+      </ul>
+      <div class="mg-tabs__panel" id="tab-1-panel">
+        As the UN Office for Disaster Risk Reduction, UNDRR convenes partners and coordinates activities to create safer, more resilient communities.
+      </div>
+      <!-- Add other tab panels as needed -->
+    </section>
+
+    <!-- Cards Section -->
+    <section class="mg-grid mg-grid__col-3">
+      <article class="mg-card mg-card--vertical">
+        <div class="mg-card__image">
+          <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="A person looks on" class="mg-card__img">
+        </div>
+        <div class="mg-card__content">
+          <span class="mg-label mg-label--primary">CONTENT TAG</span>
+          <header class="mg-heading mg-heading--3 mg-card__title"><a href="javascript:void(0)">Title in large size</a></header>
+          <p class="mg-paragraph mg-card__excerpt">
+            Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely by vulnerable populations and communities. This paper explores health risks from climate change in a global context, setting out key risks actions
+          </p>
+          <div class="mg-card__actions">
+            <a href="javascript:void(0)" class="mg-cta-button mg-cta-button--primary">
+              <span class="mg-cta-button__text">Primary action</span>
+            </a>
+          </div>
+        </div>
+      </article>
+      <!-- Repeat the card two more times for the 3-column layout -->
+      <article class="mg-card mg-card--vertical">
+        <div class="mg-card__image">
+          <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="A person looks on" class="mg-card__img">
+        </div>
+        <div class="mg-card__content">
+          <span class="mg-label mg-label--primary">CONTENT TAG</span>
+          <header class="mg-heading mg-heading--3 mg-card__title"><a href="javascript:void(0)">Title in large size</a></header>
+          <p class="mg-paragraph mg-card__excerpt">
+            Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely by vulnerable populations and communities. This paper explores health risks from climate change in a global context, setting out key risks actions
+          </p>
+          <div class="mg-card__actions">
+            <a href="javascript:void(0)" class="mg-cta-button mg-cta-button--primary">
+              <span class="mg-cta-button__text">Primary action</span>
+            </a>
+          </div>
+        </div>
+      </article>
+      <article class="mg-card mg-card--vertical">
+        <div class="mg-card__image">
+          <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="A person looks on" class="mg-card__img">
+        </div>
+        <div class="mg-card__content">
+          <span class="mg-label mg-label--primary">CONTENT TAG</span>
+          <header class="mg-heading mg-heading--3 mg-card__title"><a href="javascript:void(0)">Title in large size</a></header>
+          <p class="mg-paragraph mg-card__excerpt">
+            Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely by vulnerable populations and communities. This paper explores health risks from climate change in a global context, setting out key risks actions
+          </p>
+          <div class="mg-card__actions">
+            <a href="javascript:void(0)" class="mg-cta-button mg-cta-button--primary">
+              <span class="mg-cta-button__text">Primary action</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <!-- Footer -->
+    <footer class="mg-footer">
+      <div class="mg-container">
+        <div class="mg-footer__bottom">
+          <p class="mg-paragraph mg-footer__copyright">
+            © 2024 United Nations Office for Disaster Risk Reduction. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>
+```
+
+## Available CSS Files
+
+Choose the right CSS files for your project:
+
+### Theme Variants (Choose One)
+
+**UNDRR Official Theme**
+```html
+<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style.css">
+```
+
+**Prevention Web Theme**
+```html
+<link rel="stylesheet" href="https://unisdr.github.io/undrr-mangrove/css/style-preventionweb.css">
+```
+
+## Component Categories
+
+### Layout & Structure
+- `mg-container` - Content containers with max-width
+- `mg-grid` - Flexible grid system
+- `mg-section` - Page sections with spacing
+
+### Typography
+- `mg-heading` - Styled headings (h1-h6)
+- `mg-paragraph` - Body text with proper spacing
+- `mg-link` - Styled links and text links
+
+### Buttons & Actions
+- `mg-cta-button` - Primary and secondary call-to-action buttons
+- `mg-chip` - Small interactive chips
+- `mg-share-buttons` - Social sharing buttons
+
+### Forms
+- `mg-form` - Form container and styling
+- `mg-form__input` - Text inputs
+- `mg-form__textarea` - Multi-line text areas
+- `mg-form__select` - Dropdown selects
+
+### Content Components
+- `mg-card` - Content cards (vertical/horizontal)
+- `mg-stats-card` - Statistics display cards
+- `mg-label` - Content category labels
+
+### Navigation
+- `mg-breadcrumb` - Breadcrumb navigation
+- `mg-menu` - Primary navigation menus
+- `mg-pagination` - Page navigation
+
+## Best Practices
+
+### 1. Semantic HTML First
+Always use the correct HTML element:
+```html
+<!-- Good -->
+<button class="mg-cta-button">Submit</button>
+<nav class="mg-breadcrumb">...</nav>
+
+<!-- Avoid -->
+<div class="mg-cta-button">Submit</div>
+<div class="mg-breadcrumb">...</div>
+```
+
+### 2. Accessibility Attributes
+Include proper ARIA labels and attributes:
+```html
+<button class="mg-cta-button" aria-label="Download PDF report">
+  <span class="mg-cta-button__text">Download</span>
+  <span class="mg-cta-button__icon" aria-hidden="true">↓</span>
+</button>
+```
+
+### 3. Responsive Design
+Use responsive utility classes:
+```html
+<div class="mg-grid mg-grid--1-col mg-grid--md-2-cols mg-grid--lg-3-cols">
+  <!-- Content automatically adapts to screen size -->
+</div>
+```
+
+### 4. Loading Performance
+Load CSS efficiently:
+```html
+<!-- Preload critical CSS -->
+<link rel="preload" href="path/to/style-gutenberg.css" as="style">
+<link rel="stylesheet" href="path/to/style-gutenberg.css">
+
+<!-- Async load theme CSS -->
+<link rel="stylesheet" href="path/to/style-undrr.css" media="print" onload="this.media='all'">
+```
+
+## JavaScript Enhancement (Optional)
+
+Some components work better with JavaScript. Include these for enhanced functionality:
+
+```html
+<!-- Optional: Mangrove JavaScript for enhanced components -->
+<script src="https://unisdr.github.io/undrr-mangrove/js/mangrove.min.js"></script>
+
+<!-- Initialize enhanced components -->
+<script>
+  // Auto-initialize all Mangrove components
+  Mangrove.init();
+
+  // Or initialize specific components
+  Mangrove.Accordion.init();
+  Mangrove.Dropdown.init();
+</script>
+```
+
+## Browser Support
+
+Mangrove CSS works in:
+- ✅ Chrome 70+
+- ✅ Firefox 63+
+- ✅ Safari 12+
+- ✅ Edge 79+
+- ✅ Internet Explorer 11 (with polyfills)
+
+## Next Steps
+
+- **Browse Components**: Explore the component library in the sidebar
+- **Copy HTML**: Use the HTML tab in each component story
+- **Customize**: Override CSS variables for theming
+- **Upgrade**: Consider [React Integration](/?path=/docs/getting-started-react-integration--docs) for dynamic applications
+
+Need help? Check out [Best Practices](/?path=/docs/getting-started-best-practices--docs) or [Real-world Examples](/?path=/docs/getting-started-examples--docs)!


### PR DESCRIPTION
Create onboarding documentation including Vanilla HTML/CSS, Sass, and React integration guides with examples and best practices.

For https://gitlab.com/undrr/web-backlog/-/issues/2219

## To do

 - [ ] Proper title case for headlines ("My headline" not "My Headline")
 - [ ] Update links to use storybook's linkTo (e.g. `<a href="javascript:void(0)" onClick={linkTo('getting-started-best-practices', 'docs')} >`)
 - [ ] Fix up full HTML example and link to codepen demo https://codepen.io/khawkins98/pen/MYwbKwe