### PR TITLE
docs: improve cross-referencing between documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Thank you for contributing to the UNDRR Mangrove component library.
 ## Getting started
 
 - See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) for environment setup, scripts, branching, and commit conventions.
+- See [`docs/TESTING.md`](docs/TESTING.md) for unit, visual, and accessibility testing.
+- See [`docs/RELEASES.md`](docs/RELEASES.md) for versioning, tagging, and publishing.
 - For a step-by-step guide to contributing new components—including structure, best practices, and review process—check out the [component contribution guide](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-component-contribution-guide--docs) in our Storybook docs.
 
 ## Writing guidelines

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,6 +13,16 @@ For more detailed information, see the [Getting Started Guide](https://unisdr.gi
 - **Writing guidelines**: UX writing standards — [docs/WRITING.md](./WRITING.md)
 - **Writing quick reference**: concise checklist for AI tools and reviews — [docs/WRITING-SHORT.md](./WRITING-SHORT.md)
 
+### Storybook documentation
+
+These guides live inside Storybook and cover component standards, integration, and best practices:
+
+- [Getting started guide](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-a-getting-started-guide--docs) — onboarding, installation methods, and integration options
+- [Component contribution guide](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-component-contribution-guide--docs) — component structure, code standards, and PR process
+- [Component structure](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-component-structure--docs) — architecture and organization patterns
+- [Testing components](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-testing-components--docs) — testing strategies within Storybook
+- [Best practices](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-best-practices--docs) — accessibility, performance, and architecture guidance
+
 ## Prerequisites
 
 - Node.js 22 (use nvm or similar to manage versions)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -125,7 +125,7 @@ it('loads data on mount', async () => {
 
 ## Visual Testing with Chromatic
 
-Visual testing is handled automatically through our CI/CD pipeline. See [CHROMATIC_VISUAL_TESTING.md](./CHROMATIC_VISUAL_TESTING.md) for detailed information.
+Visual testing is handled automatically through our CI/CD pipeline.
 
 ### Quick Overview
 

--- a/stories/Documentation/ComponentContribution.mdx
+++ b/stories/Documentation/ComponentContribution.mdx
@@ -19,6 +19,23 @@ Before contributing, please review **<LinkTo kind="getting-started-mangrove-the-
 
 Further information on detailed setup, workflow, and contribution docs in the [development section of our GitHub README](https://github.com/unisdr/undrr-mangrove/?tab=readme-ov-file#development).
 
+### Related guides
+
+These guides on GitHub cover process and workflow:
+
+- [Development guide](https://github.com/unisdr/undrr-mangrove/blob/main/docs/DEVELOPMENT.md) — environment setup, scripts, branching, and commit conventions
+- [Contributing guide](https://github.com/unisdr/undrr-mangrove/blob/main/CONTRIBUTING.md) — how to propose changes and submit PRs
+- [Testing guide](https://github.com/unisdr/undrr-mangrove/blob/main/docs/TESTING.md) — unit, visual, and accessibility testing
+- [Release process](https://github.com/unisdr/undrr-mangrove/blob/main/docs/RELEASES.md) — versioning, tagging, and publishing
+- [Writing guidelines](https://github.com/unisdr/undrr-mangrove/blob/main/docs/WRITING.md) — UX writing standards
+
+These Storybook guides cover related component topics:
+
+- **<LinkTo kind="getting-started-component-structure" story="docs">Component structure</LinkTo>** — architecture and organization patterns
+- **<LinkTo kind="getting-started-testing-components" story="docs">Testing components</LinkTo>** — testing strategies within Storybook
+- **<LinkTo kind="getting-started-best-practices" story="docs">Best practices</LinkTo>** — accessibility, performance, and architecture guidance
+- **<LinkTo kind="getting-started-writing-guidelines" story="docs">Writing guidelines</LinkTo>** — UX writing standards for components and docs
+
 ## Component development workflow
 
 ### 1. Planning phase


### PR DESCRIPTION
## Summary

- Add Storybook documentation links to `docs/DEVELOPMENT.md` so GitHub readers can discover component guides
- Add `TESTING.md` and `RELEASES.md` links to `CONTRIBUTING.md` for quicker contributor onboarding
- Add a "Related guides" section to `ComponentContribution.mdx` linking back to GitHub process docs and to related Storybook pages
- Remove broken reference to nonexistent `CHROMATIC_VISUAL_TESTING.md` in `docs/TESTING.md`

## Test plan

- [ ] Verify all GitHub links resolve correctly
- [ ] Verify Storybook `<LinkTo>` links navigate to the correct pages (`yarn dev`)
- [ ] Confirm no rendering issues in the MDX file