### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ Production sites should pin to a specific version:
 ```
 https://assets.undrr.org/static/sitemap.html#mangrove-1-2-10
 https://assets.undrr.org/static/mangrove/README.md
-https://assets.undrr.org/static/mangrove/1.4.0/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
+https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js
 ```
 
 #### Bleeding edge test rep
@@ -277,7 +277,7 @@ https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js
 ```
 https://assets.undrr.org/testing/static/sitemap.html#mangrove-1-2-4
 https://assets.undrr.org/testing/static/mangrove/latest/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.0/css/style.css
+https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
 ... etc
 ```
 

--- a/docs/CDN-REFERENCE.md
+++ b/docs/CDN-REFERENCE.md
@@ -36,7 +36,7 @@ The DELTA Resilience theme has no legacy variant.
 
 **Example:**
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
 ```
 
 ### JavaScript modules
@@ -49,7 +49,7 @@ The DELTA Resilience theme has no legacy variant.
 **Example:**
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
   mgTabs();
 </script>
 ```
@@ -101,7 +101,7 @@ Then import the Mangrove component as an ES module:
 
   // Load component from CDN
   const MegaMenuModule = await import(
-    'https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js'
+    'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
   );
 
   // Unwrap ESM/CJS interop - bundle may be double-wrapped
@@ -158,7 +158,7 @@ Base URL: `https://assets.undrr.org/static/logos/`
 Pin to a specific version for stability:
 
 ```
-https://assets.undrr.org/static/mangrove/1.4.0/css/style.css
+https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
 ```
 
 ### Latest (testing only)

--- a/docs/HYDRATION.md
+++ b/docs/HYDRATION.md
@@ -29,8 +29,8 @@ Related: [GitHub issue #803](https://github.com/unisdr/undrr-mangrove/issues/803
 <section data-mg-share-buttons data-main-label="Share this"></section>
 
 <script type="module">
-  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js';
-  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.0/components/ShareButtons.js';
+  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
+  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
   createHydrator({ selector: '[data-mg-share-buttons]', component: ShareButtons, fromElement });
 </script>
 ```

--- a/docs/RELEASE-1.4.md
+++ b/docs/RELEASE-1.4.md
@@ -130,10 +130,10 @@ Commit the CSS files to the Drupal repo and deploy. Nothing else changes.
 
 ```html
 <!-- Before (1.3.x) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.3.3/css/style.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css">
 
 <!-- After (1.4.0, using legacy variant) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-legacy.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-legacy.css">
 ```
 
 **For npm consumers loading compiled CSS:**

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -153,9 +153,9 @@ https://assets.undrr.org/testing/static/mangrove/latest/css/style.css
 https://assets.undrr.org/testing/static/mangrove/latest/components/MegaMenu.js
 
 # Versioned (from tagged releases)
-https://assets.undrr.org/static/mangrove/1.4.0/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
+https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js
 ```
 
 ## CI/CD configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@undrr/undrr-mangrove",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Mangrove design System for UNDRR",
   "main": "src/index.js",
   "type": "module",

--- a/stories/Atom/Layout/Grid/Grid.mdx
+++ b/stories/Atom/Layout/Grid/Grid.mdx
@@ -42,7 +42,7 @@ Use the grid to create a layout of your choice based on the design you want to a
 
 Add the base layout style from
 
-- https://assets.undrr.org/static/mangrove/1.4.0/assets/css/grid.min.css
+- https://assets.undrr.org/static/mangrove/1.4.1/assets/css/grid.min.css
 
 ## Changelog
 

--- a/stories/Components/Cards/IconCard/IconCard.mdx
+++ b/stories/Components/Cards/IconCard/IconCard.mdx
@@ -253,8 +253,8 @@ IconCard supports [layered hydration](https://github.com/unisdr/undrr-mangrove/b
 | `data-variant` | `'default'` | `'default'` or `'negative'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import IconCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/IconCard.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import IconCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/IconCard.js";
 createHydrator({ selector: "[data-mg-icon-card]", component: IconCard, fromElement });
 ```
 

--- a/stories/Components/Cards/StatsCard/StatsCard.mdx
+++ b/stories/Components/Cards/StatsCard/StatsCard.mdx
@@ -149,8 +149,8 @@ StatsCard supports [layered hydration](https://github.com/unisdr/undrr-mangrove/
 | `data-class-name` | `''` | Additional CSS class names |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import StatsCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/StatsCard.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import StatsCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/StatsCard.js";
 createHydrator({ selector: "[data-mg-stats-card]", component: StatsCard, fromElement });
 ```
 

--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -179,21 +179,21 @@ Use these static HTML pages directly from the CDN when integrating with CDNs or 
 
 **Cloudflare-specific templates:**
 ```text
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/5xx.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/challenge.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/managed-challenge.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/5xx.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/challenge.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/managed-challenge.html
 ```
 
 **Individual error pages** (for platforms that support per-code configuration):
 ```text
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/401.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/403.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/404.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/429.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/500.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/502.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/503.html
-https://assets.undrr.org/static/mangrove/1.4.0/error-pages/504.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/401.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/403.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/404.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/429.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/500.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/502.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/503.html
+https://assets.undrr.org/static/mangrove/1.4.1/error-pages/504.html
 ```
 
 ## CSS and JS references

--- a/stories/Components/ErrorPages/static/401.html
+++ b/stories/Components/ErrorPages/static/401.html
@@ -88,7 +88,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/403.html
+++ b/stories/Components/ErrorPages/static/403.html
@@ -84,7 +84,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/404.html
+++ b/stories/Components/ErrorPages/static/404.html
@@ -96,7 +96,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/429.html
+++ b/stories/Components/ErrorPages/static/429.html
@@ -91,7 +91,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/500.html
+++ b/stories/Components/ErrorPages/static/500.html
@@ -87,7 +87,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/502.html
+++ b/stories/Components/ErrorPages/static/502.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/503.html
+++ b/stories/Components/ErrorPages/static/503.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/504.html
+++ b/stories/Components/ErrorPages/static/504.html
@@ -87,7 +87,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/5xx.html
+++ b/stories/Components/ErrorPages/static/5xx.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/challenge.html
+++ b/stories/Components/ErrorPages/static/challenge.html
@@ -88,7 +88,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/managed-challenge.html
+++ b/stories/Components/ErrorPages/static/managed-challenge.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.0/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/Gallery/Gallery.mdx
+++ b/stories/Components/Gallery/Gallery.mdx
@@ -290,8 +290,8 @@ Gallery supports [layered hydration](https://github.com/unisdr/undrr-mangrove/bl
 | `data-loop` | `'false'` | Enable infinite loop navigation |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import { Gallery, fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/Gallery.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import { Gallery, fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/Gallery.js";
 createHydrator({ selector: "[data-mg-gallery]", component: Gallery, fromElement });
 ```
 

--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -158,8 +158,8 @@ MegaMenu supports [layered hydration](https://github.com/unisdr/undrr-mangrove/b
 In Drupal, the wrapper reads the prefixed form (`data-mg-mega-menu-logo-src`, `data-mg-mega-menu-logo-alt`, etc.) following the Drupal `data-mg-{component}-{prop}` convention. These override the `SITE_LOGOS` body class lookup. For CDN / vanilla HTML consumers, use the short `data-logo-*` names listed above (read by `fromElement`).
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import MegaMenu, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import MegaMenu, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js";
 createHydrator({ selector: "[data-mg-mega-menu]", component: MegaMenu, fromElement });
 ```
 

--- a/stories/Components/OnThisPageNav/OnThisPageNav.mdx
+++ b/stories/Components/OnThisPageNav/OnThisPageNav.mdx
@@ -147,7 +147,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 </nav>
 
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.0/js/on-this-page-nav.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/on-this-page-nav.js"></script>
 ```
 
 ## Skipping auto-initialization
@@ -162,7 +162,7 @@ Add `data-mg-on-this-page-nav-skip-auto-init` to skip a nav during auto-init. Th
 </nav>
 
 <script type="module">
-  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/on-this-page-nav.js';
+  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/on-this-page-nav.js';
   // Initialize after other setup is complete
   mgOnThisPageNav([document.querySelector('[data-mg-on-this-page-nav-skip-auto-init]')]);
 </script>

--- a/stories/Components/QuoteHighlight/QuoteHighlight.mdx
+++ b/stories/Components/QuoteHighlight/QuoteHighlight.mdx
@@ -189,8 +189,8 @@ QuoteHighlight supports [layered hydration](https://github.com/unisdr/undrr-mang
 | `data-alignment` | `'full'` | `'full'`, `'left'`, or `'right'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import QuoteHighlight, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/QuoteHighlight.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import QuoteHighlight, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/QuoteHighlight.js";
 createHydrator({ selector: "[data-mg-quote-highlight]", component: QuoteHighlight, fromElement });
 ```
 

--- a/stories/Components/ScrollContainer/ScrollContainer.mdx
+++ b/stories/Components/ScrollContainer/ScrollContainer.mdx
@@ -238,8 +238,8 @@ ScrollContainer supports [layered hydration](https://github.com/unisdr/undrr-man
 Child elements are extracted from a `.mg-scroll__content` wrapper inside the container. If no wrapper is found, the container's `innerHTML` is used directly.
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import ScrollContainer, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/ScrollContainer.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import ScrollContainer, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/ScrollContainer.js";
 createHydrator({ selector: "[data-mg-scroll-container]", component: ScrollContainer, fromElement });
 ```
 

--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
@@ -412,8 +412,8 @@ SyndicationSearchWidget supports [layered hydration](https://github.com/unisdr/u
 All attributes are optional. Only attributes present on the container are included in the config; the component uses its own defaults for anything missing.
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import SyndicationSearchWidget, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/SyndicationSearchWidget.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import SyndicationSearchWidget, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/SyndicationSearchWidget.js";
 createHydrator({ selector: "[data-mg-search-widget]", component: SyndicationSearchWidget, fromElement });
 ```
 

--- a/stories/Components/Tab/Tab.mdx
+++ b/stories/Components/Tab/Tab.mdx
@@ -72,7 +72,7 @@ Tabs are vanilla JavaScript. No React, no build step, just HTML and a script imp
 Pick the Mangrove theme stylesheet for your site ([CDN reference](/?path=/docs/getting-started-integration-cdn-reference--docs) lists all themes).
 
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
 ```
 
 #### 2. Include the JavaScript
@@ -81,7 +81,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 
 ```html
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js"></script>
 ```
 
 The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is already parsed). Module scripts are deferred by default, so `mgTabs()` runs after the DOM is available.
@@ -90,7 +90,7 @@ For manual or dynamic initialization, import the function:
 
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
   mgTabs();
 </script>
 ```
@@ -237,7 +237,7 @@ Add `data-mg-js-tabs-skip-auto-init` to skip a container during auto-init. This 
 </article>
 
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
   // Initialize after other setup is complete
   mgTabs([document.querySelector('[data-mg-js-tabs-skip-auto-init]')]);
 </script>

--- a/stories/Components/TableOfContents/TableOfContents.mdx
+++ b/stories/Components/TableOfContents/TableOfContents.mdx
@@ -81,7 +81,7 @@ standalone script from the UNDRR CDN (or npm as
 ```html
 <script
   type="module"
-  src="https://assets.undrr.org/static/mangrove/1.4.0/js/table-of-contents.js"
+  src="https://assets.undrr.org/static/mangrove/1.4.1/js/table-of-contents.js"
 ></script>
 ```
 
@@ -115,7 +115,7 @@ The script auto-initializes on `DOMContentLoaded`. For manual control, import th
 function directly:
 
 ```js
-import { mgTableOfContents } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/table-of-contents.js';
+import { mgTableOfContents } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/table-of-contents.js';
 
 const contentElement = document.querySelector('.mg-content');
 const tocElement = document.querySelector('[data-mg-table-of-contents]');

--- a/stories/Components/TextCta/TextCta.mdx
+++ b/stories/Components/TextCta/TextCta.mdx
@@ -108,8 +108,8 @@ TextCta supports [layered hydration](https://github.com/unisdr/undrr-mangrove/bl
 | `data-centered` | `'true'` | `'true'` or `'false'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js";
-import TextCta, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.0/components/TextCta.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
+import TextCta, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/TextCta.js";
 createHydrator({ selector: "[data-mg-text-cta]", component: TextCta, fromElement });
 ```
 

--- a/stories/Documentation/GettingStarted.mdx
+++ b/stories/Documentation/GettingStarted.mdx
@@ -47,7 +47,7 @@ Choose the approach that fits your project. Each guide has its own quick start w
 Include CSS via CDN and copy HTML structures from the component docs. No build step, no JavaScript required for most components.
 
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
 ```
 
 - [See on CodePen](https://codepen.io/khawkins98/pen/MYwbKwe) — a working page with footer widget, analytics, and messaging

--- a/stories/Documentation/ReactIntegration.mdx
+++ b/stories/Documentation/ReactIntegration.mdx
@@ -69,10 +69,10 @@ Load the compiled CSS from UNDRR's CDN. Pick the theme that matches your site:
 
 ```html
 <!-- UNDRR default theme -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
 
 <!-- Or a site-specific theme -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-preventionweb.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css" />
 ```
 
 Available theme files: `style.css`, `style-preventionweb.css`, `style-mcr.css`, `style-irp.css`, `style-delta.css`. Legacy variants (`style-legacy.css`, `style-preventionweb-legacy.css`, `style-mcr-legacy.css`, `style-irp-legacy.css`) are available for sites with custom CSS written for the pre-1.4 10px root. See the [v1.4 release notes](/docs/getting-started-release-notes-v1-4--docs) for details.

--- a/stories/Documentation/VanillaHtmlCss.mdx
+++ b/stories/Documentation/VanillaHtmlCss.mdx
@@ -49,11 +49,11 @@ Add these `<link>` tags to your HTML `<head>`:
     <!-- UNDRR Theme (Choose one) -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
     />
 
     <!-- Alternative: Prevention Web Theme -->
-    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-preventionweb.css"> -->
+    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css"> -->
   </head>
   <body>
     <!-- Your content here -->
@@ -103,7 +103,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
 />
 ```
 
@@ -112,7 +112,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css"
 />
 ```
 
@@ -121,7 +121,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-mcr.css"
+  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-mcr.css"
 />
 ```
 
@@ -130,7 +130,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-irp.css"
+  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-irp.css"
 />
 ```
 
@@ -139,7 +139,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.0/css/style-delta.css"
+  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-delta.css"
 />
 ```
 
@@ -231,7 +231,7 @@ Some components (like Tabs) have lightweight JavaScript modules:
 
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
 
   document.addEventListener('DOMContentLoaded', () => {
     mgTabs();
@@ -288,7 +288,7 @@ React 19 dropped UMD builds, so we use [import maps](https://developer.mozilla.o
 
     // Load component from CDN
     const MegaMenuModule = await import(
-      'https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js'
+      'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
     );
 
     // Unwrap ESM/CJS interop - bundle may be double-wrapped as { default: { default: Component } }
@@ -334,8 +334,8 @@ Components that support hydration (ShareButtons, ScrollContainer, QuoteHighlight
 
 ```html
 <script type="module">
-  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js';
-  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.0/components/ShareButtons.js';
+  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
+  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
 
   createHydrator({
     selector: '[data-mg-share-buttons]',
@@ -367,7 +367,7 @@ Components that don't yet export `fromElement` (BarChart, MapComponent, etc.) ca
   import React from 'react';
   import { createRoot } from 'react-dom/client';
   const MegaMenuModule = await import(
-    'https://assets.undrr.org/static/mangrove/1.4.0/components/MegaMenu.js'
+    'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
   );
   let MegaMenu = MegaMenuModule?.default ?? MegaMenuModule;
   if (typeof MegaMenu !== 'function' && MegaMenu?.default) {
@@ -402,7 +402,7 @@ A self-contained page you can save as an `.html` file and open in a browser. It 
     <!-- Mangrove CSS theme -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.4.0/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
     />
 
     <!-- Import map: provides React to Mangrove ES module bundles -->
@@ -432,8 +432,8 @@ A self-contained page you can save as an `.html` file and open in a browser. It 
 
     <!-- Load the hydration runtime and component, then mount -->
     <script type="module">
-      import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.0/components/hydrate.js';
-      import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.0/components/ShareButtons.js';
+      import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
+      import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
 
       createHydrator({
         selector: '[data-mg-share-buttons]',

--- a/stories/Utilities/ShowMore/ShowMore.mdx
+++ b/stories/Utilities/ShowMore/ShowMore.mdx
@@ -60,7 +60,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 
 <Source language="html" code={`
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.0/js/show-more.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js"></script>
 `} />
 
 The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is already parsed). Module scripts are deferred by default, so no wrapper is needed.
@@ -68,7 +68,7 @@ The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is 
 For dynamically added content, import and call the init function:
 
 <Source language="js" code={`
-import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/show-more.js';
+import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js';
 
 // Initialize specific buttons
 mgShowMore([myButton]);
@@ -89,7 +89,7 @@ Add `data-mg-show-more-skip-auto-init` to skip a button during auto-init. This i
    data-mg-show-more-target=".my-content">Show more</a>
 
 <script type="module">
-  import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.0/js/show-more.js';
+  import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js';
   // Initialize after other setup is complete
   mgShowMore([document.querySelector('[data-mg-show-more-skip-auto-init]')]);
 </script>


### PR DESCRIPTION
## Summary

Prepare patch release v1.4.1.

- Bump `version` in `package.json` from 1.4.0 → 1.4.1
- Update all CDN links across 33 files (docs, stories, error pages) to reference `/static/mangrove/1.4.1/`

### Changes since v1.4.0

- **feat**: publish TableOfContents vanilla JS as standalone asset (#901)
- **feat**: named z-index tokens for global stacking contexts (#889)
- **feat**: OnThisPageNav scroll arrow buttons for horizontal overflow (#888)
- **feat**: standardize vanilla JS component lifecycle (#886)
- **feat**: OnThisPageNav sticky horizontal navigation (#879)
- **fix**: card alignment, button contrast, and theme token improvements (#872)
- **fix**: add missing SCSS redirect for TableOfContents (#877)
- **fix**: remove debug logging from build and fix encoding issue
- **docs**: use versioned CDN paths instead of latest (#902)
- **docs**: add DELTA Resilience CodePen as vanilla HTML + hydration example
- **ci**: fix storybook path filters and concurrency group naming
- **ci**: add path filters, caching, and concurrency to workflows (#887)
- **chore**: batch dependency updates 2026-03-26 (#882)

### Pre-release checks

- [x] Tests: 608/608 passed (39 suites)
- [x] Lint: clean
- [x] Build: compiled successfully
- [x] AI manifest: validation passed

## Test plan

- [ ] Verify CDN URLs reference `1.4.1` in Storybook docs
- [ ] Confirm `package.json` version is `1.4.1`
- [ ] After merge: tag `v1.4.0` → push tag → verify npm publish workflow triggers