### PR TITLE
fix: prevent event listener leak in mgShowMore

### DIFF
--- a/stories/Utilities/ShowMore/ShowMore.mdx
+++ b/stories/Utilities/ShowMore/ShowMore.mdx
@@ -86,5 +86,6 @@ The collapsed height is controlled by the `--mg-show-more-height` CSS custom pro
 
 ## Changelog
 
+- **1.1.1** — 2026-03-05: Fixed event listener leak — target click handler now registers once at init instead of on every toggle; clicking expanded content no longer inadvertently collapses it
 - **1.1** — 2026-02-23: Replaced white gradient overlay with CSS `mask-image` for background-agnostic fade effect
 - **1.0** — 2023-08-24: Released component

--- a/stories/assets/js/show-more.js
+++ b/stories/assets/js/show-more.js
@@ -11,18 +11,13 @@ export function mgShowMore() {
     item.dataset.dataVfGoogleAnalyticsLabel =
       'Show more: ' + item.dataset.mgShowMoreLabelCollapsed || `Show more`;
 
+    const mgShowMoreTargetClass =
+      item.dataset.mgShowMoreTarget || '.mg-show-more--container';
+    const mgShowMoreTarget = document.querySelector(mgShowMoreTargetClass);
+
     item.addEventListener('click', event => {
       event.preventDefault();
-      let mgShowMoreTargetClass =
-        item.dataset.mgShowMoreTarget || '.mg-show-more--container';
-      let mgShowMoreTarget = document.querySelector(mgShowMoreTargetClass);
       mgShowMoreTarget.classList.toggle('mg-show-more--collapsed');
-
-      // Allow items to be shown by clicking anywhere on the collapsed item
-      // https://gitlab.com/undrr/web-backlog/-/issues/1612
-      mgShowMoreTarget.addEventListener('click', () => {
-        item.click();
-      });
 
       // Which label to show?
       item.textContent = mgShowMoreTarget.classList.contains(
@@ -35,6 +30,14 @@ export function mgShowMore() {
         item.classList.remove('mg-show-more--button--open');
       } else {
         item.classList.add('mg-show-more--button--open');
+      }
+    });
+
+    // Allow items to be shown by clicking anywhere on the collapsed item
+    // https://gitlab.com/undrr/web-backlog/-/issues/1612
+    mgShowMoreTarget.addEventListener('click', () => {
+      if (mgShowMoreTarget.classList.contains('mg-show-more--collapsed')) {
+        item.click();
       }
     });
 


### PR DESCRIPTION
## Summary

- The click-to-expand listener on the target element (from [#1612](https://gitlab.com/undrr/web-backlog/-/issues/1612)) was inside the button's click handler, so a new listener was added on every toggle
- Moved target resolution and the target click listener to initialization scope so they register once
- Added a guard so clicking inside expanded content doesn't collapse it — only collapsed targets expand on click

## Test plan

- [ ] Add a show-more button targeting a content block
- [ ] Click the button multiple times to toggle — verify no duplicate expand/collapse behavior
- [ ] When collapsed, click the target content — it should expand
- [ ] When expanded, click inside the target content — it should stay expanded (not collapse)