### PR TITLE
feat(MegaMenu): add visual feedback animations when switching menu sections

### DIFF
--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -48,6 +48,8 @@ const MyComponent = () => (
 
 ### Changelog
 
+- 0.7.1
+  - Refinements to UX of opening 3rd level menu on desktop (subtle colours and animation)
 - 0.7
   - **Major refactor**: Converted to mobile-first, CSS-driven responsive architecture
   - Eliminated window resize event listeners (zero JavaScript resize handlers)

--- a/stories/Components/MegaMenu/Section/Section.jsx
+++ b/stories/Components/MegaMenu/Section/Section.jsx
@@ -239,7 +239,9 @@ export default function Section({
               </ul>
 
               {/* Desktop version - shows items based on hover state */}
+              {/* Key forces remount on tab change, retriggering CSS animations */}
               <ul
+                key={`desktop-menu-${itemIndex}`}
                 role="menu"
                 aria-label="Submenu items"
                 className="mg-mega-content__menu--desktop"

--- a/stories/Components/MegaMenu/megamenu.scss
+++ b/stories/Components/MegaMenu/megamenu.scss
@@ -326,6 +326,19 @@
 
     .mg-mega-content__menu--desktop {
       display: block;
+      // Blue flash background that fades out (retriggered via React key)
+      animation: mg-mega-right-flash 400ms ease-out;
+
+      // Staggered slide-in for menu items
+      li {
+        animation: mg-mega-item-slide-in 250ms ease-out both;
+
+        @for $i from 1 through 12 {
+          &:nth-child(#{$i}) {
+            animation-delay: #{($i - 1) * 30}ms;
+          }
+        }
+      }
     }
   }
 
@@ -366,6 +379,32 @@
         }
       }
     }
+  }
+}
+
+/* Subtle blue gradient flash that fades to transparent on right content area */
+@keyframes mg-mega-right-flash {
+  0% {
+    background: linear-gradient(
+      to bottom,
+      rgba($mg-color-interactive, 0.06) 0%,
+      transparent 100%
+    );
+  }
+  100% {
+    background: transparent;
+  }
+}
+
+/* Menu items slide in from the left */
+@keyframes mg-mega-item-slide-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
   }
 }
 


### PR DESCRIPTION
Add subtle animations to the mega menu right content area to provide clearer visual feedback when users switch between menu sections:

- Staggered slide-in animation for menu items (from left, 30ms delay per item)
- Subtle blue gradient flash that fades from top to bottom
- Animations retrigger on section change via React key prop
