### PR TITLE
docs: improve Tabs component usage guidance

### DIFF
--- a/stories/Components/Tab/Tab.mdx
+++ b/stories/Components/Tab/Tab.mdx
@@ -48,12 +48,11 @@ Import `mgTabs` from the CDN and call it once the DOM is ready:
 ```html
 <script type="module">
   import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.3.1/js/tabs.js';
-
-  document.addEventListener('DOMContentLoaded', () => {
-    mgTabs();
-  });
+  mgTabs();
 </script>
 ```
+
+Module scripts are deferred by default, so the DOM is already parsed when this runs. No `DOMContentLoaded` wrapper needed.
 
 `mgTabs()` finds every `[data-mg-js-tabs]` element on the page and wires up the tab behavior.
 
@@ -137,7 +136,7 @@ Two exported functions:
 | Function | Description |
 |----------|-------------|
 | `mgTabs(scope?, activateDeepLinkOnLoad?)` | Initializes all tab containers. `scope` is an optional `NodeList`; defaults to all `[data-mg-js-tabs]` elements. `activateDeepLinkOnLoad` defaults to `true`. |
-| `mgTabsRuntime(scope?, activateDeepLinkOnLoad?)` | Initializes a single tab container. `scope` is an optional DOM element; defaults to `document`. Use this for tabs injected after page load. |
+| `mgTabsRuntime(scope?, activateDeepLinkOnLoad?)` | Initializes tabs within a scope element. `scope` is an optional DOM element (a tab container or a parent that contains them); defaults to `document`. Use this for tabs injected after page load. |
 
 If you inject tab markup dynamically (e.g. from an API response), call `mgTabsRuntime()` on the new container:
 
@@ -160,7 +159,8 @@ mgTabsRuntime(newContainer);
 The `<Tab>` component renders the same HTML as above and calls `mgTabs()` on mount. It's available from the Mangrove source but not published as a precompiled bundle on the CDN.
 
 ```jsx
-import { Tab } from '@undrr/undrr-mangrove/stories/Components/Tab/Tab';
+// Requires the full Mangrove source tree (not available from the npm package alone)
+import { Tab } from 'stories/Components/Tab/Tab';
 
 const tabdata = [
   { text: 'Overview', text_id: 'overview', data: '<p>Overview content</p>' },


### PR DESCRIPTION
## Summary

Rewrites the Tabs component documentation with practical usage guidance that was previously missing.

- Vanilla JS setup: CSS include, CDN script import for `tabs.js`, HTML markup for both horizontal and stacked variants
- API reference for `mgTabs()` and `mgTabsRuntime()` with correct parameter docs
- Data attributes reference table
- React `<Tab>` wrapper usage (source-only, with clear disclaimer)
- Props and `tabdata` object schema
- Cross-links to CDN reference and Vanilla HTML/CSS integration pages
- Fixed a bug in the example code: removed `DOMContentLoaded` wrapper inside `type="module"` script (module scripts are deferred, so the event may have already fired by the time a CDN import resolves)
- Changelog entry for 2.4.1

Closes #798

## Test plan

- [ ] Run `yarn dev` and verify the Tabs docs page renders correctly at `Components/Tabs > Docs`
- [ ] Confirm the Canvas embed still shows the interactive tab demo
- [ ] Spot-check that the HTML markup examples match the rendered output in the HTML tab