### PR TITLE
Add react-element-to-jsx-string and react-is dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "prettier-eslint": "16.4.2",
     "prettier-stylelint": "0.4.2",
     "process": "^0.11.10",
+    "react-element-to-jsx-string": "17.0.1",
+    "react-is": "19.2.4",
     "react-syntax-highlighter": "16.1.0",
     "remark-gfm": "^4.0.1",
     "remove-files-webpack-plugin": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,6 +2325,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@base2/pretty-print-object@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@base2/pretty-print-object@npm:1.0.2"
+  checksum: 10/8a0c84c7d1ed7c92493238b9815be2eed412d70c13bc889ba6cc3ec6146b886121fe0fbbea01699a1681927c659a37a67b77a8971a009ad35556f064e131e335
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -4875,6 +4882,8 @@ __metadata:
     qrcode: "npm:^1.5.4"
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
+    react-element-to-jsx-string: "npm:17.0.1"
+    react-is: "npm:19.2.4"
     react-leaflet: "npm:5.0.0"
     react-leaflet-markercluster: "npm:5.0.0-rc.0"
     react-syntax-highlighter: "npm:16.1.0"
@@ -12153,19 +12162,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:5.0.0, is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
 "is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
     isobject: "npm:^3.0.1"
   checksum: 10/2a401140cfd86cabe25214956ae2cfee6fbd8186809555cd0e84574f88de7b17abacb2e477a6a658fa54c6083ecbda1e6ae404c7720244cd198903848fca70ca
-  languageName: node
-  linkType: hard
-
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
   languageName: node
   linkType: hard
 
@@ -16992,6 +17001,27 @@ __metadata:
   peerDependencies:
     react: ^19.2.3
   checksum: 10/5780f6d4c8e8ece09f82c5500ba2d55e01c30b5273f9281734d7d3b65013cd1fa52ec4e4436e5248c0a9e5bc340836044051168bbad8d7eac4d33ee6c2a867a1
+  languageName: node
+  linkType: hard
+
+"react-element-to-jsx-string@npm:17.0.1":
+  version: 17.0.1
+  resolution: "react-element-to-jsx-string@npm:17.0.1"
+  dependencies:
+    "@base2/pretty-print-object": "npm:1.0.2"
+    is-plain-object: "npm:5.0.0"
+  peerDependencies:
+    react: ^19.0.0
+    react-dom: ^19.0.0
+    react-is: ^19.0.0
+  checksum: 10/d5d611f55d3bb8a29dcc253cdf78d6b7eed6ad76466dccfb8d866988bbf7007d2ba3471b4b251bcb4f806331c6d71eb493497dd8bc016270abec4a51a3d3f247
+  languageName: node
+  linkType: hard
+
+"react-is@npm:19.2.4":
+  version: 19.2.4
+  resolution: "react-is@npm:19.2.4"
+  checksum: 10/3360fc50a38c23299c5003a709949f2439b2901e77962eea78d892f526f710d05a7777b600b302f853583d1861979b00d7a0a071c89c6562eac5740ac29b9665
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Type

- [x] Build related changes

## What's this PR addressing?

Adding two new dependencies to support JSX string conversion and React type checking functionality:
- `react-element-to-jsx-string` (17.0.1) - for converting React elements to JSX string representation
- `react-is` (19.2.4) - for runtime type checking of React elements

These dependencies enable enhanced code inspection and rendering capabilities in the project.

## Link to ticket

N/A

## Resources

N/A

## Test Plan

N/A - Dependency additions. Verify that `yarn install` or `npm install` completes successfully and the lockfile is properly updated.

https://claude.ai/code/session_017keuWUjLsW6hh2wajhzq91