### PR TITLE
docs: use versioned CDN paths instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,14 +262,11 @@ For CDN and static asset hosting in the [UNDRR Static assets repo](https://gitla
 
 ### Production CDN
 
-All assets are now served from versioned endpoints for stability:
+Production sites should pin to a specific version:
 
 ```
 https://assets.undrr.org/static/sitemap.html#mangrove-1-2-10
 https://assets.undrr.org/static/mangrove/README.md
-https://assets.undrr.org/static/mangrove/latest/css/style.css
-https://assets.undrr.org/static/mangrove/latest/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/latest/js/tabs.js
 https://assets.undrr.org/static/mangrove/1.4.0/css/style.css
 https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js
 https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js

--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -179,21 +179,21 @@ Use these static HTML pages directly from the CDN when integrating with CDNs or 
 
 **Cloudflare-specific templates:**
 ```text
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/5xx.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/challenge.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/managed-challenge.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/5xx.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/challenge.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/managed-challenge.html
 ```
 
 **Individual error pages** (for platforms that support per-code configuration):
 ```text
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/401.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/403.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/404.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/429.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/500.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/502.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/503.html
-https://assets.undrr.org/static/mangrove/latest/assets/error-pages/504.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/401.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/403.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/404.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/429.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/500.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/502.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/503.html
+https://assets.undrr.org/static/mangrove/1.4.0/error-pages/504.html
 ```
 
 ## CSS and JS references

--- a/stories/Components/OnThisPageNav/OnThisPageNav.mdx
+++ b/stories/Components/OnThisPageNav/OnThisPageNav.mdx
@@ -147,7 +147,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 </nav>
 
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/testing/static/mangrove/latest/assets/js/on-this-page-nav.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.0/js/on-this-page-nav.js"></script>
 ```
 
 ## Skipping auto-initialization
@@ -162,7 +162,7 @@ Add `data-mg-on-this-page-nav-skip-auto-init` to skip a nav during auto-init. Th
 </nav>
 
 <script type="module">
-  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/latest/assets/js/on-this-page-nav.js';
+  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/on-this-page-nav.js';
   // Initialize after other setup is complete
   mgOnThisPageNav([document.querySelector('[data-mg-on-this-page-nav-skip-auto-init]')]);
 </script>


### PR DESCRIPTION
## Summary

- Replace `/latest/assets/js/` and `/latest/assets/error-pages/` URLs with pinned versioned paths (`1.4.0/js/`, `1.4.0/error-pages/`) in README, OnThisPageNav, and ErrorPage docs
- The `latest` endpoint has a different directory layout than versioned npm builds (`assets/js/` vs `js/`), which was causing confusion and broken examples
- Production should always pin to a version

## Files changed

- **README.md** — removed `latest` examples from the "Production CDN" section
- **OnThisPageNav.mdx** — two CDN examples updated
- **ErrorPage.mdx** — all Cloudflare error page CDN links updated

## Related

- https://gitlab.com/undrr/web-backlog/-/work_items/2742