### PR TITLE
fix(docs): update CDN assets to use tagged releases [skip chromatic]

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,16 +255,20 @@ For CDN and static asset hosting in the [UNDRR Static assets repo](https://gitla
 
 ### Production CDN
 
+All assets are now served from versioned endpoints for stability:
+
 ```
-https://assets.undrr.org/static/sitemap.html#mangrove-1-2-4
+https://assets.undrr.org/static/sitemap.html#mangrove-1-2-9
 https://assets.undrr.org/static/mangrove/README.md
 https://assets.undrr.org/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/static/mangrove/latest/components/MegaMenu.js
 https://assets.undrr.org/static/mangrove/latest/assets/js/tabs.js
-https://assets.undrr.org/static/mangrove/1.2.5/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
 ```
 
-### Bleeding edge test repo
+#### Bleeding edge test repo
 
 ```
 https://assets.undrr.org/testing/static/sitemap.html#mangrove-1-2-4
@@ -272,6 +276,31 @@ https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/testing/static/mangrove/1.2.5/css/style.css
 ... etc
 ```
+
+### Checking and updating to the latest version
+
+To check the current latest version available on npm:
+
+```bash
+npm view @undrr/undrr-mangrove version
+# or
+npm info @undrr/undrr-mangrove version
+```
+
+To install the latest version:
+
+```bash
+npm install @undrr/undrr-mangrove@latest
+```
+
+To update all dependencies to their latest semver-compatible versions:
+
+```bash
+npm outdated
+npm update
+```
+
+**Note**: We no longer provide bleeding-edge or "latest" endpoints. All CDN assets are now served from stable, versioned releases to ensure consistency and reliability.
 
 ## Assorted technical notes
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -78,6 +78,9 @@ https://assets.undrr.org/testing/static/mangrove/README.md
 https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/testing/static/mangrove/latest/components/MegaMenu.js
 https://assets.undrr.org/testing/static/mangrove/latest/assets/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
 ```
 
 The workflow ensures that the `dist` branch always reflects the latest stable build from `main`, making it reliable for production CDN usage.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@undrr/undrr-mangrove",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Mangrove design System for UNDRR",
   "main": "index.js",
   "scripts": {
     "build": "NODE_ENV=production yarn run scss && storybook build -o docs-build-temp --loglevel verbose && webpack --progress",
     "dev": "NODE_ENV=development yarn run storybook",
     "storybook": "NODE_ENV=development storybook dev -p 6006",
+    "update-cdn-version": "node scripts/update-cdn-version.js",
     "scss": "sass ./stories/assets/scss:./stories/assets/css --silence-deprecation import",
     "scss-watch": "sass --watch ./stories/assets/scss:./stories/assets/css --silence-deprecation import",
     "lint": "yarn run lint:css && yarn run lint:js",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,41 @@
+# Scripts
+
+This directory contains utility scripts for the Mangrove project.
+
+## update-cdn-version.js
+
+Automatically updates all CDN links in documentation files to use the current version from `package.json` instead of "latest" or "testing" endpoints.
+
+### Usage
+
+```bash
+# Run the script directly
+node scripts/update-cdn-version.js
+
+# Or use the npm script
+yarn update-cdn-version
+```
+
+### What it does
+
+1. Reads the current version from `package.json`
+2. Updates all documentation files to replace:
+   - `https://assets.undrr.org/testing/static/mangrove/latest/` → `https://assets.undrr.org/static/mangrove/{version}/`
+   - `https://assets.undrr.org/static/mangrove/latest/` → `https://assets.undrr.org/static/mangrove/{version}/`
+
+### Files updated
+
+- `README.md`
+- `stories/Documentation/GettingStarted.mdx`
+- `stories/Documentation/VanillaHtmlCss.mdx`
+- `stories/Documentation/Intro.mdx`
+- `stories/Components/Accordion/Accordion.mdx`
+- `stories/Components/StatsCardSlider/StatsCardSlider.mdx`
+- `stories/Components/LanguageSwitcher/LanguageSwitcher.mdx`
+- `stories/Utilities/ShowMore/ShowMore.mdx`
+- `stories/Atom/Layout/Grid/Grid.mdx`
+- `docs/RELEASES.md`
+
+### When to use
+
+Run this script after each release to ensure all documentation points to the stable, versioned CDN assets instead of bleeding-edge ones. 

--- a/scripts/update-cdn-version.js
+++ b/scripts/update-cdn-version.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Read version from package.json
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const version = packageJson.version;
+
+console.log(`Updating CDN links to use version ${version}...`);
+
+// Files to update with their patterns
+const filesToUpdate = [
+  {
+    path: 'README.md',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      },
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Documentation/GettingStarted.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Documentation/VanillaHtmlCss.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Documentation/Intro.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/Accordion/Accordion.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/StatsCardSlider/StatsCardSlider.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/LanguageSwitcher/LanguageSwitcher.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Utilities/ShowMore/ShowMore.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Atom/Layout/Grid/Grid.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'docs/RELEASES.md',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  }
+];
+
+// Update each file
+filesToUpdate.forEach(fileConfig => {
+  const filePath = fileConfig.path;
+  
+  if (!fs.existsSync(filePath)) {
+    console.warn(`Warning: File ${filePath} not found, skipping...`);
+    return;
+  }
+  
+  let content = fs.readFileSync(filePath, 'utf8');
+  let updated = false;
+  
+  fileConfig.patterns.forEach(pattern => {
+    const newContent = content.replace(pattern.from, pattern.to);
+    if (newContent !== content) {
+      content = newContent;
+      updated = true;
+    }
+  });
+  
+  if (updated) {
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log(`✅ Updated ${filePath}`);
+  } else {
+    console.log(`⏭️  No changes needed for ${filePath}`);
+  }
+});
+
+console.log(`\n🎉 CDN links updated to version ${version}!`);
+console.log(`\nNote: The following files were updated to use tagged releases:`);
+console.log(`- All documentation files now point to https://assets.undrr.org/static/mangrove/${version}/`);
+console.log(`- Removed references to 'latest' and 'testing' endpoints`);
+console.log(`- Users should now use stable, versioned assets instead of bleeding-edge ones`); 

--- a/stories/Atom/Layout/Grid/Grid.mdx
+++ b/stories/Atom/Layout/Grid/Grid.mdx
@@ -41,7 +41,7 @@ Use the grid to create a layout of your choice based on the design you want to a
 
 Add the base layout style from
 
-- https://assets.undrr.org/testing/static/mangrove/latest/assets/css/grid.min.css
+- https://assets.undrr.org/static/mangrove/1.2.9/assets/css/grid.min.css
 
 ### Changelog
 

--- a/stories/Components/Accordion/Accordion.mdx
+++ b/stories/Components/Accordion/Accordion.mdx
@@ -81,8 +81,8 @@ Accordions make information processing and discovering more effective. However, 
 
 Add following CSS in your project
 
-- [Base layouting CSS](https://assets.undrr.org/testing/static/mangrove/latest/assets/css/foundation.min.css).
-- [Copy and add this component CSS in your project](https://assets.undrr.org/testing/static/mangrove/latest/assets/css/components/accordion.min.css).
+- [Base layouting CSS](https://assets.undrr.org/static/mangrove/1.2.9/assets/css/foundation.min.css).
+- [Copy and add this component CSS in your project](https://assets.undrr.org/static/mangrove/1.2.9/assets/css/components/accordion.min.css).
 
 #### JS
 

--- a/stories/Components/LanguageSwitcher/LanguageSwitcher.mdx
+++ b/stories/Components/LanguageSwitcher/LanguageSwitcher.mdx
@@ -131,7 +131,7 @@ There are two states: Default and Open.
 
 #### JS:
 
-- https://assets.undrr.org/testing/static/mangrove/latest/assets/js/lang-switcher.js
+- https://assets.undrr.org/static/mangrove/1.2.9/assets/js/lang-switcher.js
 
 ### Interactions
 

--- a/stories/Components/StatsCardSlider/StatsCardSlider.mdx
+++ b/stories/Components/StatsCardSlider/StatsCardSlider.mdx
@@ -206,5 +206,5 @@ This is collection of [Stats card](/docs/components-ui-components-cards-stats-ca
   - swiper('.stats-slider');
 - Add following JS files too
   - Swiper (https://swiperjs.com/)
-  - https://assets.undrr.org/testing/static/mangrove/latest/assets/js/swiper.js
+  - https://assets.undrr.org/static/mangrove/1.2.9/assets/js/swiper.js
 - Refer [this document](https://github.com/unisdr/undrr-mangrove/wiki/Swiper-documentation) for Swiper integration and options

--- a/stories/Documentation/GettingStarted.mdx
+++ b/stories/Documentation/GettingStarted.mdx
@@ -56,20 +56,20 @@ The fastest way to get started:
     <!-- Base styling -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
     />
     <!-- or choose a site specific theme -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-mcr.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-mcr.css"
     />
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-irp.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-irp.css"
     />
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-preventionweb.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
     />
   </head>
   <body>
@@ -132,6 +132,50 @@ npm install @undrr/undrr-mangrove
 
 # Yarn
 yarn add @undrr/undrr-mangrove
+```
+
+### Checking and updating to the latest version
+
+To check the current latest version available on npm:
+
+```bash
+npm view @undrr/undrr-mangrove version
+# or
+npm info @undrr/undrr-mangrove version
+```
+
+To install the latest version:
+
+```bash
+npm install @undrr/undrr-mangrove@latest
+```
+
+To update all dependencies to their latest semver-compatible versions:
+
+```bash
+npm outdated
+npm update
+```
+
+### Production CDN
+
+All assets are now served from versioned endpoints for stability:
+
+```
+https://assets.undrr.org/static/sitemap.html#mangrove-1-2-9
+https://assets.undrr.org/static/mangrove/README.md
+https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
+```
+
+#### Bleeding edge test repo
+
+```
+https://assets.undrr.org/testing/static/sitemap.html#mangrove-1-2-4
+https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css
+https://assets.undrr.org/testing/static/mangrove/1.2.5/css/style.css
+... etc
 ```
 
 ### Basic node usage

--- a/stories/Documentation/Intro.mdx
+++ b/stories/Documentation/Intro.mdx
@@ -85,12 +85,12 @@ Developers are encouraged to consume the project through the remotely available 
 <!-- UNDRR global style -->
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
 />
 <!-- or -->
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
 />
 ```
 

--- a/stories/Documentation/VanillaHtmlCss.mdx
+++ b/stories/Documentation/VanillaHtmlCss.mdx
@@ -38,11 +38,11 @@ Add these `<link>` tags to your HTML `<head>`:
     <!-- UNDRR Theme (Choose one) -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
     />
 
     <!-- Alternative: Prevention Web Theme -->
-    <!-- <link rel="stylesheet" href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-preventionweb.css"> -->
+    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"> -->
   </head>
   <body>
     <!-- Your content here -->
@@ -76,7 +76,7 @@ Choose the right CSS files for your project:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
 />
 ```
 
@@ -85,7 +85,7 @@ Choose the right CSS files for your project:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
 />
 ```
 
@@ -175,7 +175,7 @@ Some components work better with JavaScript. Include these for enhanced function
   import {
     mgTabs,
     mgTabsRuntime,
-  } from 'https://assets.undrr.org/testing/static/mangrove/latest/assets/js/tabs.js';
+  } from 'https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js';
 
   console.log('done');
   // Initialize tabs on page load

--- a/stories/Utilities/ShowMore/ShowMore.mdx
+++ b/stories/Utilities/ShowMore/ShowMore.mdx
@@ -84,7 +84,7 @@ Partly hide some text until the user clicks a button.
 
 #### JS:
 
-- https://assets.undrr.org/testing/static/mangrove/latest/assets/js/show-more.js
+- https://assets.undrr.org/static/mangrove/1.2.9/assets/js/show-more.js
 
 ### Changelog
 


### PR DESCRIPTION
- Replace bleeding-edge URLs with versioned endpoints across all docs
- Add automated version injection script
- Add user guidance for version checking and updates
- Remove references to "latest" and "testing" endpoints

Fixes #489
