### PR TITLE
feat: Complete Footer component CSS for Drupal theme migration

### DIFF
--- a/stories/Components/Footer/footer.scss
+++ b/stories/Components/Footer/footer.scss
@@ -14,6 +14,10 @@
   a:hover {
     color: $mg-color-white;
   }
+
+  .container {
+    margin-bottom: 0;
+  }
 }
 
 .mg-footer--about-footer--links {
@@ -24,4 +28,19 @@
 
 .mg-footer--about-footer--description {
   font-size: $mg-font-size-400;
+}
+
+.mg-footer--social-links {
+  display: inline-flex;
+  gap: 1.5rem;
+  padding-left: 0;
+
+  li {
+    display: inline-block;
+  }
+
+  li a {
+    color: $mg-color-white;
+    text-underline-offset: 5px;
+  }
 }


### PR DESCRIPTION
## Summary

- Add `.mg-footer--social-links` for social media platform link layout (migrated from Drupal theme's `.social-media-links--platforms`)
- Add `.container { margin-bottom: 0 }` reset to `.mg-footer--about-footer`
- Enables Drupal themes to import Mangrove `footer.scss` via `_mangrove-components.scss` and drop their own footer CSS

## Context

As part of [web-backlog#2656](https://gitlab.com/undrr/web-backlog/-/issues/2656), we're moving footer and user feedback blocks from the `content` region to the proper `footer` region across all 10 UNDRR Drupal themes. As part of that work, footer component CSS is being migrated from the Drupal `undrr_common` base theme into Mangrove so it can be reused across systems.

The Drupal themes now import this SCSS and the old `.about-footer` / `.social-media-links--platforms` styles have been removed from `undrr_common`. Database content will be double-classed during the transition (`about-footer mg-footer--about-footer`), then the old classes removed once the handover is confirmed.

## Test plan

- [ ] Verify `footer.scss` compiles with `yarn scss`
- [ ] Check Storybook Footer stories render correctly
- [ ] Confirm `.mg-footer--social-links` styles match the old `.social-media-links--platforms` output