### PR TITLE
fix(deps): resolve @tootallnate/once security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
     "vanilla-cookieconsent": "^3.1.0"
   },
   "resolutions": {
-    "@storybook/react/webpack": "5"
+    "@storybook/react/webpack": "5",
+    "http-proxy-agent": "^7.0.0"
   },
   "engine": {
     "node": ">=18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,13 +4171,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: 10/ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
-  languageName: node
-  linkType: hard
-
 "@trysound/sax@npm:0.2.0":
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
@@ -11563,18 +11556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
-  dependencies:
-    "@tootallnate/once": "npm:2"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10/5ee19423bc3e0fd5f23ce991b0755699ad2a46a440ce9cec99e8126bb98448ad3479d2c0ea54be5519db5b19a4ffaa69616bac01540db18506dd4dac3dc418f0
-  languageName: node
-  linkType: hard
-
-"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
+"http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:


### PR DESCRIPTION
## Summary

- Adds a `resolutions` override to force `http-proxy-agent` to `^7.0.0`, eliminating the vulnerable `@tootallnate/once@2.0.0` transitive dependency
- Fixes the Dependabot `security_update_not_possible` error for `@tootallnate/once` ([failed run](https://github.com/unisdr/undrr-mangrove/actions/runs/22923824715))
- Root cause: `storybook-design-token` → `jsdom@21` → `http-proxy-agent@5` → `@tootallnate/once@2` (fix requires v3.0.1, but v5 pins to v2). `http-proxy-agent@7` drops `@tootallnate/once` entirely

## Test plan

- [x] All 332 tests pass
- [x] `yarn why @tootallnate/once` returns no results
- [x] `yarn why http-proxy-agent` shows all instances at v7.0.2
- [ ] Verify Storybook dev server starts correctly
- [ ] Verify design token doc pages render (Colors, Typography, Spacing, Breakpoints)