### PR TITLE
fix: align with UNDRR styles and modernize table, breadcrumb

### DIFF
--- a/stories/Atom/Navigation/Breadcrumb/Breadcrumb.jsx
+++ b/stories/Atom/Navigation/Breadcrumb/Breadcrumb.jsx
@@ -1,6 +1,1 @@
-import React from 'react';
-// import './breadcrumb.scss';
-
-export const Breadcrumb = ({ text }) => (
-  <a href="#">{text}</a>
-);
+// Retried

--- a/stories/Atom/Navigation/Breadcrumb/breadcrumb.scss
+++ b/stories/Atom/Navigation/Breadcrumb/breadcrumb.scss
@@ -1,17 +1,1 @@
-
-// * breadcrumb start *//
-.breadcrumb__item {
-  @extend %border-none;
-  @extend %img_none;
-
-  color: $mg-color-red-900;
-  font-size: $mg-font-size-100;
-  font-weight: 600;
-  text-transform: uppercase;
-
-  &:hover {
-    color: $mg-color-red-900;
-  }
-}
-
-// * breadcrumb end *//
+// Retried

--- a/stories/Atom/Table/Table.jsx
+++ b/stories/Atom/Table/Table.jsx
@@ -1,12 +1,4 @@
 import React from 'react';
-// import './table.scss';
-
-const TableScroll = ({ tableType, children }) => (tableType == 'scroll' ?
-	<div className="scroll" tabIndex="0">
-		{children}
-	</div>
-	: children
-);
 
 export const variant_options = {
 	default: "",
@@ -31,44 +23,17 @@ export const TableTag = ({ text, tdtext, details, variant, size, responsive, ...
 	let table_type = variant_options[`${variant}`];
 	let table_size = variant_options1[`${size}`];
 	let table_responsive = variant_options2[`${responsive}`];
+
+	// Build the complete CSS class string
+	const tableClasses = [
+		'mg-table',
+		table_size && `mg-table--${table_size}`,
+		table_type && `mg-table--${table_type}`,
+		table_responsive && responsive !== 'auto' && `mg-table--${table_responsive}`
+	].filter(Boolean).join(' ');
+
 	return (
-		<TableScroll tableType={responsive}>
-      {variant === 'default' && size === 'large' && responsive === 'auto'
-      ? (
-        <table>
-          	<thead>
-					<tr>
-						<th>{text}</th>
-						<th>{text}</th>
-						<th>{text}</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>{tdtext}</td>
-						<td>{tdtext}</td>
-						<td>{details}</td>
-					</tr>
-					<tr>
-						<td>{tdtext}</td>
-						<td>{tdtext}</td>
-						<td>{details}</td>
-					</tr>
-					<tr>
-						<td>{tdtext}</td>
-						<td>{tdtext}</td>
-						<td>{details}</td>
-					</tr>
-					<tr>
-						<td>{tdtext}</td>
-						<td>{tdtext}</td>
-						<td>{details}</td>
-					</tr>
-				</tbody>
-      </table>
-      )
-      : (
-			<table className={cls(`${table_type}`, `${table_size}`, `${table_responsive}`)}>
+		<table className={tableClasses} tabIndex={responsive === 'scroll' ? "0" : undefined}>
 				<thead>
 					<tr>
 						<th>{text}</th>
@@ -98,9 +63,7 @@ export const TableTag = ({ text, tdtext, details, variant, size, responsive, ...
 						<td>{details}</td>
 					</tr>
 				</tbody>
-      </table>
-      )}
-		</TableScroll>
+		</table>
 	);
 };
 

--- a/stories/Atom/Table/Table.mdx
+++ b/stories/Atom/Table/Table.mdx
@@ -22,54 +22,95 @@ Tables are used to represent data sets that are easy to understand and access.
 ### Overview
 
 Tables are used for large volumes of data that can be accessed easily and understandable by the user. These tables are created using various modifiers like default, striped, bordered, small, stacked, scroll.
+- **Comparative data:** Perfect for side-by-side comparisons
+- **Scannable information:** Users need to quickly find specific data points
+- **Reports and analytics:** Financial data, metrics, or any tabular reporting
 
-#### When to use:
+## Styling variants
 
-These tables are used when there is huge data. When there is a huge volume of data to handle. Using this the data can be accessed easily.
+### Default table
 
-### Formatting
+Your basic table setup—clean, simple, and gets the job done.
 
-#### Default
+<Story of={TableStories.DefaultTable} />
 
-The table is large in size, variant default and responsive is auto
+### Striped table
 
-### Behaviors
+Alternating row colors make it easier to scan across columns, especially with wide datasets. This applies the `.mg-table--striped` class.
 
-#### States
+<Story of={TableStories.StripedTable} />
 
-The tables are created using various modifiers:
+### Bordered table
 
-**Default**: In this, there are 2 different states:
+Clear cell boundaries for when you need extra visual definition. Uses the `.mg-table--border` class.
 
-Large: In this state, the table size will be large, the variant is the default, and has auto responsive.
-Small: In the state, the table size is small, the variant is the default, and has auto responsive.
+<Story of={TableStories.BorderedTable} />
 
-**Selected**: In this, it has 2 different types of modifiers:
+## Size options
 
-Striped: The table size can be larger, or small, the variant is striped and the responsiveness of the table is either stacked, auto or scroll.
+### Small table
 
-Stripped with stacked table view: In this, the table has stripped rows with stacked views.
+Compact tables for dense information or smaller spaces. Applies `.mg-table--small` for reduced font size and padding.
 
-Stripped with scrolled table view: In this, the table has a stripped style of view with scrollable content.
+<Story of={TableStories.SmallTable} />
 
-The table size can be large or small, the variant is the border. The responsiveness of the table is either stacked, auto or scroll.
+### Small striped table
 
-* Border with stacked table view: This table has a border and will be stacked.
-* Border with scroll table view:  In this, the table has a border and will be scrollable.
+Combining size and styling variants—perfect for detailed data in tight spaces.
 
-<Canvas>
-  <Story of={TableStories.DefaultTable} />
-</Canvas>
+<Story of={TableStories.SmallStripedTable} />
 
-### Usage
+## Responsive behaviors
 
-* Select the size control as either Large or Small, variant as Default, Stripped or Border and responsive control as Stacked, Auto or Scroll from the control tab of canvas.
-* Copy the HTML from the HTML tab
+### Stacked table (mobile-first)
 
-### Interactions
+On smaller screens, this converts to a card-like layout using `.mg-table--stacked`. Resize your browser to see the magic happen.
 
-No interactions are needed with the progress bar.
+<Story of={TableStories.StackedTable} />
 
-### Changelog
+### Scrollable table
 
-1.0 — Released component
+For wide tables that need horizontal scrolling. The `.mg-table--scroll` class provides smooth horizontal navigation directly on the table element.
+
+<Story of={TableStories.ScrollableTable} />
+
+### Bordered stacked table
+
+You can combine styling and responsive modifiers—here's a bordered table that stacks on mobile.
+
+<Story of={TableStories.BorderedStackedTable} />
+
+## Implementation notes
+Here's what's happening under the hood: The table component automatically applies CSS classes based on your props, building combinations like `mg-table mg-table--small mg-table--striped mg-table--stacked` for complex layouts.
+
+**Pro tip:** Striped tables work especially well for financial data or any content where users need to track across multiple columns—the alternating colors act like visual guidelines.
+
+### CSS class structure
+
+- **Base:** `mg-table` (required on all tables)
+- **Size:** `mg-table--small` (large is default)
+- **Styling:** `mg-table--striped`, `mg-table--border`
+- **Responsive:** `mg-table--stacked`, `mg-table--scroll`
+
+### Setup steps
+
+1. **Choose your size:** Select Large or Small from the size control
+2. **Pick a variant:** Default, Striped, or Bordered from the variant control
+3. **Set responsiveness:** Choose Stacked, Auto, or Scroll from the responsive control
+4. **Copy the code:** Grab the HTML from the HTML tab and you're good to go
+
+## Usage guidelines
+
+The table component handles all the responsive heavy lifting for you, so you can focus on your content rather than wrestling with CSS breakpoints. Mix and match variants to create exactly the table experience your users need.
+
+### Accessibility considerations
+
+- Tables include proper semantic structure with `thead` and `tbody`
+- Scrollable tables are keyboard navigable with `tabIndex="0"`
+- RTL (right-to-left) language support is built-in
+
+## Changelog
+
+**2.0** — **Breaking change:** All `table` elements must now include the `.mg-table` class for proper styling and functionality.
+
+**1.0** — Released component

--- a/stories/Atom/Table/Table.stories.jsx
+++ b/stories/Atom/Table/Table.stories.jsx
@@ -95,5 +95,133 @@ export const DefaultTable = {
     );
   },
 
-  name: "Table",
+  name: "Default table",
+};
+
+export const StripedTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        variant="striped"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Striped table",
+};
+
+export const BorderedTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        variant="border"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Bordered table",
+};
+
+export const SmallTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        size="small"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Small table",
+};
+
+export const SmallStripedTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        size="small"
+        variant="striped"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Small striped table",
+};
+
+export const StackedTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        responsive="stacked"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Stacked table (mobile-first)",
+};
+
+export const ScrollableTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        responsive="scroll"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Scrollable table",
+};
+
+export const BorderedStackedTable = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+
+    return (
+      <TableTag
+        text={caption.headertext}
+        tdtext={caption.tdtext}
+        details={caption.details}
+        variant="border"
+        responsive="stacked"
+        {...args}
+      ></TableTag>
+    );
+  },
+
+  name: "Bordered stacked table",
 };

--- a/stories/Atom/Table/table.scss
+++ b/stories/Atom/Table/table.scss
@@ -1,22 +1,24 @@
 /* table tag start */
-table {
+.mg-table {
   border-collapse: collapse;
   border-spacing: 0;
   width: 100%;
+  word-break: auto-phrase; // https://gitlab.com/undrr/web-backlog/-/issues/2053
+  text-wrap: balance;
 
   @include devicebreak(medium) {
     width: auto;
   }
 
-  &.small {
+  &.mg-table--small {
     th,
     td {
-      font-size: $mg-font-size-300;
+      font-size: $mg-font-size-250;
       -webkit-text-size-adjust: 100%;
     }
   }
 
-  &.striped {
+  &.mg-table--striped {
     tr {
       @extend %border-none;
 
@@ -26,16 +28,19 @@ table {
     }
   }
 
-  &.border {
+  &.mg-table--border {
     border-collapse: collapse;
 
     th,
     td {
       border: 1px solid $mg-color-neutral-400;
-    }
+      border-collapse: collapse;
+      box-sizing: border-box;
+      min-width: 50px;
+      }
   }
 
-  &.stacked {
+  &.mg-table--stacked {
     th,
     td {
       display: block;
@@ -55,7 +60,7 @@ table {
       }
     }
 
-    &.border {
+    &.mg-table--border {
       tr {
         border: 1px solid $mg-color-neutral-400;
 
@@ -72,9 +77,9 @@ table {
   }
 }
 
-th,
-td {
-  font-size: $mg-font-size-400;
+.mg-table th,
+.mg-table td {
+  font-size: $mg-font-size-300;
   line-height: 1.4;
   padding: $mg-spacing-25;
   vertical-align: top;
@@ -84,24 +89,20 @@ td {
   }
 }
 
-thead {
-  tr {
-    th {
-      background-color: $mg-color-neutral-300;
-      font-weight: 600;
-      text-align: left;
-    }
-  }
+.mg-table thead tr th {
+  // background-color: $mg-color-neutral-300;
+  font-weight: 600;
+  text-align: center;
 }
 
-tbody {
-  tr {
-    @extend %border-bottom;
-  }
+.mg-table tbody tr {
+  @extend %border-bottom;
 }
 
-.scroll {
+.mg-table--scroll {
   overflow-x: auto;
+  width: max-content;
+  min-width: 100%;
 
   thead {
     th {
@@ -116,8 +117,8 @@ tbody {
 }
 
 [dir="rtl"] {
-  th,
-  td {
+  .mg-table th,
+  .mg-table td {
     text-align: right;
 
     @include devicebreak(medium) {
@@ -127,11 +128,11 @@ tbody {
 }
 
 // burmese lang
-:lang(my) {
-  th,
-  td {
-    line-height: 1.7;
-  }
-}
+// :lang(my) {
+//   th,
+//   td {
+//     line-height: 1.7;
+//   }
+// }
 
 /* table tag end */

--- a/stories/Components/Breadcrumbs/Breadcrumbs.jsx
+++ b/stories/Components/Breadcrumbs/Breadcrumbs.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
-// import './breadcrumbs.scss';
 
 export function Breadcrumbcomponent({ data, Color, ...args }) {
   const lastIndex = data.length - 1;
 
-  let color = '';
+  let colorClass = '';
   if (Color == 'White') {
-    color = 'white';
+    colorClass = 'mg-breadcrumb--white';
   }
 
   return (
-    <nav aria-label="breadcrumbs" data-viewport="true" className={['breadcrumb', `${color}`].join(' ')}>
+    <nav aria-label="breadcrumbs" className={['mg-breadcrumb', `${colorClass}`].join(' ').trim()}>
       <ul>
         {data.map((item, i) => {
           if (i === lastIndex) {

--- a/stories/Components/Breadcrumbs/Breadcrumbs.stories.jsx
+++ b/stories/Components/Breadcrumbs/Breadcrumbs.stories.jsx
@@ -138,3 +138,24 @@ export const DefaultBreadcrumbs = {
     },
   },
 };
+
+export const WhiteBreadcrumbs = {
+  render: (args, { globals: { locale } }) => {
+    const caption = getCaptionForLocale(locale);
+    return <Breadcrumbcomponent data={caption} Color="White" {...args}></Breadcrumbcomponent>;
+  },
+
+  name: "White breadcrumbs",
+
+  parameters: {
+    backgrounds: {
+      default: "dark",
+      values: [
+        {
+          name: "dark",
+          value: "#1a1a1a",
+        },
+      ],
+    },
+  },
+};

--- a/stories/Components/Breadcrumbs/breadcrumbs.scss
+++ b/stories/Components/Breadcrumbs/breadcrumbs.scss
@@ -1,89 +1,85 @@
+.mg-breadcrumb {
+  font-family: $mg-font-family-condensed;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: $mg-font-size-300;
+  padding: 0;
 
-.breadcrumb {
-  ul {
-    align-items: baseline;
-    display: flex;
-    flex-wrap: wrap;
-    font-size: $mg-font-size-100;
+  li {
+    display: inline-block;
+    margin: 0;
     padding: 0;
+    position: relative;
 
-    li {
-      display: inline-block;
-      margin: $mg-spacing-25 $mg-spacing-100 $mg-spacing-25 0;
-      padding-left: 0;
-      position: relative;
+    &:first-of-type {
+      margin-left: 0;
+    }
 
-      &::after {
-        color: $mg-color-red-900;
-        content: "/";
-        font-weight: bold;
-        position: absolute;
-        right: -12px;
-        top: 0;
-      }
+    &:last-of-type {
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      margin-right: 0;
+      max-width: calc(100vw - 2rem);
+    }
 
-      &:first-of-type {
-        margin-left: 0;
-      }
+    a {
+      background: none;
+      color: $mg-color-text;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      transition: opacity 0.2s ease;
 
-      &:last-of-type {
-        font-weight: 600;
-        letter-spacing: 0.03em;
-        margin-right: 0;
-        max-width: calc(100vw - 2rem);
-
-        &::after {
-          display: none;
-        }
-      }
-
-      a {
-        background: none;
-        color: $mg-color-red-900;
-        font-size: $mg-font-size-100;
-        font-weight: 600;
-        letter-spacing: 0.03em;
-        text-transform: uppercase;
-        transition: opacity 0.2s ease;
-
-        &:hover {
-          color: $mg-color-red-900;
-        }
+      &:hover {
+        color: $mg-color-text;
       }
     }
   }
 
-  &.white {
-    li {
-      &::after {
-        color: $mg-color-white;
-      }
+  li + li:before {
+    font-family: $mg-font-family-icons;
+    color: $mg-color-text;
+    content: "\f105";
+    padding: 0 12px 0 14px;
+    vertical-align: top;
+  }
 
-      a {
-        color: $mg-color-white;
+  li + li:has(a:empty):before {
+    display: none;
+  }
+}
 
-        &:hover {
-          color: $mg-color-white;
-          opacity: 0.7;
-        }
-      }
-    }
-
-    &:last-of-type,
-    li:last-of-type {
+.mg-breadcrumb.mg-breadcrumb--white {
+  li {
+    color: $mg-color-white;
+    a {
       color: $mg-color-white;
+
+      &:hover {
+        color: $mg-color-white;
+        opacity: 0.7;
+      }
     }
+  }
+
+  &:last-of-type,
+  li:last-of-type {
+    color: $mg-color-white;
+  }
+
+  li + li:before {
+    color: $mg-color-white;
   }
 }
 
 [dir="rtl"] {
-  .breadcrumb {
-    ul {
-      padding: 0;
-    }
+  .mg-breadcrumb {
+    padding: 0;
 
     li {
-      margin: $mg-spacing-25 0 $mg-spacing-25 $mg-spacing-100;
+      margin: 0;
       padding-right: 0;
 
       a {
@@ -91,7 +87,7 @@
       }
 
       &:first-of-type {
-        margin-left: $mg-spacing-100;
+        margin-left: 0;
         margin-right: 0;
       }
 
@@ -99,21 +95,19 @@
         margin-left: 0;
         margin-right: 0;
       }
+    }
 
-      &::after {
-        @include transform(translate(0, -63%) rotate(140deg));
+    li + li:before {
+      @include transform(rotate(180deg));
 
-        left: -14px;
-        right: unset;
-        top: 63%;
-      }
+      padding: 0 14px 0 12px;
     }
   }
 }
 
 // burmese lang
-:lang(my) {
-  .breadcrumb li:last-of-type {
-    font-size: $mg-font-size-100;
-  }
-}
+// :lang(my) {
+//   .mg-breadcrumb li:last-of-type {
+//     font-size: $mg-font-size-100;
+//   }
+// }

--- a/stories/assets/scss/_components.scss
+++ b/stories/assets/scss/_components.scss
@@ -19,8 +19,9 @@
 @import "../../Atom/Images/ImageCredit/image-credit";
 @import "../../Atom/Layout/Container/container";
 @import "../../Atom/Layout/Grid/grid";
-@import "../../Atom/Layout/Spacing/spacing";
-@import "../../Atom/Navigation/Breadcrumb/breadcrumb";
+
+// @import "../../Atom/Layout/Spacing/spacing"; // Retried
+// @import "../../Atom/Navigation/Breadcrumb/breadcrumb"; // Retried
 @import "../../Atom/Navigation/LanguageSwitcherRow/language-switcher-row";
 @import "../../Atom/Navigation/MenuItems/menu-items";
 @import "../../Atom/Navigation/ProgressBarNavigation/progress-bar-navigation";

--- a/stories/assets/scss/_foundational.scss
+++ b/stories/assets/scss/_foundational.scss
@@ -13,14 +13,14 @@ html {
 }
 
 body {
-  color: $mg-color-black;
+  color: $mg-color-text;
   font-family: $mg-font-family;
   font-size: $mg-font-size-300;
-  line-height: $mg-font-line-height-500;
+  line-height: $mg-font-line-height-700;
 
-  @include devicebreak(medium) {
-    font-size: $mg-font-size-300;
-  }
+  // @include devicebreak(medium) {
+  //   font-size: $mg-font-size-300;
+  // }
 }
 
 button {
@@ -65,11 +65,7 @@ h2 {
   line-height: 1.1;
 
   @include devicebreak(medium) {
-    font-size: 2.813rem;
-  }
-
-  @include devicebreak(large) {
-    font-size: 3.438rem;
+    font-size: 2.6rem;
   }
 }
 
@@ -197,99 +193,99 @@ a {
 }
 
 // burmese lang
-:lang(my) {
-  body {
-    font-family: $mg-font-family;
-    line-height: 1.7;
-  }
+// :lang(my) {
+//   body {
+//     font-family: $mg-font-family;
+//     line-height: 1.7;
+//   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    line-height: 1.7;
-  }
+//   h1,
+//   h2,
+//   h3,
+//   h4,
+//   h5,
+//   h6 {
+//     line-height: 1.7;
+//   }
 
-  h1 {
-    font-family: $mg-font-family;
-    font-size: 2.625rem;
+//   h1 {
+//     font-family: $mg-font-family;
+//     font-size: 2.625rem;
 
-    @include devicebreak(medium) {
-      font-size: 3.875rem;
-    }
+//     @include devicebreak(medium) {
+//       font-size: 3.875rem;
+//     }
 
-    @include devicebreak(large) {
-      font-size: 5rem;
-    }
-  }
+//     @include devicebreak(large) {
+//       font-size: 5rem;
+//     }
+//   }
 
-  h2 {
-    font-size: 2rem;
+//   h2 {
+//     font-size: 2rem;
 
-    @include devicebreak(medium) {
-      font-size: 2.188rem;
-    }
+//     @include devicebreak(medium) {
+//       font-size: 2.188rem;
+//     }
 
-    @include devicebreak(large) {
-      font-size: 2.813rem;
-    }
-  }
+//     @include devicebreak(large) {
+//       font-size: 2.813rem;
+//     }
+//   }
 
-  h4 {
-    font-size: 1.3rem;
+//   h4 {
+//     font-size: 1.3rem;
 
-    @include devicebreak(medium) {
-      font-size: 1.8rem;
-    }
-  }
+//     @include devicebreak(medium) {
+//       font-size: 1.8rem;
+//     }
+//   }
 
-  h5 {
-    font-size: $mg-font-size-400;
+//   h5 {
+//     font-size: $mg-font-size-400;
 
-    @include devicebreak(medium) {
-      font-size: 1.375rem;
-    }
-  }
+//     @include devicebreak(medium) {
+//       font-size: 1.375rem;
+//     }
+//   }
 
-  p {
-    font-size: $mg-font-size-200;
-    line-height: 1.7;
+//   p {
+//     font-size: $mg-font-size-200;
+//     line-height: 1.7;
 
-    @include devicebreak(medium) {
-      font-size: $mg-font-size-300;
-    }
-  }
+//     @include devicebreak(medium) {
+//       font-size: $mg-font-size-300;
+//     }
+//   }
 
-  ul li,
-  ol li,
-  dl {
-    font-size: 0.875rem;
-    line-height: 1.9;
+//   ul li,
+//   ol li,
+//   dl {
+//     font-size: 0.875rem;
+//     line-height: 1.9;
 
-    @include devicebreak(medium) {
-      font-size: 1.125rem;
-    }
-  }
+//     @include devicebreak(medium) {
+//       font-size: 1.125rem;
+//     }
+//   }
 
-  .sbdocs {
-    .sbdocs-content,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    p {
-      font-family: $mg-font-family;
-    }
+//   .sbdocs {
+//     .sbdocs-content,
+//     h1,
+//     h2,
+//     h3,
+//     h4,
+//     h5,
+//     h6,
+//     p {
+//       font-family: $mg-font-family;
+//     }
 
-    .sbdocs-h1 {
-      font-size: $mg-spacing-150;
-    }
-  }
-}
+//     .sbdocs-h1 {
+//       font-size: $mg-spacing-150;
+//     }
+//   }
+// }
 
 [dir="rtl"] {
   ul,

--- a/stories/assets/scss/_variables.scss
+++ b/stories/assets/scss/_variables.scss
@@ -192,6 +192,7 @@ $mg-font-size-1100: 6.4rem;
 $mg-font-body: $mg-font-size-300;
 $mg-font-label: $mg-font-size-200;
 $mg-font-line-height-500: 1.25em;
+$mg-font-line-height-700: 1.5em;
 
 // This is not really a "varaible" but kept here for now
 // until we more fully rationalise our design decisions
@@ -232,6 +233,7 @@ $mg-font-line-height-500: 1.25em;
 
 $mg-font-family: "Roboto", sans-serif;
 $mg-font-family-condensed: "Roboto Condensed", sans-serif;
+$mg-font-family-icons: "fontawesome";
 
 // $mg-font-family-icons: "mangrove-icon-set";
 // Not yet activated as we are using the FontAwesome namespace


### PR DESCRIPTION
For https://gitlab.com/undrr/web-backlog/-/issues/2235 

- removes gaps in UNDRR.org and Mangrove styles
- scopes Mangrove table CSS to `.mg-table`
- scopes Mangrove breadcrumb to `.mg-breadcrumb`
    - We can now eliminate the inconsistency and use the style in Drupal

