### PR TITLE
fix: fromElement parses customFilters, customFacets, visibleTeaserFields

### DIFF
--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.fromElement.js
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.fromElement.js
@@ -3,8 +3,7 @@
  *
  * SyndicationSearchWidget is a complex-tier component: most config values
  * have sensible defaults, so only attributes explicitly set on the container
- * are included. Consumer wrappers (Layer 3) can merge additional config
- * (customFacets, customFilters, etc.) that is too complex for data attributes.
+ * are included.
  */
 export default function syndicationSearchWidgetFromElement(container) {
   const { dataset } = container;
@@ -70,6 +69,27 @@ export default function syndicationSearchWidgetFromElement(container) {
   if (dataset.longevityTiers) {
     try {
       config.longevityTiers = JSON.parse(dataset.longevityTiers);
+    } catch {
+      /* ignore malformed JSON */
+    }
+  }
+  if (dataset.customFilters) {
+    try {
+      config.customFilters = JSON.parse(dataset.customFilters);
+    } catch {
+      /* ignore malformed JSON */
+    }
+  }
+  if (dataset.customFacets) {
+    try {
+      config.customFacets = JSON.parse(dataset.customFacets);
+    } catch {
+      /* ignore malformed JSON */
+    }
+  }
+  if (dataset.visibleTeaserFields) {
+    try {
+      config.visibleTeaserFields = JSON.parse(dataset.visibleTeaserFields);
     } catch {
       /* ignore malformed JSON */
     }

--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
@@ -408,6 +408,9 @@ SyndicationSearchWidget supports [layered hydration](https://github.com/unisdr/u
 | `data-require-image` | — | Only return results with images (`true`/`false`) |
 | `data-interestingness-tiers` | — | JSON array of tier names (e.g., `'["promoted","announced"]'`) |
 | `data-longevity-tiers` | — | JSON array of tier names (e.g., `'["year","longtime","always"]'`) |
+| `data-custom-filters` | — | JSON array of custom filter strings (e.g., `'["type:news"]'`) |
+| `data-custom-facets` | — | JSON array of custom facet objects |
+| `data-visible-teaser-fields` | — | JSON array of teaser field names to show |
 
 All attributes are optional. Only attributes present on the container are included in the config; the component uses its own defaults for anything missing.
 
@@ -421,6 +424,7 @@ See the [hydration guide](https://github.com/unisdr/undrr-mangrove/blob/main/doc
 
 ## Changelog
 
+- **1.2.4** — 2026-04-09 ([web-backlog#919](https://github.com/unisdr/undrr-mangrove/issues/919)): `fromElement` now parses `data-custom-filters`, `data-custom-facets`, and `data-visible-teaser-fields` as JSON, consistent with `defaultFilters` and `allowedTypes`
 - **1.2.3** — 2026-03-19 ([web-backlog#2630](https://gitlab.com/undrr/web-backlog/-/work_items/2630)): When both `siteName` and `contentType` are hidden via `visibleTeaserFields`, the `.mg-search__result-badges` wrapper div is no longer injected into the DOM. Previously the empty wrapper was still rendered and hidden by CSS.
 - **1.2.2** — 2026-03-19: Fixed search input UI bounce — `useDeferredValue` stale flag was triggering heavy visual feedback (progress bar, button text swap, pulsing overlay, opacity drop) on every keystroke; now only `isLoading` and `isPending` drive visual indicators; increased default `debounceDelay` from 300ms to 500ms to reduce wasted API calls while staying under the 1-second perceived delay threshold; fixed `?text=` and `?query=` URL parameters being ignored due to race condition where `INITIALIZE` action overwrote the query set by `useHashSync`
 - **1.2.1** — 2026-03-13: ([web-backlog#2660](https://gitlab.com/undrr/web-backlog/-/issues/2660)) Native `requireImage`, `interestingnessTiers`, `longevityTiers` config options (moved from Drupal wrapper); `TEASER_FIELDS` constant and `allTeaserFieldsVisible()` as single source of truth for teaser field visibility; ES query optimization (skip aggs/highlights/post_filter for syndication embeds); card-aware loading skeletons; SyndicatedCards story pattern

--- a/stories/Components/SyndicationSearchWidget/__tests__/SyndicationSearchWidget.fromElement.test.js
+++ b/stories/Components/SyndicationSearchWidget/__tests__/SyndicationSearchWidget.fromElement.test.js
@@ -134,4 +134,41 @@ describe('syndicationSearchWidgetFromElement', () => {
     expect(config).not.toHaveProperty('interestingnessTiers');
     expect(config).not.toHaveProperty('longevityTiers');
   });
+
+  it('parses JSON customFilters', () => {
+    const filters = ['type:news', 'region:asia'];
+    const { config } = syndicationSearchWidgetFromElement(
+      makeContainer({ 'custom-filters': JSON.stringify(filters) })
+    );
+    expect(config.customFilters).toEqual(filters);
+  });
+
+  it('parses JSON customFacets', () => {
+    const facets = [{ field: 'region', label: 'Region' }];
+    const { config } = syndicationSearchWidgetFromElement(
+      makeContainer({ 'custom-facets': JSON.stringify(facets) })
+    );
+    expect(config.customFacets).toEqual(facets);
+  });
+
+  it('parses JSON visibleTeaserFields', () => {
+    const fields = ['title', 'date'];
+    const { config } = syndicationSearchWidgetFromElement(
+      makeContainer({ 'visible-teaser-fields': JSON.stringify(fields) })
+    );
+    expect(config.visibleTeaserFields).toEqual(fields);
+  });
+
+  it('ignores malformed JSON for customFilters, customFacets, visibleTeaserFields', () => {
+    const { config } = syndicationSearchWidgetFromElement(
+      makeContainer({
+        'custom-filters': 'not-json',
+        'custom-facets': '{broken',
+        'visible-teaser-fields': '[bad',
+      })
+    );
+    expect(config).not.toHaveProperty('customFilters');
+    expect(config).not.toHaveProperty('customFacets');
+    expect(config).not.toHaveProperty('visibleTeaserFields');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #919

`SyndicationSearchWidget.fromElement.js` was silently ignoring `data-custom-filters`, `data-custom-facets`, and `data-visible-teaser-fields`. These are straightforward JSON props that follow the same pattern as `defaultFilters` and `allowedTypes`, which were already parsed.

## Changes

- **`SyndicationSearchWidget.fromElement.js`** — add JSON parsing for `customFilters`, `customFacets`, and `visibleTeaserFields`; remove outdated comment saying these were "too complex for data attributes"
- **`SyndicationSearchWidget.fromElement.test.js`** — four new tests: parse `customFilters`, parse `customFacets`, parse `visibleTeaserFields`, ignore malformed JSON for all three
- **`SyndicationSearchWidget.mdx`** — document the three new data attributes in the attribute reference table; add changelog entry for 1.2.4

## Breaking change assessment

Non-breaking. These attributes were previously ignored, so no consumer can rely on them being absent. Consumers who already wrap `fromElement` to parse these attributes are unaffected — the result is identical.