### PR TITLE
feat: differentiate challenge pages from error pages

### DIFF
--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -56,6 +56,45 @@ For static error pages (e.g., for CDN or upstream error handling), it is importa
 
 <Canvas of={Stories.Unauthorized401} />
 
+## Challenge pages
+
+Challenge pages are shown when Cloudflare needs to verify a visitor (e.g., CAPTCHA or browser check). They are deliberately designed to look different from error pages so visitors understand they are being verified — not blocked by an error.
+
+### Design approach
+
+The challenge page design follows [Cloudflare's guidance on custom challenge pages](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/) and UX research on CAPTCHA friction:
+
+- **Neutral background** (`#f2f2f2`) instead of the blue error background — signals "routine checkpoint", not "something broke"
+- **Centered, narrower card** with rounded corners and subtle shadow — focuses attention on the verification widget
+- **UNDRR logo for trust** — unexpected interstitials can feel like phishing; brand presence reassures visitors
+- **Calm, non-error language** — "routine check", not "blocked" or "suspicious"; no technical details shown by default
+- **Generous whitespace** — the page should feel unhurried; the Turnstile widget is the sole focus
+
+The Cloudflare Turnstile widget (which replaces `::CAPTCHA_BOX::`) renders at 300 x 65px (normal) or full-width with min 300px (flexible mode). The card is sized to comfortably contain it. Most legitimate visitors pass the managed challenge automatically with no interaction.
+
+### Important constraints
+
+- **Do not** include a `<meta name="referrer">` tag — it breaks the Cloudflare challenge flow
+- **Do not** use aggressive language ("blocked", "suspicious", "threat") on verification pages
+- The `::CAPTCHA_BOX::` token is **required** in both static HTML templates — Cloudflare replaces it with the actual widget at runtime
+- Static templates must not exceed 1.5 MB (Cloudflare limit)
+
+### Design references
+
+- [Cloudflare Turnstile widget configurations](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/) — widget sizes, themes, and rendering modes
+- [Cloudflare custom challenge pages](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/) — customization options and constraints
+- [Cloudflare additional configuration](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/additional-configuration/) — CSP restrictions, favicon, and referrer policy warnings
+- [CAPTCHA can ruin your UX (Auth0)](https://auth0.com/blog/captcha-can-ruin-your-ux-here-s-how-to-use-it-right/) — friction impact and mitigation strategies
+- [Cloudflare Turnstile accessibility (WCAG 2.1 AA)](https://developers.cloudflare.com/turnstile/frequently-asked-questions/) — the widget is WCAG 2.1 Level AA compliant
+
+### Interactive challenge
+
+<Canvas of={Stories.InteractiveChallenge} />
+
+### Managed challenge
+
+<Canvas of={Stories.ManagedChallenge} />
+
 ## Content
 
 - Keep the title short and specific to the state
@@ -169,6 +208,7 @@ https://assets.undrr.org/static/mangrove/latest/assets/error-pages/504.html
 
 ## Changelog
 
+- 1.3.0 — Challenge pages now use neutral background and teal accent to differentiate from error pages ([#2615](https://gitlab.com/undrr/web-backlog/-/issues/2615))
 - 1.2.0 — Added 401, 500, 504, 5xx, challenge, managed-challenge static templates; added URL via client-side JS; added `vf:page-type` meta tags for analytics ([#2556](https://gitlab.com/undrr/web-backlog/-/issues/2556))
 - 1.1.0 — Added Cloudflare integration with error tokens and deferred asset loading ([#2556](https://gitlab.com/undrr/web-backlog/-/issues/2556))
 - 1.0.0 — Added standard error pages component and examples

--- a/stories/Components/ErrorPages/ErrorPage.stories.jsx
+++ b/stories/Components/ErrorPages/ErrorPage.stories.jsx
@@ -13,6 +13,15 @@ export default {
       control: { type: 'select' },
       options: Object.keys(DEFAULT_COPY).map(Number),
     },
+    variant: {
+      control: { type: 'select' },
+      options: ['error', 'challenge'],
+    },
+    challengeType: {
+      control: { type: 'select' },
+      options: ['challenge', 'managed-challenge'],
+      if: { arg: 'variant', eq: 'challenge' },
+    },
     showSearch: { control: 'boolean' },
     showRequestDetails: { control: 'boolean' },
   },
@@ -48,4 +57,18 @@ export const GatewayTimeout504 = {
 
 export const Unauthorized401 = {
   args: { code: 401, showRequestDetails: true },
+};
+
+export const InteractiveChallenge = {
+  args: {
+    variant: 'challenge',
+    challengeType: 'challenge',
+  },
+};
+
+export const ManagedChallenge = {
+  args: {
+    variant: 'challenge',
+    challengeType: 'managed-challenge',
+  },
 };

--- a/stories/Components/ErrorPages/ErrorPagesContent.js
+++ b/stories/Components/ErrorPages/ErrorPagesContent.js
@@ -51,6 +51,27 @@ export const DEFAULT_COPY = {
 };
 
 /**
+ * Default copy for Cloudflare challenge pages
+ *
+ * Challenge pages verify visitors before granting access. They are not errors,
+ * so the tone is neutral and reassuring rather than apologetic.
+ *
+ * @see https://gitlab.com/undrr/web-backlog/-/issues/2615
+ */
+export const CHALLENGE_COPY = {
+  challenge: {
+    title: 'Security check',
+    description: 'Please verify you are human',
+    body: 'This is a routine check to keep the site secure. It only takes a moment.',
+  },
+  'managed-challenge': {
+    title: 'Security check',
+    description: 'Checking your browser',
+    body: 'This is a routine check to keep the site secure. It only takes a moment.',
+  },
+};
+
+/**
  * Cloudflare error tokens for custom error pages
  *
  * These tokens are replaced by Cloudflare at runtime when serving custom error pages.

--- a/stories/Components/ErrorPages/error-pages.scss
+++ b/stories/Components/ErrorPages/error-pages.scss
@@ -38,4 +38,31 @@
     height: 50px;
     margin: 1rem 0;
   }
+
+  &--challenge {
+    background-color: $mg-color-neutral-25;
+
+    .mg-error-page__container {
+      text-align: center;
+      padding: 3rem 2.5rem 2rem;
+      margin-top: 4rem;
+      max-width: 540px;
+      border-radius: 8px;
+      box-shadow: 0 2px 12px rgb(0 0 0 / 0.08);
+    }
+
+    .undrr-logo {
+      width: 100%;
+      margin: 0 0 2.5rem;
+      background-position: center;
+      height: 35px;
+    }
+
+    h1 {
+      font-size: 2.3rem;
+      font-weight: 600;
+      color: $mg-color-text;
+      margin: 0 0 0.5rem;
+    }
+  }
 }

--- a/stories/Components/ErrorPages/static/challenge.html
+++ b/stories/Components/ErrorPages/static/challenge.html
@@ -39,6 +39,10 @@
       hr{border:1px solid #b3b3b3}
       small{display:block;margin-bottom:.5rem}
       .mg-error-page{min-height:100vh;background:#004f91;padding-bottom:2rem}
+      .mg-error-page--challenge{background:#f2f2f2}
+      .mg-error-page--challenge .mg-error-page__container{text-align:center;padding:3rem 2.5rem 2rem;margin-top:4rem;max-width:540px;border-radius:8px;box-shadow:0 2px 12px rgb(0 0 0 / 8%)}
+      .mg-error-page--challenge .undrr-logo{width:100%;margin:0 0 2.5rem;background-position:center;height:35px}
+      .mg-error-page--challenge h1{font-size:2.3rem;font-weight:600;color:#1a1a1a;margin:0 0 .5rem}
       .mg-page-header__decoration{display:flex}
       .mg-page-header__decoration div{width:25%;height:7px}
       .mg-page-header__decoration div:nth-child(1){background:#c10920}
@@ -52,7 +56,7 @@
     </style>
   </head>
   <body>
-    <main class="mg-error-page">
+    <main class="mg-error-page mg-error-page--challenge">
       <div class="mg-page-header__decoration" aria-hidden="true">
         <div></div>
         <div></div>
@@ -60,23 +64,20 @@
         <div></div>
       </div>
       <div class="mg-error-page__container">
-        <h1>Security check</h1>
-        <h2>Please verify you are human</h2>
-        <p>We need to verify your request before you can access this page. Please complete the challenge below.</p>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
+        <h1>Please verify you are human</h1>
+        <p>This is a routine check to keep the site secure. It only takes a moment.</p>
         <!-- Cloudflare CAPTCHA box - REQUIRED for challenge pages -->
         ::CAPTCHA_BOX::
         <p>
-          If you think this is in error or need help,
-          <a href="https://www.undrr.org/contact-us">please contact us</a>
-          and provide the details below.
+          Having trouble?
+          <a href="https://www.undrr.org/contact-us">Contact us</a>
+          and include the details below.
         </p>
         <!-- Cloudflare tokens - replace with your platform's variables if not using Cloudflare -->
         <p class="mg-code" role="note" aria-label="Request details">
           Ray ID: ::RAY_ID:: | Your IP: ::CLIENT_IP:: | Location: ::GEO::
         </p>
-        <hr />
-        <small>This website is operated by</small>
-        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script>

--- a/stories/Components/ErrorPages/static/managed-challenge.html
+++ b/stories/Components/ErrorPages/static/managed-challenge.html
@@ -41,6 +41,10 @@
       hr{border:1px solid #b3b3b3}
       small{display:block;margin-bottom:.5rem}
       .mg-error-page{min-height:100vh;background:#004f91;padding-bottom:2rem}
+      .mg-error-page--challenge{background:#f2f2f2}
+      .mg-error-page--challenge .mg-error-page__container{text-align:center;padding:3rem 2.5rem 2rem;margin-top:4rem;max-width:540px;border-radius:8px;box-shadow:0 2px 12px rgb(0 0 0 / 8%)}
+      .mg-error-page--challenge .undrr-logo{width:100%;margin:0 0 2.5rem;background-position:center;height:35px}
+      .mg-error-page--challenge h1{font-size:2.3rem;font-weight:600;color:#1a1a1a;margin:0 0 .5rem}
       .mg-page-header__decoration{display:flex}
       .mg-page-header__decoration div{width:25%;height:7px}
       .mg-page-header__decoration div:nth-child(1){background:#c10920}
@@ -54,7 +58,7 @@
     </style>
   </head>
   <body>
-    <main class="mg-error-page">
+    <main class="mg-error-page mg-error-page--challenge">
       <div class="mg-page-header__decoration" aria-hidden="true">
         <div></div>
         <div></div>
@@ -62,23 +66,20 @@
         <div></div>
       </div>
       <div class="mg-error-page__container">
-        <h1>Security check</h1>
-        <h2>Checking your browser</h2>
-        <p>Please wait while we verify your connection. This usually takes just a moment.</p>
+        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
+        <h1>Checking your browser</h1>
+        <p>This is a routine check to keep the site secure. It only takes a moment.</p>
         <!-- Cloudflare CAPTCHA box - REQUIRED for managed challenge pages -->
         ::CAPTCHA_BOX::
         <p>
-          If you think this is in error or need help,
-          <a href="https://www.undrr.org/contact-us">please contact us</a>
-          and provide the details below.
+          Having trouble?
+          <a href="https://www.undrr.org/contact-us">Contact us</a>
+          and include the details below.
         </p>
         <!-- Cloudflare tokens - replace with your platform's variables if not using Cloudflare -->
         <p class="mg-code" role="note" aria-label="Request details">
           Ray ID: ::RAY_ID:: | Your IP: ::CLIENT_IP:: | Location: ::GEO::
         </p>
-        <hr />
-        <small>This website is operated by</small>
-        <a href="https://www.undrr.org/"><div class="undrr-logo" aria-hidden="true"></div></a>
       </div>
     </main>
     <script>


### PR DESCRIPTION
## Before 

<img width="1604" height="672" alt="grafik" src="https://github.com/user-attachments/assets/8c118871-2e1e-45a1-a2e5-0ba615f5e3bc" />

## After 

<img width="977" height="490" alt="grafik" src="https://github.com/user-attachments/assets/260071a0-e732-4bf7-9d36-f99119d451da" />

## Summary

- Adds `mg-error-page--challenge` BEM modifier to visually differentiate Cloudflare challenge/CAPTCHA pages from error pages
- Challenge pages now use a neutral `#f2f2f2` background, centered narrower card (540px), rounded corners, UNDRR logo at top for trust, and calm non-error language
- Updates both the React `ErrorPage` component (new `variant` and `challengeType` props) and the static HTML templates (`challenge.html`, `managed-challenge.html`)

## Design approach

The challenge page design follows [Cloudflare's guidance on custom challenge pages](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/) and UX research on CAPTCHA friction:

- **Neutral background** instead of blue error background — signals "routine checkpoint", not "something broke"
- **UNDRR logo at top** — unexpected interstitials can feel like phishing; brand presence reassures visitors
- **Calm language** — "routine check", not "blocked" or "suspicious"
- **Semibold heading** (600 weight) — softer tone than bold error headings
- **Smaller logo** (35px) with generous whitespace below — logo acts as trust mark, not hero

## Files changed

| File | Change |
|------|--------|
| `error-pages.scss` | `&--challenge` modifier with neutral background, centered card, logo/heading styles |
| `ErrorPage.jsx` | `variant` and `challengeType` props, challenge-specific rendering |
| `ErrorPagesContent.js` | `CHALLENGE_COPY` export with default copy for both challenge types |
| `ErrorPage.stories.jsx` | `InteractiveChallenge` and `ManagedChallenge` stories |
| `ErrorPage.mdx` | Design approach docs, constraints, Cloudflare reference links, changelog |
| `static/challenge.html` | Challenge modifier class + inline CSS + restructured markup |
| `static/managed-challenge.html` | Same as above for managed challenge variant |

## References

- Resolves https://gitlab.com/undrr/web-backlog/-/issues/2615
- [Cloudflare custom challenge pages](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/)
- [Cloudflare Turnstile widget](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/widget-configurations/)

## Test plan

- [x] `yarn dev` — both new stories render with grey background, centered card; existing error stories unchanged
- [x] `yarn lint` — no errors
- [x] `yarn test` — 185/185 pass
- [x] Visual: challenge stories look clearly distinct from error stories at a glance
- [x] Static HTML: open `challenge.html` and `managed-challenge.html` in browser to verify layout