### PR TITLE
fix: add missing SCSS redirect for TableOfContents

### DIFF
--- a/stories/Components/TableOfContents/TableOfContents.scss
+++ b/stories/Components/TableOfContents/TableOfContents.scss
@@ -1,0 +1,3 @@
+// TableOfContents.scss — DEPRECATED, use table-of-contents.scss
+@import "./table-of-contents";
+@warn "TableOfContents.scss is deprecated. Import table-of-contents.scss instead.";


### PR DESCRIPTION
## Summary
- The kebab-case SCSS rename in #861 deleted `TableOfContents.scss` without leaving a deprecation redirect, unlike SyndicationSearchWidget, FullWidth, and ShowMore which all got redirects
- This broke Drupal's Sass build (`undrr_common/scss/_mangrove-components.scss` line 45 imports the old PascalCase path)
- Adds a matching shallow redirect: `@import "./table-of-contents"` + `@warn` deprecation notice

## Test plan
- [ ] Drupal Sass build (`cd docroot/themes/custom/undrr && sass scss/mangrove/mangrove.scss`) compiles without error
- [ ] Storybook `yarn scss` compiles without error
- [ ] Deprecation warning appears in Sass output referencing the old filename