### PR TITLE
fix: MegaMenu topbar width on extra-large screens

### DIFF
--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -48,6 +48,8 @@ const MyComponent = () => (
 
 ### Changelog
 
+- 0.7.3
+  - Topbar now expands to the extra-large breakpoint (1440px) on wider screens, matching the container system
 - 0.7.2
   - Migrated icon classes from `fa-*` to `mg-icon-*` namespace
 - 0.7.1

--- a/stories/Components/MegaMenu/megamenu.scss
+++ b/stories/Components/MegaMenu/megamenu.scss
@@ -11,8 +11,12 @@
   align-items: flex-start;
   z-index: 10;
   padding: 0;
-  max-width: $mg-breakpoint-desktop; // mg-mega-toolbar does not play well with mg-container
+  max-width: $mg-breakpoint-desktop;
   margin: 0 auto;
+
+  @media screen and (min-width: $mg-breakpoint-desktop-wide) {
+    max-width: $mg-breakpoint-desktop-wide;
+  }
 
   // these are note "mobile first" as they seem to cause a glitch with firefox and .mg-container-full-width
   @media screen and (max-width: $mg-breakpoint-tablet) {


### PR DESCRIPTION
## Summary

- The MegaMenu topbar was constrained to `$mg-breakpoint-desktop` (1164px) on all screen sizes, leaving excessive whitespace on wider displays where page content expands to 1440px
- Added a responsive `max-width` step-up at the `$mg-breakpoint-desktop-wide` (1440px) breakpoint, matching the existing `.mg-container` pattern
- Updated component changelog to 0.7.3

## Test plan

- [ ] Verify MegaMenu fills to 1440px on screens wider than 1440px
- [ ] Verify MegaMenu still caps at 1164px on screens between 1164px and 1440px
- [ ] Verify no layout changes on tablet and mobile breakpoints
- [ ] Check RTL layout is unaffected
- [ ] Visual regression: compare before/after at 1920px viewport width