### PR TITLE
fix: replace Drupal-specific selectors with mg-card BEM classes in search widget

### DIFF
--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.scss
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.scss
@@ -736,26 +736,17 @@ $search-input-padding-x: $mg-spacing-250;
 // ========================================
 // Modifier classes on the results container hide specific teaser fields
 // via the visibleTeaserFields config option.
-// Title (.field--name-node-title) is intentionally not toggleable.
-// Non-mangrove selectors (.st-tag--spl, .field--name-*, etc.) originate from
-// Drupal's rendered teaser HTML. Elasticsearch indexes pre-rendered teasers
-// with these classes intact, so we target them directly here rather than
-// re-parsing or transforming the markup at runtime.
+// Title (.mg-card__title) is intentionally not toggleable.
+// Teaser HTML uses standard mg-card__* BEM wrapper classes added by
+// Drupal teaser templates (see web-backlog#2660).
 
 .mg-search--hide-image .mg-card__visual { display: none; }
-.mg-search--hide-contentType .st-tag--spl { display: none; }
-.mg-search--hide-publicationType .field--name-field-undrr-publication-types { display: none; }
-.mg-search--hide-date .field--name-published-at,
-.mg-search--hide-date .field--name-field-publication-date,
-.mg-search--hide-date .field--name-field-release-date,
-.mg-search--hide-date .field--name-field-event-date-range,
-.mg-search--hide-date .field--name-field-date-time,
-.mg-search--hide-date .field--name-field-closing-date,
-.mg-search--hide-date .collection-freshness { display: none; }
+.mg-search--hide-contentType .mg-card__tag { display: none; }
+.mg-search--hide-publicationType .mg-card__publication-type { display: none; }
+.mg-search--hide-date .mg-card__date { display: none; }
 .mg-search--hide-siteName .mg-search__result-site-name { display: none; }
-.mg-search--hide-summary .field--name-body,
-.mg-search--hide-summary .mg-card__content > p:not(.mg-search__result-site-name) { display: none; }
-.mg-search--hide-organization .field--name-field-organization { display: none; }
+.mg-search--hide-summary .mg-card__description { display: none; }
+.mg-search--hide-organization .mg-card__organization { display: none; }
 
 // ========================================
 // Card Display Mode (mg-grid layout)

--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.stories.jsx
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.stories.jsx
@@ -410,16 +410,15 @@ Results are sorted by date (\`defaultSort: 'newest'\`).
 \`\`\`js
 visibleTeaserFields: {
   image: true,           // Card image (.mg-card__visual)
-  contentType: false,    // Content type badge (.st-tag--spl)
-  publicationType: false,// Publication subtype (.field--name-field-undrr-publication-types)
-  date: true,            // Publication date (.field--name-published-at)
+  contentType: false,    // Content type badge (.mg-card__tag)
+  publicationType: false,// Publication subtype (.mg-card__publication-type)
+  date: true,            // Publication date (.mg-card__date)
   siteName: false,       // Domain label (.mg-search__result-site-name)
-  summary: true,         // Body text (.mg-card__content > p)
-  organization: false,   // Organization name (.field--name-field-organization)
+  summary: true,         // Body text (.mg-card__description)
+  organization: false,   // Organization name (.mg-card__organization)
 }
 \`\`\`
 
-Non-mg-prefixed selectors come from Drupal teaser HTML indexed by Elasticsearch.
 Uses CSS modifier classes — zero JS overhead, \`display: none\` removes from layout and accessibility tree.
         `,
       },

--- a/stories/Components/SyndicationSearchWidget/utils/constants.js
+++ b/stories/Components/SyndicationSearchWidget/utils/constants.js
@@ -467,10 +467,10 @@ export function isFilterVisible(key, visibleFilters) {
 /**
  * Build CSS modifier classes to hide teaser fields based on visibility config.
  *
- * The corresponding SCSS rules target both Mangrove classes (e.g., .mg-card__visual)
- * and Drupal-originated classes (e.g., .field--name-published-at, .st-tag--spl).
- * Drupal renders teasers as HTML with these classes, and Elasticsearch indexes the
- * pre-rendered markup, so the classes arrive intact in search results.
+ * The corresponding SCSS rules target standard mg-card__* BEM wrapper classes
+ * (e.g., .mg-card__visual, .mg-card__date, .mg-card__description).
+ * Drupal teaser templates add these classes (see web-backlog#2660), and
+ * Elasticsearch indexes the pre-rendered markup with them intact.
  *
  * @param {Object|null} visibleTeaserFields - Map of field keys to booleans. null = all visible.
  * @returns {string} Space-separated CSS class string (e.g., 'mg-search--hide-image mg-search--hide-date')


### PR DESCRIPTION
## Summary

Replace Drupal-specific CSS selectors with standard `mg-card__*` BEM wrapper classes in the search widget's `visibleTeaserFields` hiding feature.

Follows [web-backlog#2660](https://gitlab.com/undrr/web-backlog/-/work_items/2660) which adds these BEM classes to Drupal teaser templates, giving us a single predictable CSS hook per semantic element instead of multiple content-type-specific field selectors.

### Before → After

| Field | Before (Drupal selectors) | After (BEM) |
|-------|--------------------------|-------------|
| contentType | `.st-tag--spl` | `.mg-card__tag` |
| publicationType | `.field--name-field-undrr-publication-types` | `.mg-card__publication-type` |
| date | 7 selectors (`.field--name-published-at`, `.field--name-field-release-date`, etc.) | `.mg-card__date` |
| summary | `.field--name-body` + `.mg-card__content > p:not(...)` | `.mg-card__description` |
| organization | `.field--name-field-organization` | `.mg-card__organization` |
| image | `.mg-card__visual` (unchanged) | `.mg-card__visual` |
| siteName | `.mg-search__result-site-name` (unchanged) | `.mg-search__result-site-name` |

### Files changed

- **`SyndicationSearchWidget.scss`** — Simplified hide selectors from 14 lines to 7
- **`constants.js`** — Updated JSDoc for `buildHiddenFieldClasses`
- **`SyndicationSearchWidget.stories.jsx`** — Updated inline code example comments

## Test plan

- [ ] `yarn test` passes (buildHiddenFieldClasses tests)
- [ ] `yarn scss` compiles without errors
- [ ] Verify `visibleTeaserFields` hiding works in Storybook (HiddenFields story)
- [ ] After Drupal templates are updated (web-backlog#2660) and search index is rebuilt, verify hiding works on live search results