### PR TITLE
docs: write for two audiences — consumers and maintainers

### DIFF
--- a/docs/COMPONENT-GUIDE.md
+++ b/docs/COMPONENT-GUIDE.md
@@ -84,6 +84,29 @@ Create `stories/Components/{Category}/{ComponentName}/__tests__/{ComponentName}.
 
 Create `stories/Components/{Category}/{ComponentName}/{ComponentName}.mdx` with overview, usage examples, props table, CSS class reference, and changelog. See `Pager.mdx` for the full structure and the [component standards](https://unisdr.github.io/undrr-mangrove/?path=/docs/contributing-component-standards--docs) for documentation requirements.
 
+### Write for two audiences
+
+Component MDX docs serve two very different readers. Structure content so each can get what they need without wading through what they don't.
+
+**Consumers** (people integrating the component) scan, not read. Lead with a one-sentence description, a working `<Canvas>` example, and a props table. One sentence of context is enough — they don't need to know how it works internally.
+
+**Maintainers** (contributors, reviewers, on-call debuggers) need the "why": design decisions, edge cases, known limitations, and historical context. This belongs at the end of the document, or in a clearly labelled section.
+
+Structure your MDX in this order:
+1. What it does (one sentence)
+2. Live examples (`<Canvas>`)
+3. How to use it (usage snippet + props table)
+4. Behaviours and constraints
+5. Accessibility
+6. Implementation notes / known limitations (maintainer depth)
+7. Server-rendered / CDN usage (if applicable)
+8. Changelog
+
+Avoid explaining implementation internals in the usage or props sections. If you find yourself writing "internally, this component does X because Y", that belongs at the bottom or in a code comment — not in the consumer-facing usage guide.
+
+See [Writing guidelines — Write for two audiences](WRITING.md) for the full principle.
+
+
 **Add a review checklist reference** right after the `<Meta>` block. Adjust the relative path based on file depth (`../../../` for depth-3 components like `Pager/`, `../../../../` for depth-4 like `Cards/Card/`):
 
 ```mdx

--- a/docs/COMPONENT-GUIDE.md
+++ b/docs/COMPONENT-GUIDE.md
@@ -96,7 +96,7 @@ Structure your MDX in this order:
 1. What it does (one sentence)
 2. Live examples (`<Canvas>`)
 3. How to use it (usage snippet + props table)
-4. Behaviours and constraints
+4. Behaviors and constraints
 5. Accessibility
 6. Implementation notes / known limitations (maintainer depth)
 7. Server-rendered / CDN usage (if applicable)

--- a/docs/WRITING-SHORT.md
+++ b/docs/WRITING-SHORT.md
@@ -10,6 +10,11 @@ Use this as a compact, LLM‑friendly summary of the Mangrove Writing standards.
 6. Remove unnecessary words — if design alone works, skip text.
 7. Consistency — same terminology, tone, and style everywhere.
 8. Strong writing basics — active voice, plain language, clarity, rhythm.
+9. Write for two audiences — consumers scan (give them a description + example + props); maintainers read for the “why” (design decisions, edge cases, history). Don’t conflate them in one document.
+
+Layer your docs: what it does → how to use it → why it works that way. Keep the “why” at the end or behind a details block.
+
+> “Too much information and no information accomplish the same goal.” — Ibrahim Diallo
 
 Also:
 
@@ -45,6 +50,8 @@ UN guidance:
 - [Mailchimp content style guide](https://styleguide.mailchimp.com/)
 
 Originally inspired by Nick DiLallo’s “This is good Writing — Eight principles for every interface you’ll ever write” ([UX Collective, 2020](https://uxdesign.cc/this-is-good-ux-writing-10c4b956a6c3)).
+
+The “Write for two audiences” principle is inspired by Ibrahim Diallo’s “[How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)” (2025).
 
 ## Related documentation
 

--- a/docs/WRITING.md
+++ b/docs/WRITING.md
@@ -38,6 +38,27 @@ This guide helps anyone contributing to Mangrove write interface copy, documenta
 - Example: On a tracking page, show “Arrives tomorrow” before “Order #123456.”
 - Reference: [GOV.UK — front‑load your content](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#front-load-your-content)
 
+## Write for two audiences
+
+Technical documentation — especially component docs — serves two distinct audiences with different needs. Confusing them produces documentation that serves neither.
+
+**Consumers** (integrators, builders) scan like a menu. They want to know: does this component do what I need, and what props does it take? Give them a one-line description, a working example, and a props table. That is often enough. Resist the urge to explain your internals.
+
+**Maintainers** (library contributors, on-call debuggers) need the full picture: why a prop exists, why there are two data sources, why a field is sometimes null, what a past breaking change affected. This context prevents future developers from “fixing” things that weren’t broken.
+
+The failure mode is writing one document that tries to serve both equally — too deep to skim, not structured enough to dig into. Instead:
+
+- Lead with what it does
+- Follow with how to use it (example first, then props)
+- Place the “why” at the end, or in a collapsed details block
+
+> “Too much information and no information accomplish the same goal.”
+> — Ibrahim Diallo, [How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)
+
+Also apply this at the API/component design level: consistent naming patterns mean consumers can guess correctly without reading anything. When ` /user/orders` works, `/user/orders/123` should just work too.
+
+Reference: [Ibrahim Diallo — How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)
+
 ## Serve a functional purpose
 
 - Every piece of copy should guide, explain, or prevent errors — never filler.
@@ -163,4 +184,5 @@ Reference: [UN disability‑inclusive communications guidelines (PDF)](https://d
 ## Acknowledgements and sources
 
 - Originally inspired by Nick DiLallo’s “This is good Writing — Eight principles for every interface you’ll ever write” ([UX Collective, 2020](https://uxdesign.cc/this-is-good-ux-writing-10c4b956a6c3)).
+- The “Write for two audiences” section is inspired by Ibrahim Diallo’s “[How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)” (2025).
 - Additional references are listed above in each section.

--- a/docs/WRITING.md
+++ b/docs/WRITING.md
@@ -55,7 +55,7 @@ The failure mode is writing one document that tries to serve both equally — to
 > “Too much information and no information accomplish the same goal.”
 > — Ibrahim Diallo, [How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)
 
-Also apply this at the API/component design level: consistent naming patterns mean consumers can guess correctly without reading anything. When ` /user/orders` works, `/user/orders/123` should just work too.
+Also apply this at the API/component design level: consistent naming patterns mean consumers can guess correctly without reading anything. When `/user/orders` works, `/user/orders/123` should just work too.
 
 Reference: [Ibrahim Diallo — How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)
 

--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -55,9 +55,7 @@ import { MegaMenu } from '@components';
 
 ### Multilingual sites and language-prefixed logo links
 
-`logoHref` defaults to `'/'`. The component doesn't know or care about language prefixes (`/ar/`, `/fr/`, etc.) because URL structure varies between CMSs.
-
-In Drupal, have the Twig template output the language-prefixed root into a data attribute. The wrapper reads `data-mg-mega-menu-logo-*` attributes, which override the default `SITE_LOGOS` body class lookup. Example for an Arabic page:
+Pass the language-prefixed root path to `logoHref` (for example, `"/ar/"` for Arabic). In Drupal, output this from Twig into the `data-mg-mega-menu-logo-href` attribute:
 
 ```html
 <div data-mg-mega-menu
@@ -67,7 +65,7 @@ In Drupal, have the Twig template output the language-prefixed root into a data 
 </div>
 ```
 
-Twig is the right place to resolve the prefix. The React component just renders whatever href it receives. If no logo data attributes are set, the Drupal wrapper falls back to a `SITE_LOGOS` map that resolves the logo from the body class (e.g., `mg-current-domain--www-preventionweb-net`).
+`logoHref` defaults to `'/'`. If no logo data attributes are set, the Drupal wrapper resolves the logo from the page's body class (for example, `mg-current-domain--www-preventionweb-net`).
 
 ## Props
 
@@ -155,7 +153,7 @@ MegaMenu supports [layered hydration](https://github.com/unisdr/undrr-mangrove/b
 | `data-logo-width` | — | Explicit width for CLS prevention |
 | `data-logo-height` | — | Explicit height for CLS prevention |
 
-In Drupal, the wrapper reads the prefixed form (`data-mg-mega-menu-logo-src`, `data-mg-mega-menu-logo-alt`, etc.) following the Drupal `data-mg-{component}-{prop}` convention. These override the `SITE_LOGOS` body class lookup. For CDN / vanilla HTML consumers, use the short `data-logo-*` names listed above (read by `fromElement`).
+> **Drupal note:** The Drupal wrapper reads prefixed attribute names (`data-mg-mega-menu-logo-src`, etc.) and falls back to a `SITE_LOGOS` body-class map when no logo attributes are set. CDN / vanilla HTML consumers use the short `data-logo-*` names above.
 
 ```js
 import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";

--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -65,7 +65,7 @@ Pass the language-prefixed root path to `logoHref` (for example, `"/ar/"` for Ar
 </div>
 ```
 
-`logoHref` defaults to `'/'`. If no logo data attributes are set, the Drupal wrapper resolves the logo from the page's body class (for example, `mg-current-domain--www-preventionweb-net`).
+`logoHref` defaults to `'/'` unless your CMS or wrapper provides a different value. If logo asset data attributes are not set, the Drupal wrapper resolves `logoSrc` and `logoAlt` from the page's body class (for example, `mg-current-domain--www-preventionweb-net`). `logoHref` is not inferred from the body class — it must be passed explicitly for language-prefixed URLs.
 
 ## Props
 

--- a/stories/Components/ScrollContainer/ScrollContainer.mdx
+++ b/stories/Components/ScrollContainer/ScrollContainer.mdx
@@ -207,9 +207,9 @@ These are gaps that affect users or accessibility auditors:
 - The arrow button group has no accessible label describing its purpose
 - There are no live announcements when the scroll position changes
 - No keyboard equivalent for mouse drag scrolling beyond the arrow buttons
-- Arrow buttons do not appear on small viewports, including for keyboard users on touch-screen laptops
+- Arrow buttons may be hidden on devices classified as mobile by the component's JavaScript touch/user-agent detection, including some iPads or other misclassified devices
 
-> **Implementation note (for contributors):** The `<section>` and `<nav>` elements lack ARIA labels; there is no `role="region"` or live region on the scroll container itself. Arrow button visibility on small viewports is controlled by a JavaScript mobile-detection check rather than CSS, which is why it applies to all small screens regardless of input type.
+> **Implementation note (for contributors):** The `<section>` and `<nav>` elements lack ARIA labels; there is no `role="region"` or live region on the scroll container itself. Arrow button visibility is controlled by a JavaScript mobile-detection check (`ontouchstart` plus a mobile/iPad user-agent match), not by viewport size or CSS breakpoints, so the limitation affects devices detected as mobile rather than all small screens.
 
 ## Server-rendered / CDN usage
 

--- a/stories/Components/ScrollContainer/ScrollContainer.mdx
+++ b/stories/Components/ScrollContainer/ScrollContainer.mdx
@@ -201,11 +201,15 @@ The scroll container itself does not implement custom keyboard event handlers. U
 
 ### Known limitations
 
-- The `<section>` element has no `aria-label` or `aria-labelledby`, so screen readers may announce it as an unlabelled section
-- The `<nav>` wrapper around arrow buttons has no `aria-label` to describe its purpose
-- There is no `role="region"` or similar on the scrollable container itself, and no live announcements when the scroll position changes
-- On desktop, mouse drag scrolling works, but there is no equivalent keyboard-based drag interaction beyond the arrow buttons
-- Arrow buttons are hidden on mobile devices via a JavaScript mobile detection check rather than CSS, meaning they may not appear for keyboard users on small viewports
+These are gaps that affect users or accessibility auditors:
+
+- Screen readers may announce the scroll container as an unlabelled section (the `<section>` has no `aria-label`)
+- The arrow button group has no accessible label describing its purpose
+- There are no live announcements when the scroll position changes
+- No keyboard equivalent for mouse drag scrolling beyond the arrow buttons
+- Arrow buttons do not appear on small viewports, including for keyboard users on touch-screen laptops
+
+> **Implementation note (for contributors):** The `<section>` and `<nav>` elements lack ARIA labels; there is no `role="region"` or live region on the scroll container itself. Arrow button visibility on small viewports is controlled by a JavaScript mobile-detection check rather than CSS, which is why it applies to all small screens regardless of input type.
 
 ## Server-rendered / CDN usage
 


### PR DESCRIPTION
## What

Adds a new `Write for two audiences` section to the writing guidelines, and applies the principle to two sample component docs.

Inspired by Ibrahim Diallo's *[How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)* (2025).

## Why

Our component MDX docs currently conflate two very different readers:

- **Consumers** (integrators, Drupal/React builders) scan for: does it do what I need, what are the props, give me an example.
- **Maintainers** (contributors, reviewers, on-call debuggers) need the *why*: design decisions, edge cases, historical context.

Writing one document that serves both equally produces docs that are too deep to skim and not structured enough to dig into — the equivalent of no documentation at all.

## Changes

### Guidelines updated

- **`docs/WRITING.md`** — new `Write for two audiences` section with the consumer/maintainer distinction, layered structure (what → how → why), the overexplaining trap, and consistent API design as implicit documentation. Credit added to Acknowledgements.
- **`docs/WRITING-SHORT.md`** — quick-reference additions including the Diallo maxim.
- **`docs/COMPONENT-GUIDE.md` Step 5** — explicit MDX section ordering and guidance on keeping implementation rationale out of usage sections.

### Sample applications (not a full rewrite)

- **`MegaMenu.mdx`** — simplified the multilingual `logoHref` section to lead with the consumer answer (pass the prefix; here's the HTML); moved Drupal internals (SITE_LOGOS body-class fallback) to a callout note rather than mid-prose.
- **`ScrollContainer.mdx`** — rewrote the accessibility known limitations list to lead with user impact (what a user or auditor would observe); moved implementation causes (JS mobile detection, missing ARIA labels) to a contributor note.

## Credit

> "Too much information and no information accomplish the same goal."  
> — Ibrahim Diallo, [How do we get developers to read the docs?](https://idiallo.com/blog/how-do-we-get-developers-to-read-the-docs)