### PR TITLE
chore: remove unused card share functionality

### DIFF
--- a/stories/Components/Cards/Card/BookCard.mdx
+++ b/stories/Components/Cards/Card/BookCard.mdx
@@ -111,5 +111,6 @@ It's images have a 3x4 in aspect ratio.
 
 ### Changelog
 
+- 1.0.2: Removed unfinished/unused card “share” support (`item.share` / `mg-card__share`) from card components and documentation.
 - 1.0.1: Responsive fixes.
 - 1.0: Released component.

--- a/stories/Components/Cards/Card/HorizontalBookCard.jsx
+++ b/stories/Components/Cards/Card/HorizontalBookCard.jsx
@@ -26,7 +26,6 @@ export function HorizontalBookCard({ data, Hovercolors }) {
                 alt={item.imgalt}
                 className="mg-card__image"
               />
-              {/* <a href={item.link} className="mg-card__share">{item.share}</a> */}
             </div>
           )}
 

--- a/stories/Components/Cards/Card/HorizontalBookCard.mdx
+++ b/stories/Components/Cards/Card/HorizontalBookCard.mdx
@@ -13,7 +13,6 @@ export const getCaptionForLocale = locale => {
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -80,7 +79,6 @@ This paper explores health risks from climate change in a global context, settin
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -113,7 +111,7 @@ When a card with data, CTA links and image is to be displayed.
 
 #### Default
 
-It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels, social share link and/or image.
+It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels and/or image.
 
 ### Content
 
@@ -130,5 +128,6 @@ It consists of a title, paragraph, CTA links (primary, secondary and tertiary), 
 
 ### Changelog
 
-1.1 — Handle case when image is not available
-1.0 — Released component
+- 1.1.1: Removed unfinished/unused card “share” support (`item.share` / `mg-card__share`) from card components and documentation.
+- 1.1: Handle case when image is not available
+- 1.0: Released component

--- a/stories/Components/Cards/Card/HorizontalBookCard.stories.jsx
+++ b/stories/Components/Cards/Card/HorizontalBookCard.stories.jsx
@@ -11,7 +11,6 @@ const getCaptionForLocale = locale => {
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -78,7 +77,6 @@ This paper explores health risks from climate change in a global context, settin
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',

--- a/stories/Components/Cards/Card/HorizontalCard.jsx
+++ b/stories/Components/Cards/Card/HorizontalCard.jsx
@@ -27,9 +27,6 @@ export function HorizontalCard({ data, Hovercolors }) {
               alt={item.imgalt}
               className="mg-card__image"
             />
-            <a href={item.link} className="mg-card__share">
-              {item.share}
-            </a>
           </div>
 
           <div className={cls('mg-card__content', `${hovercolors_variant}`)}>

--- a/stories/Components/Cards/Card/HorizontalCard.mdx
+++ b/stories/Components/Cards/Card/HorizontalCard.mdx
@@ -13,7 +13,6 @@ export const getCaptionForLocale = locale => {
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -80,7 +79,6 @@ This paper explores health risks from climate change in a global context, settin
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -99,11 +97,11 @@ This paper explores health risks from climate change in a global context, settin
 
 # Mangrove card (horizontal)
 
-The Mangrove Horzontal Card components are cards with information and/or image.
+The Mangrove Horizontal Card components are cards with information and/or image.
 
 ### Overview
 
-The Mangrove Horzontal Card component defines a card of information with some items. It is a multi-usage component that creates boxes that are usually teasing some kind of content.
+The Mangrove Horizontal Card component defines a card of information with some items. It is a multi-usage component that creates boxes that are usually teasing some kind of content.
 
 #### When to use:
 
@@ -113,11 +111,11 @@ When a card with data, CTA links and image is to be displayed.
 
 #### Default
 
-It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels, social share link and/or image.
+It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels and/or image.
 
 ### Content
 
-There are two types of Mangrove Horzontal Card components: Mangrove Horzontal Card with Image and Mangrove Horzontal Card without Image.
+There are two types of Mangrove Horizontal Card components: Mangrove Horizontal Card with image and Mangrove Horizontal Card without image.
 
 <Canvas of={HorizontalCardStories.DefaultHorizontalCard} meta={HorizontalCardStories} />
 
@@ -132,4 +130,5 @@ There are two types of Mangrove Horzontal Card components: Mangrove Horzontal Ca
 
 ### Changelog
 
-1.0 — Released component
+- 1.0.1: Removed unfinished/unused card “share” support (`item.share` / `mg-card__share`) from card components and documentation.
+- 1.0 — Released component

--- a/stories/Components/Cards/Card/HorizontalCard.stories.jsx
+++ b/stories/Components/Cards/Card/HorizontalCard.stories.jsx
@@ -11,7 +11,6 @@ const getCaptionForLocale = locale => {
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -78,7 +77,6 @@ This paper explores health risks from climate change in a global context, settin
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',

--- a/stories/Components/Cards/Card/VerticalCard.jsx
+++ b/stories/Components/Cards/Card/VerticalCard.jsx
@@ -26,11 +26,6 @@ export function VerticalCard({ data, Hovercolors }) {
                 alt={item.imgalt}
                 className="mg-card__image"
               />
-              {item.link && item.share && (
-                <a href={item.link} className="mg-card__share">
-                  {item.share}
-                </a>
-              )}
             </div>
           )}
 

--- a/stories/Components/Cards/Card/VerticalCard.mdx
+++ b/stories/Components/Cards/Card/VerticalCard.mdx
@@ -12,7 +12,6 @@ export const getCaptionForLocale = locale => {
             title: 'Title in large size',
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -79,7 +78,6 @@ by vulnerable populations and communities.This paper explores health risks from 
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -112,7 +110,7 @@ When a card with data, CTA links and image is to be displayed.
 
 #### Default
 
-It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels, social share link and/or image.
+It consists of a title, paragraph, CTA links (primary, secondary and tertiary), labels and/or image.
 
 It's image in 16x9 in aspect ratio.
 
@@ -133,5 +131,6 @@ There are two types of Mangrove Vertical Card components: Mangrove Vertical Card
 
 ### Changelog
 
-1.1 — Handle case when image is not available
-1.0 — Released component
+- 1.1.1: Removed unfinished/unused card “share” support (`item.share` / `mg-card__share`) from card components and documentation.
+- 1.1 — Handle case when image is not available
+- 1.0 — Released component

--- a/stories/Components/Cards/Card/VerticalCard.stories.jsx
+++ b/stories/Components/Cards/Card/VerticalCard.stories.jsx
@@ -10,7 +10,6 @@ const getCaptionForLocale = locale => {
             title: 'Title in large size',
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -77,7 +76,6 @@ by vulnerable populations and communities.This paper explores health risks from 
             summaryText: `Climate change is a <a href="#" class="mg-card__text-link">global health emergency</a>, with impacts felt most acutely
 by vulnerable populations and communities.
 This paper explores health risks from climate change in a global context, setting out key risks actions`,
-            share: 'Social Share Button',
             label1: 'Label 1',
             label2: 'Label 2',
             button: 'Primary action',
@@ -133,7 +131,6 @@ export const NoImageVerticalCard = {
       ...item,
       imgback: null,
       imgalt: null,
-      share: null,
     }));
 
     return (

--- a/stories/Components/Cards/Card/card.scss
+++ b/stories/Components/Cards/Card/card.scss
@@ -69,12 +69,20 @@
 
   &__hc.mg-card-book__hc {
     .mg-card__visual {
+      align-self: flex-start;
       border: 1px solid rgba($mg-color-neutral-600, 0.2);
+      max-width: 200px;
       overflow: hidden;
+
+      @media (min-width: $mg-breakpoint-mobile) {
+        max-width: unset;
+      }
+
     }
 
     &:has(.mg-card__visual) {
-      grid-template-rows: 200px 1fr auto;
+      grid-template-rows: unset;
+      gap: $mg-spacing-100 0;
 
       @media (min-width: $mg-breakpoint-mobile) {
         grid-template-columns: 160px 1fr;
@@ -96,14 +104,6 @@
     align-self: center;
   }
 
-  &__share {
-    cursor: pointer;
-    display: inline-block;
-    padding: 0 $mg-spacing-50 $mg-spacing-25;
-    position: absolute;
-    z-index: 101;
-  }
-
   &__label {
     color: $mg-color-label;
     cursor: pointer;
@@ -114,15 +114,7 @@
     &:hover {
       color: $mg-color-label;
     }
-
-    // &--active {
-    //     background: #d4d4d4;
-    //     font-weight: bold;
-    // }
   }
-
-  // &__content {
-  // }
 
   &__title {
     font-size: $mg-font-size-500;

--- a/stories/Documentation/ReactIntegration.mdx
+++ b/stories/Documentation/ReactIntegration.mdx
@@ -485,7 +485,6 @@ export default App;
       link: '/article/link',
       imgalt: 'Image description',
       imgback: 'path/to/image.jpg',
-      share: 'Social Share Button', // Optional
       label1: 'Label 1', // Optional
       label2: 'Label 2', // Optional
     },


### PR DESCRIPTION
Removed unfinished/unused card “share” support (`item.share` / `mg-card__share`) from card components and documentation. This was never fully implemented or used.

