### PR TITLE
feat: add error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ For CDN and static asset hosting in the [UNDRR Static assets repo](https://gitla
 All assets are now served from versioned endpoints for stability:
 
 ```
-https://assets.undrr.org/static/sitemap.html#mangrove-1-2-9
+https://assets.undrr.org/static/sitemap.html#mangrove-1-2-10
 https://assets.undrr.org/static/mangrove/README.md
 https://assets.undrr.org/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/static/mangrove/latest/components/MegaMenu.js

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ https://assets.undrr.org/static/mangrove/README.md
 https://assets.undrr.org/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/static/mangrove/latest/components/MegaMenu.js
 https://assets.undrr.org/static/mangrove/latest/assets/js/tabs.js
-https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
-https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.10/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/js/tabs.js
 ```
 
 #### Bleeding edge test repo

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -78,9 +78,9 @@ https://assets.undrr.org/testing/static/mangrove/README.md
 https://assets.undrr.org/testing/static/mangrove/latest/assets/css/style.css
 https://assets.undrr.org/testing/static/mangrove/latest/components/MegaMenu.js
 https://assets.undrr.org/testing/static/mangrove/latest/assets/js/tabs.js
-https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
-https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.10/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/js/tabs.js
 ```
 
 The workflow ensures that the `dist` branch always reflects the latest stable build from `main`, making it reliable for production CDN usage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@undrr/undrr-mangrove",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Mangrove design System for UNDRR",
   "main": "index.js",
   "scripts": {

--- a/scripts/update-cdn-version.js
+++ b/scripts/update-cdn-version.js
@@ -12,6 +12,64 @@ console.log(`Updating CDN links to use version ${version}...`);
 // Files to update with their patterns
 const filesToUpdate = [
   {
+    path: 'stories/Components/ErrorPages/ErrorPage.mdx',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/testing\/static\/mangrove\/latest\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      },
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      },
+    ]
+  },
+  {
+    path: 'stories/Components/ErrorPages/static/404.html',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/ErrorPages/static/403.html',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/ErrorPages/static/429.html',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/ErrorPages/static/503.html',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
+    path: 'stories/Components/ErrorPages/static/502.html',
+    patterns: [
+      {
+        from: /https:\/\/assets\.undrr\.org\/static\/mangrove\/[0-9]+\.[0-9]+\.[0-9]+\//g,
+        to: `https://assets.undrr.org/static/mangrove/${version}/`
+      }
+    ]
+  },
+  {
     path: 'README.md',
     patterns: [
       {

--- a/stories/Atom/Layout/Grid/Grid.mdx
+++ b/stories/Atom/Layout/Grid/Grid.mdx
@@ -41,7 +41,7 @@ Use the grid to create a layout of your choice based on the design you want to a
 
 Add the base layout style from
 
-- https://assets.undrr.org/static/mangrove/1.2.9/assets/css/grid.min.css
+- https://assets.undrr.org/static/mangrove/1.2.10/assets/css/grid.min.css
 
 ### Changelog
 

--- a/stories/Components/Accordion/Accordion.mdx
+++ b/stories/Components/Accordion/Accordion.mdx
@@ -81,8 +81,8 @@ Accordions make information processing and discovering more effective. However, 
 
 Add following CSS in your project
 
-- [Base layouting CSS](https://assets.undrr.org/static/mangrove/1.2.9/assets/css/foundation.min.css).
-- [Copy and add this component CSS in your project](https://assets.undrr.org/static/mangrove/1.2.9/assets/css/components/accordion.min.css).
+- [Base layouting CSS](https://assets.undrr.org/static/mangrove/1.2.10/assets/css/foundation.min.css).
+- [Copy and add this component CSS in your project](https://assets.undrr.org/static/mangrove/1.2.10/assets/css/components/accordion.min.css).
 
 #### JS
 

--- a/stories/Components/ErrorPages/ErrorPage.jsx
+++ b/stories/Components/ErrorPages/ErrorPage.jsx
@@ -1,92 +1,5 @@
 import React from 'react';
-
-const DEFAULT_COPY = {
-  401: {
-    title: 'You are not signed in',
-    description:
-      'This page requires you to be signed in. If you think you should have access, sign in and try again.',
-    primary: { label: 'Go to home', href: '/' },
-    secondary: {
-      label: 'Contact support',
-      href: 'https://www.undrr.org/contact-us',
-    },
-  },
-  403: {
-    title: 'You do not have permission to view this page',
-    description:
-      'Your account does not have access to this content.',
-    primary: { label: 'Go to home', href: '/' },
-    secondary: {
-      label: 'Contact support',
-      href: 'https://www.undrr.org/contact-us',
-    },
-  },
-  404: {
-    title: 'We cannot find that page',
-    description:
-      'The page may have moved or no longer exists. Check the URL or use search to find what you need.',
-    primary: { label: 'Go to home', href: '/' },
-    secondary: { label: 'Browse directory', href: 'https://www.undrr.org/undrr-directory' },
-  },
-  429: {
-    title: 'Too many requests',
-    description:
-      'You have made too many requests in a short time. Wait a moment and try again.',
-    primary: {
-      label: 'Try again',
-      href: '',
-      action: () => window.location.reload(),
-    },
-    secondary: { label: 'Go to home', href: '/' },
-  },
-  500: {
-    title: 'Something went wrong on our side',
-    description:
-      'We could not complete your request. Try again in a few minutes. If the problem continues, contact us.',
-    primary: {
-      label: 'Try again',
-      href: '',
-      action: () => window.location.reload(),
-    },
-    secondary: {
-      label: 'Contact support',
-      href: 'https://www.undrr.org/contact-us',
-    },
-  },
-  502: {
-    title: 'Bad gateway',
-    description:
-      'There was a temporary problem connecting to the service. Try again in a moment.',
-    primary: {
-      label: 'Try again',
-      href: '',
-      action: () => window.location.reload(),
-    },
-    secondary: { label: 'Go to home', href: '/' },
-  },
-  503: {
-    title: 'Service unavailable',
-    description:
-      'The site is temporarily unavailable due to maintenance or high load. Please try again later.',
-    primary: {
-      label: 'Try again',
-      href: '',
-      action: () => window.location.reload(),
-    },
-    secondary: { label: 'Status page', href: '/status' },
-  },
-  504: {
-    title: 'Gateway timeout',
-    description:
-      'The service took too long to respond. Refresh the page or try again later.',
-    primary: {
-      label: 'Try again',
-      href: '',
-      action: () => window.location.reload(),
-    },
-    secondary: { label: 'Go to home', href: '/' },
-  },
-};
+import { DEFAULT_COPY } from './ErrorPagesContent.js';
 
 function renderAction(action) {
   if (!action) return null;
@@ -136,6 +49,8 @@ export function ErrorPage({
   const resolvedDescription = description || defaults.description;
   const resolvedPrimary = primaryAction || defaults.primary;
   const resolvedSecondary = secondaryAction || defaults.secondary;
+  const resolvedActionsHtml = actionsHtml ?? defaults.actionsHtml;
+  const resolvedDetails = details ?? defaults.details;
 
   return (
     <main className="mg-error-page" {...props}>
@@ -158,11 +73,15 @@ export function ErrorPage({
 
           <h1>{`Error ${code}`}</h1>
           <h2>{resolvedTitle}</h2>
-          <p>{resolvedDescription}</p>
-          {(actionsHtml || actionsContent) && (
+          {typeof resolvedDescription === 'string' ? (
+            <p dangerouslySetInnerHTML={{ __html: resolvedDescription }} />
+          ) : (
+            <p>{resolvedDescription}</p>
+          )}
+          {(resolvedActionsHtml || actionsContent) && (
             <div className="mg-error-page__actions">
-              {actionsHtml && (
-                <div dangerouslySetInnerHTML={{ __html: actionsHtml }} />
+              {resolvedActionsHtml && (
+                <div dangerouslySetInnerHTML={{ __html: resolvedActionsHtml }} />
               )}
               {actionsContent}
             </div>
@@ -181,8 +100,8 @@ export function ErrorPage({
             </div>
           )}
 
-          {details && (
-            <pre role="note" aria-label="error details"><code className="mg-code--block">{details}</code></pre>
+          {resolvedDetails && (
+            <pre role="note" aria-label="error details"><code className="mg-code--block">{resolvedDetails}</code></pre>
           )}
 
           {showSearch && (

--- a/stories/Components/ErrorPages/ErrorPage.jsx
+++ b/stories/Components/ErrorPages/ErrorPage.jsx
@@ -1,0 +1,221 @@
+import React from 'react';
+
+const DEFAULT_COPY = {
+  401: {
+    title: 'You are not signed in',
+    description:
+      'This page requires you to be signed in. If you think you should have access, sign in and try again.',
+    primary: { label: 'Go to home', href: '/' },
+    secondary: {
+      label: 'Contact support',
+      href: 'https://www.undrr.org/contact-us',
+    },
+  },
+  403: {
+    title: 'You do not have permission to view this page',
+    description:
+      'Your account does not have access to this content.',
+    primary: { label: 'Go to home', href: '/' },
+    secondary: {
+      label: 'Contact support',
+      href: 'https://www.undrr.org/contact-us',
+    },
+  },
+  404: {
+    title: 'We cannot find that page',
+    description:
+      'The page may have moved or no longer exists. Check the URL or use search to find what you need.',
+    primary: { label: 'Go to home', href: '/' },
+    secondary: { label: 'Browse directory', href: 'https://www.undrr.org/undrr-directory' },
+  },
+  429: {
+    title: 'Too many requests',
+    description:
+      'You have made too many requests in a short time. Wait a moment and try again.',
+    primary: {
+      label: 'Try again',
+      href: '',
+      action: () => window.location.reload(),
+    },
+    secondary: { label: 'Go to home', href: '/' },
+  },
+  500: {
+    title: 'Something went wrong on our side',
+    description:
+      'We could not complete your request. Try again in a few minutes. If the problem continues, contact us.',
+    primary: {
+      label: 'Try again',
+      href: '',
+      action: () => window.location.reload(),
+    },
+    secondary: {
+      label: 'Contact support',
+      href: 'https://www.undrr.org/contact-us',
+    },
+  },
+  502: {
+    title: 'Bad gateway',
+    description:
+      'There was a temporary problem connecting to the service. Try again in a moment.',
+    primary: {
+      label: 'Try again',
+      href: '',
+      action: () => window.location.reload(),
+    },
+    secondary: { label: 'Go to home', href: '/' },
+  },
+  503: {
+    title: 'Service unavailable',
+    description:
+      'The site is temporarily unavailable due to maintenance or high load. Please try again later.',
+    primary: {
+      label: 'Try again',
+      href: '',
+      action: () => window.location.reload(),
+    },
+    secondary: { label: 'Status page', href: '/status' },
+  },
+  504: {
+    title: 'Gateway timeout',
+    description:
+      'The service took too long to respond. Refresh the page or try again later.',
+    primary: {
+      label: 'Try again',
+      href: '',
+      action: () => window.location.reload(),
+    },
+    secondary: { label: 'Go to home', href: '/' },
+  },
+};
+
+function renderAction(action) {
+  if (!action) return null;
+  const { label, href, action: onClick } = action;
+  const commonProps = {
+    className: 'mg-button mg-button-primary',
+  };
+  if (onClick && !href) {
+    return (
+      <button type="button" onClick={onClick} {...commonProps}>
+        {label}
+      </button>
+    );
+  }
+  return (
+    <a href={href} className={commonProps.className}>
+      {label}
+    </a>
+  );
+}
+
+/**
+ * ErrorPage component: standardized UX for common HTTP error states.
+ * - Uses sentence case headings and calm, actionable guidance per writing standards
+ * - Provides sensible default copy for common error codes
+ * - Allows override of title, description, and actions
+ */
+export function ErrorPage({
+  code = 404,
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+  showSearch = false,
+  searchAction = '/search',
+  contactUrl = 'https://www.undrr.org/contact-us',
+  showBrandHeader = true,
+  showButtons = false,
+  actionsHtml,
+  actionsContent,
+  details,
+  ...props
+}) {
+  const defaults = DEFAULT_COPY[code] || DEFAULT_COPY[404];
+
+  const resolvedTitle = title || defaults.title;
+  const resolvedDescription = description || defaults.description;
+  const resolvedPrimary = primaryAction || defaults.primary;
+  const resolvedSecondary = secondaryAction || defaults.secondary;
+
+  return (
+    <main className="mg-error-page" {...props}>
+      {showBrandHeader && (
+        <>
+          <div className="mg-page-header__decoration" aria-hidden="true">
+            <div />
+            <div />
+            <div />
+            <div />
+          </div>
+        </>
+      )}
+      <div className="mg-error-page__container mg-container--spacer">
+        {!showBrandHeader && (
+          <p className="mg-error-page__code" aria-hidden="true">
+            {code}
+          </p>
+        )}
+
+          <h1>{`Error ${code}`}</h1>
+          <h2>{resolvedTitle}</h2>
+          <p>{resolvedDescription}</p>
+          {(actionsHtml || actionsContent) && (
+            <div className="mg-error-page__actions">
+              {actionsHtml && (
+                <div dangerouslySetInnerHTML={{ __html: actionsHtml }} />
+              )}
+              {actionsContent}
+            </div>
+          )}
+          {showButtons && (
+            <div className="mg-error-page__actions">
+              {resolvedPrimary && renderAction(resolvedPrimary)}
+              {resolvedSecondary && (
+                <a
+                  className="mg-button mg-button-secondary"
+                  href={resolvedSecondary.href}
+                >
+                  {resolvedSecondary.label}
+                </a>
+              )}
+            </div>
+          )}
+
+          {details && (
+            <pre role="note" aria-label="error details"><code className="mg-code--block">{details}</code></pre>
+          )}
+
+          {showSearch && (
+            <form
+              className="mg-error-page__search"
+              action={searchAction}
+              role="search"
+            >
+              <label className="mg-u-sr-only" htmlFor="error-search">
+                Search
+              </label>
+              <input
+                id="error-search"
+                name="q"
+                type="search"
+                placeholder="Search"
+              />
+              <button type="submit" className="mg-button mg-button-primary">
+                Search
+              </button>
+            </form>
+          )}
+          <p>
+            If you think this is in error or need help, <a href={contactUrl}>please contact us</a> and provide a link to the page.
+          </p>
+          <hr />
+          <small>This website is operated by</small>
+          <a href="https://www.undrr.org/">
+            <div className="undrr-logo" aria-hidden="true" />
+          </a>
+        </div>
+    </main>
+  );
+}
+
+export default ErrorPage;

--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -1,0 +1,77 @@
+import { Meta, Canvas } from '@storybook/blocks';
+import * as Stories from './ErrorPage.stories.jsx';
+
+<Meta of={Stories} title="Components/Error pages" />
+
+# Standard error pages
+
+Consistent error pages improve clarity and reduce friction when things go wrong. Use the `ErrorPage` component to display common HTTP error states with clear guidance and next steps.
+
+The error pages and guidance shown here are recommendations. When implementing in your own platform or application, adapt the links (such as "Go to home", "Contact support", or "Status page") to match your actual URLs and support channels.
+
+For static error pages (e.g., for CDN or upstream error handling), it is important to:
+
+- **Include analytics code** (such as Google Analytics enhancements) to track error events and user behavior.
+- **Include critical messaging JavaScript** (such as UNDRR messaging) to ensure users receive important updates or alerts, even on error pages.
+
+See the static HTML examples for reference on including these scripts.
+
+## When to use
+
+- Show a user‑friendly page for common error codes (404, 403, 429, 500, 502, 503, 504)
+- Provide calm, actionable messages that explain what happened and what to do next
+- Keep headings in sentence case and preserve proper nouns, following our writing guidelines
+
+## Formatting
+
+### 404 not found
+
+<Canvas of={Stories.NotFound404} />
+
+### 403 forbidden
+
+<Canvas of={Stories.Forbidden403} />
+
+### 429 too many requests
+
+<Canvas of={Stories.TooManyRequests429} />
+
+### 503 service unavailable
+
+<Canvas of={Stories.ServiceUnavailable503} />
+
+### 500 internal server error
+
+<Canvas of={Stories.InternalServerError500} />
+
+## Content
+
+- Keep the title short and specific to the state
+- Explain the situation briefly; avoid blame and technical jargon
+- Offer 1–2 clear actions: try again, go home, contact support, or search
+
+## CSS and JS references
+
+- CSS: included in the global component bundle via `stories/assets/scss/_components.scss`
+- JS: not required. Optional actions use simple links or reloads
+
+## CDN links
+
+Use these static HTML pages directly from the CDN when integrating with CDNs or upstream error handlers:
+
+```text
+https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/403.html
+https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/404.html
+https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/429.html
+https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/502.html
+https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/503.html
+```
+
+## Interactions
+
+- Primary action uses the solid button style; secondary action uses the outlined style
+- Optional search field helps users recover from 404 states
+
+## Changelog
+
+- 1.3.0 — Added standard error pages component and examples

--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -74,4 +74,4 @@ https://assets.undrr.org/static/mangrove/1.2.10/assets/error-pages/503.html
 
 ## Changelog
 
-- 1.3.0 — Added standard error pages component and examples
+- 1.0.0 — Added standard error pages component and examples

--- a/stories/Components/ErrorPages/ErrorPage.stories.jsx
+++ b/stories/Components/ErrorPages/ErrorPage.stories.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ErrorPage from './ErrorPage.jsx';
+
+export default {
+  title: 'Components/Error pages/ErrorPage',
+  component: ErrorPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    code: {
+      control: { type: 'select' },
+      options: [401, 403, 404, 429, 500, 502, 503, 504],
+    },
+    showSearch: { control: 'boolean' },
+  },
+};
+
+const Template = args => <ErrorPage {...args} />;
+
+export const NotFound404 = Template.bind({});
+NotFound404.args = { code: 404, showSearch: true };
+
+export const Forbidden403 = Template.bind({});
+Forbidden403.args = { code: 403 };
+
+export const TooManyRequests429 = Template.bind({});
+TooManyRequests429.args = { code: 429 };
+
+export const ServiceUnavailable503 = Template.bind({});
+ServiceUnavailable503.args = {
+  code: 503,
+  actionsHtml:
+    'If this continues, please check the <a href="https://messaging.undrr.org/">UNDRR status page</a>.',
+  details:
+    'Error code: 503 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
+};
+
+export const InternalServerError500 = Template.bind({});
+InternalServerError500.args = {
+  code: 500,
+  details:
+    'Error code: 500 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
+};

--- a/stories/Components/ErrorPages/ErrorPage.stories.jsx
+++ b/stories/Components/ErrorPages/ErrorPage.stories.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ErrorPage from './ErrorPage.jsx';
+import { DEFAULT_COPY } from './ErrorPagesContent.js';
 
 export default {
-  title: 'Components/Error pages/ErrorPage',
+  title: 'Components/Error pages',
   component: ErrorPage,
   parameters: {
     layout: 'fullscreen',
@@ -10,7 +11,7 @@ export default {
   argTypes: {
     code: {
       control: { type: 'select' },
-      options: [401, 403, 404, 429, 500, 502, 503, 504],
+      options: Object.keys(DEFAULT_COPY).map(Number),
     },
     showSearch: { control: 'boolean' },
   },
@@ -28,17 +29,7 @@ export const TooManyRequests429 = Template.bind({});
 TooManyRequests429.args = { code: 429 };
 
 export const ServiceUnavailable503 = Template.bind({});
-ServiceUnavailable503.args = {
-  code: 503,
-  actionsHtml:
-    'If this continues, please check the <a href="https://messaging.undrr.org/">UNDRR status page</a>.',
-  details:
-    'Error code: 503 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
-};
+ServiceUnavailable503.args = { code: 503 };
 
 export const InternalServerError500 = Template.bind({});
-InternalServerError500.args = {
-  code: 500,
-  details:
-    'Error code: 500 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
-};
+InternalServerError500.args = { code: 500 };

--- a/stories/Components/ErrorPages/ErrorPagesContent.js
+++ b/stories/Components/ErrorPages/ErrorPagesContent.js
@@ -1,0 +1,49 @@
+export const DEFAULT_COPY = {
+  401: {
+    title: 'You are not signed in',
+    description:
+      'This page requires you to be signed in. If you think you should have access, sign in and try again.',
+  },
+  403: {
+    title: 'You do not have permission to view this page',
+    description: 'Your account does not have access to this content.',
+  },
+  404: {
+    title: 'We cannot find the page you are looking for',
+    description:
+      'If you entered a web address, check it is correct. If you followed a link, it may be incorrect. <br /> You can also <a href="/">view the homepage</a>, browse the <a href="https://www.undrr.org/undrr-directory">UNDRR directory</a>, or try searching:',
+  },
+  429: {
+    title: 'Too many requests',
+    description:
+      'You have made too many requests in a short time. Wait a moment and try again.',
+  },
+  500: {
+    title: 'Something went wrong on our side',
+    description:
+      'We could not complete your request. Try again in a few minutes. If the problem continues, contact us.',
+    details:
+      'Error code: 500 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
+  },
+  502: {
+    title: 'Bad gateway',
+    description:
+      'There was a temporary problem connecting to the service. Try again in a moment.',
+  },
+  503: {
+    title: 'We are temporarily unavailable',
+    description:
+      'The site is temporarily unavailable due to maintenance or high load. Please try again later.',
+    actionsHtml:
+      'If this continues, please check the <a href="https://messaging.undrr.org/">UNDRR status page</a>.',
+    details:
+      'Error code: 503 Service Unavailable\nRequest ID: abc123-example\nError URL: https://example.org/varnish-error/503',
+  },
+  504: {
+    title: 'Gateway timeout',
+    description:
+      'The service took too long to respond. Refresh the page or try again later.',
+  },
+};
+
+

--- a/stories/Components/ErrorPages/error-pages.scss
+++ b/stories/Components/ErrorPages/error-pages.scss
@@ -4,6 +4,13 @@
   color: $mg-color-text;
   padding-bottom: 2rem;
 
+  h1 {
+    color: $mg-color-blue-900;
+    font-size: 1.4rem;
+    padding: 0;
+    margin: 0;
+  }
+
   &__search {
     display: flex;
     gap: 0.5rem;
@@ -21,13 +28,6 @@
     padding: 2rem 1.5rem 1rem;
     max-width: 900px;
     margin: 2rem auto;
-
-    h1 {
-      color: $mg-color-blue-900;
-      font-size: 1.4rem;
-      padding: 0;
-      margin: 0;
-    }
   }
 
   .undrr-logo {

--- a/stories/Components/ErrorPages/error-pages.scss
+++ b/stories/Components/ErrorPages/error-pages.scss
@@ -1,0 +1,41 @@
+.mg-error-page {
+  min-height: 100vh;
+  background-color: $mg-color-blue-900;
+  color: $mg-color-text;
+  padding-bottom: 2rem;
+
+  &__search {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+    align-items: center;
+
+    input[type="search"] {
+      border: 1px solid $mg-color-neutral-100;
+      max-width: 300px;
+    }
+  }
+
+  &__container {
+    background: $mg-color-neutral-0;
+    padding: 2rem 1.5rem 1rem;
+    max-width: 900px;
+    margin: 2rem auto;
+
+    h1 {
+      color: $mg-color-blue-900;
+      font-size: 1.4rem;
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  .undrr-logo {
+    background: url(https://assets.undrr.org/static/logos/undrr/undrr-logo-blue.svg)
+      no-repeat;
+    background-size: contain;
+    width: 280px;
+    height: 50px;
+    margin: 1rem 0;
+  }
+}

--- a/stories/Components/ErrorPages/static/403.html
+++ b/stories/Components/ErrorPages/static/403.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Access denied</title>
+    <title>403: Access denied</title>
     <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
   </head>
   <body>
@@ -14,19 +14,18 @@
         <div></div>
         <div></div>
       </div>
-      <div class="undrr-logo" aria-hidden="true"></div>
-      <div class="mg-error-page__container">
-        <div class="undrr-error--inner-content">
-          <h1>Error 403</h1>
-          <h2 class="mg-error-page__title">You do not have permission to view this page</h2>
-          <p class="mg-error-page__description">
-            Your account does not have access to this content. If this is unexpected, contact the site team.
-          </p>
-          <div class="mg-error-page__actions">
-            Go back to the <a href="/">home page</a> or
-            <a href="https://www.undrr.org/contact-us">contact support</a>.
-          </div>
-        </div>
+      <div class="mg-error-page__container mg-container--spacer">
+        <h1>Error 403</h1>
+        <h2>You do not have permission to view this page</h2>
+        <p>Your account does not have access to this content.</p>
+        <p>
+          If you think this is in error or need help,
+          <a href="https://www.undrr.org/contact-us">please contact us</a>
+          and provide a link to the page.
+        </p>
+        <hr />
+        <small>This website is operated by</small>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/stories/Components/ErrorPages/static/403.html
+++ b/stories/Components/ErrorPages/static/403.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Access denied</title>
+    <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
+  </head>
+  <body>
+    <main class="mg-error-page">
+      <div class="mg-page-header__decoration" aria-hidden="true">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div class="undrr-logo" aria-hidden="true"></div>
+      <div class="mg-error-page__container">
+        <div class="undrr-error--inner-content">
+          <h1>Error 403</h1>
+          <h2 class="mg-error-page__title">You do not have permission to view this page</h2>
+          <p class="mg-error-page__description">
+            Your account does not have access to this content. If this is unexpected, contact the site team.
+          </p>
+          <div class="mg-error-page__actions">
+            Go back to the <a href="/">home page</a> or
+            <a href="https://www.undrr.org/contact-us">contact support</a>.
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
+  </body>
+</html>

--- a/stories/Components/ErrorPages/static/404.html
+++ b/stories/Components/ErrorPages/static/404.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Page not found</title>
+    <title>404: Page not found</title>
     <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
   </head>
   <body>
@@ -14,26 +14,23 @@
         <div></div>
         <div></div>
       </div>
-      <div class="undrr-logo" aria-hidden="true"></div>
-      <div class="mg-error-page__container">
-        <div class="undrr-error--inner-content">
-          <h1>Error 404</h1>
-          <h2 class="mg-error-page__title">We cannot find that page</h2>
-          <p class="mg-error-page__description">
-            The page may have moved or no longer exists. Check the URL or use search to find what you need.
-          </p>
-          <div class="mg-error-page__actions">
-            You can return to the <a href="/">home page</a> or browse our
-            <a href="https://www.undrr.org/undrr-directory">directory</a>.
-          </div>
-          <form class="mg-error-page__search" action="/search" role="search">
-            <label class="mg-u-sr-only" for="error-search">Search</label>
-            <input id="error-search" name="q" type="search" placeholder="Search" />
-            <button type="submit" class="mg-button mg-button--secondary">Search</button>
-          </form>
-          <hr />
-          <p class="mg-error-page__contact">Need help? <a href="/contact">Contact us</a>.</p>
-        </div>
+      <div class="mg-error-page__container mg-container--spacer">
+        <h1>Error 404</h1>
+        <h2>We cannot find the page you are looking for</h2>
+        <p>
+          If you entered a web address, check it is correct. If you followed a link, it may be incorrect.
+          <br />
+          You can also <a href="/">view the homepage</a>, browse the
+          <a href="https://www.undrr.org/undrr-directory">UNDRR directory</a>, or try searching:
+        </p>
+        <form class="mg-error-page__search" action="/search" role="search">
+          <label class="mg-u-sr-only" for="error-search">Search</label>
+          <input id="error-search" name="q" type="search" placeholder="Search" />
+          <button type="submit" class="mg-button mg-button-primary">Search</button>
+        </form>
+        <hr />
+        <small>This website is operated by</small>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/stories/Components/ErrorPages/static/404.html
+++ b/stories/Components/ErrorPages/static/404.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page not found</title>
+    <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
+  </head>
+  <body>
+    <main class="mg-error-page">
+      <div class="mg-page-header__decoration" aria-hidden="true">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div class="undrr-logo" aria-hidden="true"></div>
+      <div class="mg-error-page__container">
+        <div class="undrr-error--inner-content">
+          <h1>Error 404</h1>
+          <h2 class="mg-error-page__title">We cannot find that page</h2>
+          <p class="mg-error-page__description">
+            The page may have moved or no longer exists. Check the URL or use search to find what you need.
+          </p>
+          <div class="mg-error-page__actions">
+            You can return to the <a href="/">home page</a> or browse our
+            <a href="https://www.undrr.org/undrr-directory">directory</a>.
+          </div>
+          <form class="mg-error-page__search" action="/search" role="search">
+            <label class="mg-u-sr-only" for="error-search">Search</label>
+            <input id="error-search" name="q" type="search" placeholder="Search" />
+            <button type="submit" class="mg-button mg-button--secondary">Search</button>
+          </form>
+          <hr />
+          <p class="mg-error-page__contact">Need help? <a href="/contact">Contact us</a>.</p>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
+  </body>
+</html>

--- a/stories/Components/ErrorPages/static/429.html
+++ b/stories/Components/ErrorPages/static/429.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Too many requests</title>
+    <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
+    <script>
+      function retry() { window.location.reload(); }
+    </script>
+  </head>
+  <body>
+    <main class="mg-error-page">
+      <div class="mg-page-header__decoration" aria-hidden="true">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div class="undrr-logo" aria-hidden="true"></div>
+      <div class="mg-error-page__container">
+        <div class="undrr-error--inner-content">
+          <h1>Error 429</h1>
+          <h2 class="mg-error-page__title">Too many requests</h2>
+          <p class="mg-error-page__description">
+            You have made too many requests in a short time. Wait a moment and try again.
+          </p>
+          <div class="mg-error-page__actions">
+            Wait a moment and <a href="#" onclick="retry();return false;">try again</a>,
+            or return to the <a href="/">home page</a>.
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
+  </body>
+</html>

--- a/stories/Components/ErrorPages/static/429.html
+++ b/stories/Components/ErrorPages/static/429.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Too many requests</title>
+    <title>429: Too many requests</title>
     <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
     <script>
       function retry() { window.location.reload(); }
@@ -17,19 +17,17 @@
         <div></div>
         <div></div>
       </div>
-      <div class="undrr-logo" aria-hidden="true"></div>
-      <div class="mg-error-page__container">
-        <div class="undrr-error--inner-content">
-          <h1>Error 429</h1>
-          <h2 class="mg-error-page__title">Too many requests</h2>
-          <p class="mg-error-page__description">
-            You have made too many requests in a short time. Wait a moment and try again.
-          </p>
-          <div class="mg-error-page__actions">
-            Wait a moment and <a href="#" onclick="retry();return false;">try again</a>,
-            or return to the <a href="/">home page</a>.
-          </div>
+      <div class="mg-error-page__container mg-container--spacer">
+        <h1>Error 429</h1>
+        <h2>Too many requests</h2>
+        <p>You have made too many requests in a short time. Wait a moment and try again.</p>
+        <div class="mg-error-page__actions">
+          <button type="button" class="mg-button mg-button-primary" onclick="retry();return false;">Try again</button>
+          <a class="mg-button mg-button-secondary" href="/">Go to home</a>
         </div>
+        <hr />
+        <small>This website is operated by</small>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/stories/Components/ErrorPages/static/502.html
+++ b/stories/Components/ErrorPages/static/502.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Bad gateway</title>
+    <title>502: Bad gateway</title>
     <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
     <script>
       function retry() { window.location.reload(); }
@@ -17,20 +17,17 @@
         <div></div>
         <div></div>
       </div>
-      <div class="undrr-logo" aria-hidden="true"></div>
-      <div class="mg-error-page__container">
-        <div class="undrr-error--inner-content">
-          <h1>Error 502</h1>
-          <h2 class="mg-error-page__title">Bad gateway</h2>
-          <p class="mg-error-page__description">
-            There was a temporary problem connecting to the service. Try again in a moment.
-          </p>
-          <div class="mg-error-page__actions">
-            There was a temporary problem. Please
-            <a href="#" onclick="retry();return false;">try again</a>, or go back to the
-            <a href="/">home page</a>.
-          </div>
+      <div class="mg-error-page__container mg-container--spacer">
+        <h1>Error 502</h1>
+        <h2>Bad gateway</h2>
+        <p>There was a temporary problem connecting to the service. Try again in a moment.</p>
+        <div class="mg-error-page__actions">
+          <button type="button" class="mg-button mg-button-primary" onclick="retry();return false;">Try again</button>
+          <a class="mg-button mg-button-secondary" href="/">Go to home</a>
         </div>
+        <hr />
+        <small>This website is operated by</small>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/stories/Components/ErrorPages/static/502.html
+++ b/stories/Components/ErrorPages/static/502.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bad gateway</title>
+    <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
+    <script>
+      function retry() { window.location.reload(); }
+    </script>
+  </head>
+  <body>
+    <main class="mg-error-page">
+      <div class="mg-page-header__decoration" aria-hidden="true">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div class="undrr-logo" aria-hidden="true"></div>
+      <div class="mg-error-page__container">
+        <div class="undrr-error--inner-content">
+          <h1>Error 502</h1>
+          <h2 class="mg-error-page__title">Bad gateway</h2>
+          <p class="mg-error-page__description">
+            There was a temporary problem connecting to the service. Try again in a moment.
+          </p>
+          <div class="mg-error-page__actions">
+            There was a temporary problem. Please
+            <a href="#" onclick="retry();return false;">try again</a>, or go back to the
+            <a href="/">home page</a>.
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
+  </body>
+</html>

--- a/stories/Components/ErrorPages/static/503.html
+++ b/stories/Components/ErrorPages/static/503.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Service unavailable</title>
+    <title>503: This service may be temporarily unavailable</title>
     <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
     <script>
       function retry() { window.location.reload(); }
@@ -17,28 +17,23 @@
         <div></div>
         <div></div>
       </div>
-      <div class="undrr-logo" aria-hidden="true"></div>
-      <div class="mg-error-page__container">
-        <div class="undrr-error--inner-content">
-          <h1>Error 503</h1>
-          <h2 class="mg-error-page__title">Service unavailable</h2>
-          <p class="mg-error-page__description">
-            The site is temporarily unavailable due to maintenance or high load. Please try again later.
-          </p>
-          <div class="mg-error-page__actions">
-            Please <a href="#" onclick="retry();return false;">try again</a> in a moment, or check our
-            <a href="/status">status page</a>.
-          </div>
-          <div class="mg-error-page__details" role="note" aria-label="error details">
-            <pre><code>Error code: 503 Service Unavailable
-Error URL: https://undrr.ddev.site/varnish-error/503</code></pre>
-          </div>
+      <div class="mg-error-page__container mg-container--spacer">
+        <h1>Error 503</h1>
+        <h2>This service may be temporarily unavailable</h2>
+        <p>The site is temporarily unavailable due to maintenance or high load. Please try again later.</p>
+        <div class="mg-error-page__actions">
+          <button type="button" class="mg-button mg-button-primary" onclick="retry();return false;">Try again</button>
+          <a class="mg-button mg-button-secondary" href="/status">Status page</a>
         </div>
+        <div role="note" aria-label="error details"><pre><code>Error code: 503 Service Unavailable
+Request ID: abc123-example
+Error URL: https://example.org/varnish-error/503</code></pre></div>
+        <hr />
+        <small>This website is operated by</small>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
   </body>
-  </html>
-
-
+</html>

--- a/stories/Components/ErrorPages/static/503.html
+++ b/stories/Components/ErrorPages/static/503.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Service unavailable</title>
+    <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css" />
+    <script>
+      function retry() { window.location.reload(); }
+    </script>
+  </head>
+  <body>
+    <main class="mg-error-page">
+      <div class="mg-page-header__decoration" aria-hidden="true">
+        <div></div>
+        <div></div>
+        <div></div>
+        <div></div>
+      </div>
+      <div class="undrr-logo" aria-hidden="true"></div>
+      <div class="mg-error-page__container">
+        <div class="undrr-error--inner-content">
+          <h1>Error 503</h1>
+          <h2 class="mg-error-page__title">Service unavailable</h2>
+          <p class="mg-error-page__description">
+            The site is temporarily unavailable due to maintenance or high load. Please try again later.
+          </p>
+          <div class="mg-error-page__actions">
+            Please <a href="#" onclick="retry();return false;">try again</a> in a moment, or check our
+            <a href="/status">status page</a>.
+          </div>
+          <div class="mg-error-page__details" role="note" aria-label="error details">
+            <pre><code>Error code: 503 Service Unavailable
+Error URL: https://undrr.ddev.site/varnish-error/503</code></pre>
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://messaging.undrr.org/src/undrr-messaging.js" defer></script>
+  </body>
+  </html>
+
+

--- a/stories/Components/Forms/InputFields/input-fields.scss
+++ b/stories/Components/Forms/InputFields/input-fields.scss
@@ -65,7 +65,6 @@ textarea {
 
   input[type="date"],
   input[type="search"] {
-    padding-left: $mg-spacing-200;
     position: relative;
   }
 
@@ -90,24 +89,8 @@ input[type="date"] {
   //   bottom 12px;
   background-color: $mg-color-white;
   color: $mg-color-neutral-500;
-  padding-left: $mg-spacing-200;
-
-  // &.disabled {
-  //   background-image: url(#{$img-path-Icon}/date-disabled.svg);
-  // }
 }
 
-input[type="search"] {
-  // background:
-  //   url(#{$img-path-Icon}/search-black.svg) no-repeat left 14px bottom
-  //   12px;
-  color: #a9b1b7;
-  padding-left: 2.5rem;
-
-  // &.disabled {
-  //   background-image: url(#{$img-path-Icon}/search-gray.svg);
-  // }
-}
 
 .help {
   &.disabled {

--- a/stories/Components/LanguageSwitcher/LanguageSwitcher.mdx
+++ b/stories/Components/LanguageSwitcher/LanguageSwitcher.mdx
@@ -131,7 +131,7 @@ There are two states: Default and Open.
 
 #### JS:
 
-- https://assets.undrr.org/static/mangrove/1.2.9/assets/js/lang-switcher.js
+- https://assets.undrr.org/static/mangrove/1.2.10/assets/js/lang-switcher.js
 
 ### Interactions
 

--- a/stories/Components/StatsCardSlider/StatsCardSlider.mdx
+++ b/stories/Components/StatsCardSlider/StatsCardSlider.mdx
@@ -206,5 +206,5 @@ This is collection of [Stats card](/docs/components-ui-components-cards-stats-ca
   - swiper('.stats-slider');
 - Add following JS files too
   - Swiper (https://swiperjs.com/)
-  - https://assets.undrr.org/static/mangrove/1.2.9/assets/js/swiper.js
+  - https://assets.undrr.org/static/mangrove/1.2.10/assets/js/swiper.js
 - Refer [this document](https://github.com/unisdr/undrr-mangrove/wiki/Swiper-documentation) for Swiper integration and options

--- a/stories/Documentation/GettingStarted.mdx
+++ b/stories/Documentation/GettingStarted.mdx
@@ -56,20 +56,20 @@ The fastest way to get started:
     <!-- Base styling -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css"
     />
     <!-- or choose a site specific theme -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-mcr.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-mcr.css"
     />
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-irp.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-irp.css"
     />
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-preventionweb.css"
     />
   </head>
   <body>
@@ -164,9 +164,9 @@ All assets are now served from versioned endpoints for stability:
 ```
 https://assets.undrr.org/static/sitemap.html#mangrove-1-2-9
 https://assets.undrr.org/static/mangrove/README.md
-https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css
-https://assets.undrr.org/static/mangrove/1.2.9/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css
+https://assets.undrr.org/static/mangrove/1.2.10/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.2.10/assets/js/tabs.js
 ```
 
 #### Bleeding edge test repo

--- a/stories/Documentation/Intro.mdx
+++ b/stories/Documentation/Intro.mdx
@@ -127,12 +127,12 @@ Developers are encouraged to consume the project through the remotely available 
 <!-- UNDRR global style -->
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css"
 />
 <!-- or -->
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-preventionweb.css"
 />
 ```
 

--- a/stories/Documentation/VanillaHtmlCss.mdx
+++ b/stories/Documentation/VanillaHtmlCss.mdx
@@ -38,11 +38,11 @@ Add these `<link>` tags to your HTML `<head>`:
     <!-- UNDRR Theme (Choose one) -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css"
     />
 
     <!-- Alternative: Prevention Web Theme -->
-    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"> -->
+    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-preventionweb.css"> -->
   </head>
   <body>
     <!-- Your content here -->
@@ -76,7 +76,7 @@ Choose the right CSS files for your project:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style.css"
 />
 ```
 
@@ -85,7 +85,7 @@ Choose the right CSS files for your project:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.2.9/assets/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.2.10/assets/css/style-preventionweb.css"
 />
 ```
 
@@ -175,7 +175,7 @@ Some components work better with JavaScript. Include these for enhanced function
   import {
     mgTabs,
     mgTabsRuntime,
-  } from 'https://assets.undrr.org/static/mangrove/1.2.9/assets/js/tabs.js';
+  } from 'https://assets.undrr.org/static/mangrove/1.2.10/assets/js/tabs.js';
 
   console.log('done');
   // Initialize tabs on page load

--- a/stories/Utilities/ShowMore/ShowMore.mdx
+++ b/stories/Utilities/ShowMore/ShowMore.mdx
@@ -84,7 +84,7 @@ Partly hide some text until the user clicks a button.
 
 #### JS:
 
-- https://assets.undrr.org/static/mangrove/1.2.9/assets/js/show-more.js
+- https://assets.undrr.org/static/mangrove/1.2.10/assets/js/show-more.js
 
 ### Changelog
 

--- a/stories/assets/scss/_components.scss
+++ b/stories/assets/scss/_components.scss
@@ -59,6 +59,7 @@
 @import "../../Components/Tab/tab";
 @import "../../Components/TableOfContents/TableOfContents";
 @import "../../Components/BlockquoteComponent/blockquotecomp";
+@import "../../Components/ErrorPages/error-pages";
 
 // Molecules
 @import "../../Molecules/ImageCaption/image-caption";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,10 @@ module.exports = [
       new MiniCssExtractPlugin(),
       //new FixStyleOnlyEntriesPlugin(),
       new CopyPlugin({
-        patterns: [{ from: 'stories/assets', to: 'assets' }],
+        patterns: [
+          { from: 'stories/assets', to: 'assets' },
+          { from: 'stories/Components/ErrorPages/static', to: 'assets/error-pages' },
+        ],
       }),
     ],
   },


### PR DESCRIPTION
This elevates the best practice we've been doing in Drupal into something that can be used across UNDRR sites.

- New `ErrorPage` component with calm, actionable copy following writing guidelines
- Storybook stories and MDX docs (sentence case); includes CDN URLs
- SCSS integrated into global rollup
- update-cdn-version script rewrites links in new docs and static pages

Closes https://github.com/unisdr/undrr-mangrove/issues/524