### PR TITLE
chore(release): v1.5.0 preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ Production sites should pin to a specific version:
 ```
 https://assets.undrr.org/static/sitemap.html#mangrove-1-2-10
 https://assets.undrr.org/static/mangrove/README.md
-https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
+https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js
 ```
 
 #### Bleeding edge test rep
@@ -277,7 +277,7 @@ https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js
 ```
 https://assets.undrr.org/testing/static/sitemap.html#mangrove-1-2-4
 https://assets.undrr.org/testing/static/mangrove/latest/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
+https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
 ... etc
 ```
 

--- a/docs/CDN-REFERENCE.md
+++ b/docs/CDN-REFERENCE.md
@@ -36,7 +36,7 @@ The DELTA Resilience theme has no legacy variant.
 
 **Example:**
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css" />
 ```
 
 ### JavaScript modules
@@ -49,7 +49,7 @@ The DELTA Resilience theme has no legacy variant.
 **Example:**
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js';
   mgTabs();
 </script>
 ```
@@ -101,7 +101,7 @@ Then import the Mangrove component as an ES module:
 
   // Load component from CDN
   const MegaMenuModule = await import(
-    'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
+    'https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js'
   );
 
   // Unwrap ESM/CJS interop - bundle may be double-wrapped
@@ -158,7 +158,7 @@ Base URL: `https://assets.undrr.org/static/logos/`
 Pin to a specific version for stability:
 
 ```
-https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
+https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
 ```
 
 ### Latest (testing only)

--- a/docs/CDN-REFERENCE.md
+++ b/docs/CDN-REFERENCE.md
@@ -45,6 +45,8 @@ The DELTA Resilience theme has no legacy variant.
 |--------|------|---------|
 | Tabs | `/js/tabs.js` | Tab component interactivity |
 | Show More | `/js/show-more.js` | Expand/collapse content sections |
+| On This Page Nav | `/js/on-this-page-nav.js` | Sticky heading nav with scroll-spy |
+| Table of Contents | `/js/table-of-contents.js` | Static page overview navigation |
 
 **Example:**
 ```html
@@ -193,7 +195,9 @@ https://assets.undrr.org/static/
 │       │   └── style-delta.css
 │       ├── js/
 │       │   ├── tabs.js
-│       │   └── show-more.js
+│       │   ├── show-more.js
+│       │   ├── on-this-page-nav.js
+│       │   └── table-of-contents.js
 │       └── components/
 │           ├── hydrate.js
 │           ├── ShareButtons.js

--- a/docs/HYDRATION.md
+++ b/docs/HYDRATION.md
@@ -29,8 +29,8 @@ Related: [GitHub issue #803](https://github.com/unisdr/undrr-mangrove/issues/803
 <section data-mg-share-buttons data-main-label="Share this"></section>
 
 <script type="module">
-  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
-  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
+  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js';
+  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.5.0/components/ShareButtons.js';
   createHydrator({ selector: '[data-mg-share-buttons]', component: ShareButtons, fromElement });
 </script>
 ```

--- a/docs/RELEASE-1.4.md
+++ b/docs/RELEASE-1.4.md
@@ -130,10 +130,10 @@ Commit the CSS files to the Drupal repo and deploy. Nothing else changes.
 
 ```html
 <!-- Before (1.3.x) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css">
 
 <!-- After (1.4.0, using legacy variant) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-legacy.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-legacy.css">
 ```
 
 **For npm consumers loading compiled CSS:**

--- a/docs/RELEASE-1.4.md
+++ b/docs/RELEASE-1.4.md
@@ -130,10 +130,10 @@ Commit the CSS files to the Drupal repo and deploy. Nothing else changes.
 
 ```html
 <!-- Before (1.3.x) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css">
 
 <!-- After (1.4.0, using legacy variant) -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-legacy.css">
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-legacy.css">
 ```
 
 **For npm consumers loading compiled CSS:**

--- a/docs/RELEASE-1.5.md
+++ b/docs/RELEASE-1.5.md
@@ -1,52 +1,88 @@
 # Mangrove 1.5 release notes
 
-> Edits to this file show up on both [GitHub](https://github.com/unisdr/undrr-mangrove/blob/main/docs/RELEASE-1.5.md) and in [Storybook](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-release-notes-v1-5--docs).
+The main change in 1.5: icons now render via CSS `mask-image` instead of a font. The `fa-*` fallback classes remain in this release and HTML markup does not change. **If you use `fa-*` classes directly in Drupal templates, start auditing them now** — the font will be removed once Drupal-side references are confirmed clean. See the [icon migration roadmap](#icon-migration-roadmap-fa--mg-icon-) for the plan.
 
-The main change in 1.5: icons now render via CSS `mask-image` instead of a font. This is a visual improvement and a long-term maintenance win — the `fa-*` fallback classes remain in this release, and HTML markup does not change. **If you use `fa-*` classes directly in Drupal templates, this is your heads-up to begin planning a migration** — the font will be removed in a future release once Drupal-side references are cleaned up. See [the icon migration roadmap](#icon-migration-roadmap-fa--mg-icon-) for the full plan.
+> **If you manage a site that uses Mangrove:** UI control icons (search, navigation arrows, menus) will shift from filled/solid to outlined. Domain icons on cards and hazard imagery use OCHA filled icons and look similar to before. This is intentional — see [Visual style shift](#visual-style-shift). No HTML changes needed. If you use `fa-*` classes directly, they still work.
 
-> **If you manage a site that uses Mangrove:** your icons will look slightly different. Lucide icons are stroked/outlined; the old FontAwesome 4 icons were solid/filled. Both respond to the CSS `color` property. No HTML changes are required now. If you use `fa-*` classes directly (outside Mangrove components), they continue to work for this release — the font still loads.
+1.4.1 was a documentation-only patch with no functional changes. These notes cover everything since 1.4.0. Full diff: [v1.4.0...v1.5.0 on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.4.0...v1.5.0).
 
-1.4.1 was a patch release that shipped shortly after 1.4.0. These release notes cover everything since 1.4.0. For the complete diff, see the [v1.4.0...v1.5.0 comparison on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.4.0...v1.5.0).
+> _Edits here show up on both [GitHub](https://github.com/unisdr/undrr-mangrove/blob/main/docs/RELEASE-1.5.md) and in [Storybook](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-release-notes-v1-5--docs)._
+
+## Find your path
+
+| I am… | Go to… |
+|---|---|
+| A Drupal developer doing the upgrade | [Upgrading from 1.4.x](#upgrading-from-14x) |
+| A site manager asking "will anything look different?" | [Visual style shift](#visual-style-shift) |
+| An accessibility auditor | [Accessibility improvements](#accessibility-improvements) and [Known issues](#known-issues) |
+| Evaluating whether to use OnThisPageNav on a page | [New components](#new-components) |
+| Planning the `fa-*` → `mg-icon-*` migration | [Icon migration roadmap](#icon-migration-roadmap-fa--mg-icon-) |
+| A React / npm consumer | [Upgrading from 1.4.x](#upgrading-from-14x) — note the [breaking changes](#breaking-changes) |
 
 ## What's new since 1.4.0
 
 ### New components
 
-- **OnThisPageNav — sticky horizontal page navigation:** A new vanilla JS component that generates a sticky "On this page" bar from page headings (h2/h3/h4) or an explicit link list. Uses IntersectionObserver for scroll-spy, auto-scrolls the nav bar to keep the active link visible, and un-sticks on short viewports per [GOV.UK accessibility research](https://technology.blog.gov.uk/2018/05/21/sticky-elements-functionality-and-accessibility-testing/). Includes an optional pinned CTA, RTL support, configurable heading depth and content scope, and a `data-mg-on-this-page-nav-skip-auto-init` opt-out for manual initialization. ([#879](https://github.com/unisdr/undrr-mangrove/pull/879))
+- **OnThisPageNav — sticky horizontal page navigation** ([#879](https://github.com/unisdr/undrr-mangrove/pull/879)): A vanilla JS component that builds a sticky "On this page" bar from page headings (h2/h3/h4) or an explicit link list. Uses IntersectionObserver for scroll-spy with `aria-current` tracking, un-sticks on short viewports per [GOV.UK accessibility research](https://technology.blog.gov.uk/2018/05/21/sticky-elements-functionality-and-accessibility-testing/), and supports RTL, configurable heading depth, and an optional pinned CTA. Best on long landing pages and reports — [TableOfContents](https://unisdr.github.io/undrr-mangrove/?path=/docs/atoms-navigation-tableofcontents--docs) is lighter for short pages.
+
+  > **Known limitation:** The overflow fade gradient doesn't flip in RTL. Tracked, fix coming.
 
 ### New features
 
-- **Icon system overhaul — CSS mask-image rendering (phases 1–2):** Replaces Fontello/FontAwesome 4 glyph rendering with `mask-image` rules backed by inline SVG data URIs. Icon sources: [Lucide](https://lucide.dev) for UI icons (MIT licensed, 24×24 stroked paths), [OCHA Humanitarian Icons](https://github.com/UN-OCHA/humanitarian-icons) for domain icons (CC0-1.0), and custom SVGs for social media brand logos (Facebook, X/Twitter, LinkedIn, YouTube, Flickr) and the SDG color wheel. The old `@font-face` and all `fa-*` alias selectors are kept for backward compatibility. No markup changes. See [the full migration roadmap](#icon-migration-roadmap-fa--mg-icon-) below. ([#907](https://github.com/unisdr/undrr-mangrove/pull/907))
-- **TableOfContents: published as standalone vanilla JS asset:** `table-of-contents.js` is now auto-discovered by webpack and published to `dist/js/` and npm, following the same convention as `tabs.js` and `on-this-page-nav.js`. Supports auto-initialization from `data-mg-table-of-contents` and `data-mg-table-of-contents-skip-auto-init`. Enables Drupal to load it directly from the CDN import map. ([#901](https://github.com/unisdr/undrr-mangrove/pull/901))
-- **Named z-index tokens for global stacking contexts:** Nine new `$mg-z-index-*` SCSS variables replace the previous magic numbers scattered across component files. Nav-zone values (`nav: 10`, `sticky: 11`, `nav-toggle: 14`, `header: 22`) are frozen to avoid breaking Drupal theme CSS that was written against those values. Above that: `drawer: 2000`, `dropdown: 2500`, `modal: 5000`, `toast: 5500`. A new "Z-index layers" page in Storybook documents the full table and reasoning. ([#889](https://github.com/unisdr/undrr-mangrove/pull/889))
-- **OnThisPageNav: horizontal overflow scroll arrows:** Scroll `<` / `>` buttons appear when the nav bar has more items than fit in view, giving users a discoverable way to reach hidden links. Buttons are RTL-aware, manage keyboard focus when hidden, and respect `prefers-reduced-motion`. ([#888](https://github.com/unisdr/undrr-mangrove/pull/888))
-- **Vanilla JS lifecycle contract standardized:** `show-more.js`, `tabs.js`, and `on-this-page-nav.js` now share a consistent initialization contract: auto-init on `DOMContentLoaded`, `data-mg-*-skip-auto-init` opt-out for manual control, idempotency guard (safe to call init multiple times), and single-element scope. This makes all three safe to load as `type="module"` directly from the CDN without hand-copying the JS into Drupal. ([#886](https://github.com/unisdr/undrr-mangrove/pull/886))
+- **Icon system overhaul — CSS mask-image rendering (phases 1–2):** Replaces Fontello/FontAwesome 4 glyph rendering with `mask-image` rules backed by SVG data URIs. Sources: [Lucide](https://lucide.dev) for UI icons, [OCHA Humanitarian Icons](https://github.com/UN-OCHA/humanitarian-icons) for domain icons, custom SVGs for social logos. The old `@font-face` and `fa-*` selectors are kept for backward compatibility. No markup changes. See [Migration: icon system change](#migration-icon-system-change-150) and the [roadmap](#icon-migration-roadmap-fa--mg-icon-) below. ([#907](https://github.com/unisdr/undrr-mangrove/pull/907))
+- **TableOfContents and OnThisPageNav: published as standalone vanilla JS assets:** `table-of-contents.js` and `on-this-page-nav.js` are now published to `dist/js/` and the CDN, following the same convention as `tabs.js` and `show-more.js`. See the updated [CDN reference](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-integration-cdn-reference--docs) for the new module paths. ([#901](https://github.com/unisdr/undrr-mangrove/pull/901))
+- **Named z-index tokens for global stacking contexts** ([#889](https://github.com/unisdr/undrr-mangrove/pull/889)): Nine new `$mg-z-index-*` SCSS variables replace scattered magic numbers. Nav-zone values (`nav: 10`, `sticky: 11`, `nav-toggle: 14`, `header: 22`) are frozen; above that: `drawer: 2000`, `dropdown: 2500`, `modal: 5000`, `toast: 5500`; `$mg-z-index-behind: -1` for pseudo-element backgrounds. Range 23–1999 is unclaimed — available for custom Drupal elements above the header but below drawers. See the new "Z-index layers" page in Storybook.
+- **OnThisPageNav: horizontal overflow scroll arrows:** `<` / `>` buttons appear when the nav bar has more items than fit in view. Buttons are RTL-aware, manage keyboard focus when hidden (WCAG 2.4.3 Focus Order; 2.1.1 Keyboard), and respect `prefers-reduced-motion` (WCAG 2.3.3). ([#888](https://github.com/unisdr/undrr-mangrove/pull/888))
+- **Vanilla JS lifecycle contract standardized** ([#886](https://github.com/unisdr/undrr-mangrove/pull/886)): `show-more.js`, `tabs.js`, and `on-this-page-nav.js` share a consistent initialization contract: auto-init on `DOMContentLoaded`, `data-mg-*-skip-auto-init` opt-out, idempotency guard, single-element scope. All three are safe to load as `type="module"` directly from the CDN.
+
+### Accessibility improvements
+
+Several WCAG gaps from previous releases are closed in 1.5:
+
+- **Secondary button contrast** was 3.99:1, below the AA minimum of 4.5:1 (WCAG 1.4.3). It's now 6.49:1 (white on `$mg-color-blue-800`). If your site has an active accessibility audit, this closes that finding.
+- **Disabled button text** was nearly invisible at 1.39:1 (`neutral-400` bg / `neutral-300` text). It's now `neutral-500` background / white text at 5.74:1 (WCAG 1.4.3).
+- **Hero and CTA button focus rings in dark contexts** (WCAG 2.4.7): a solid `2px outline` now appears on `:focus-visible` for buttons on dark or hero backgrounds, replacing a near-invisible browser default.
+- **Icons in Windows High Contrast Mode** (WCAG 1.4.11): the mask-image icon system adds `forced-color-adjust: none` on `.mg-icon` and an explicit `background-color: CanvasText` fallback under `@media (forced-colors: active)`. Icons render in Edge forced-colors emulation and Windows HCM without any action on your part. See `icons.scss` for the rationale behind both rules.
+- **Screen readers and PUA characters** (WCAG 4.1.2): font glyphs used Unicode Private Use Area codepoints (`\e808`, etc.) that some screen reader / browser combinations announced aloud. The new `content: ""` approach is silent.
+- **MegaMenu links always clickable** (WCAG 2.1.1): the `pointer-events: none` restriction on nav items is now gated behind `.mg-mega-wrapper--js-active`. If your site's MegaMenu links were occasionally unresponsive on mobile, this was the cause. Plain-HTML nav, no-JS environments, and slow hydration all keep links clickable. ([#916](https://github.com/unisdr/undrr-mangrove/pull/916))
+- **OnThisPageNav: headings inside collapsed tab panels** (WCAG 2.1.1): the nav now opens any enclosing Mangrove tab panel before calculating scroll position. Headings inside hidden panels previously reported zero dimensions and caused the page to scroll to the top. ([#917](https://github.com/unisdr/undrr-mangrove/pull/917))
 
 ### Fixes
 
-- **Card alignment, button contrast, and theme tokens** — icon card images and icons are now start-aligned (were center-aligned); icon badge shape changed from circle to rounded square (`$mg-card-icon-badge-radius`). Secondary button color updated to meet WCAG AA contrast (was 3.99:1, now compliant). Disabled button updated from near-invisible neutral-400/neutral-300 to readable neutral-500/white. Hero and CTA buttons now show a `:focus-visible` ring in dark contexts. New tokens for secondary and hero button colors allow per-theme overrides. Dead `mg-button-arrow` variant removed. ([#872](https://github.com/unisdr/undrr-mangrove/pull/872))
-- **MegaMenu: mobile pointer-events via progressive enhancement** — the `pointer-events: none` restriction on `.mg-mega-topbar__item` is now gated behind `.mg-mega-wrapper--js-active`, a class added on mount. Plain-HTML nav, no-JS environments, and failed/slow hydration keep all links clickable on mobile. ([#916](https://github.com/unisdr/undrr-mangrove/pull/916))
-- **OnThisPageNav: scroll to headings inside collapsed tab panels** — the nav now opens any enclosing Mangrove tab panel before calculating scroll position. Headings inside hidden panels previously reported zero dimensions, causing the page to scroll to the top. Nested tab support included. ([#917](https://github.com/unisdr/undrr-mangrove/pull/917))
-- **SyndicationSearchWidget: `fromElement` parses `customFilters`, `customFacets`, `visibleTeaserFields`** — these three JSON props were previously silently ignored when mounting from HTML data attributes. ([#920](https://github.com/unisdr/undrr-mangrove/pull/920))
+- **Card alignment and theme tokens** — icon card images and icons are now start-aligned (were center-aligned); icon badge shape changed from circle to rounded square (`$mg-card-icon-badge-radius`); new tokens for secondary and hero button colors allow per-theme overrides. ([#872](https://github.com/unisdr/undrr-mangrove/pull/872))
+- **SyndicationSearchWidget: `fromElement` now correctly parses `customFilters`, `customFacets`, `visibleTeaserFields`** — these three JSON props were previously silently ignored when mounting from HTML `data-*` attributes (`data-custom-filters`, `data-custom-facets`, `data-visible-teaser-fields`). If you use the SyndicationSearchWidget with custom filters or facets configured via data attributes, **verify your configuration is working correctly after upgrading** — these attributes were silently dropped in all previous versions. ([#920](https://github.com/unisdr/undrr-mangrove/pull/920))
+- **Breadcrumb separator: CSS-only chevron** — the `li + li::before` separator now renders as a CSS border triangle instead of a font glyph (`\f105`). No markup changes required. Theme CSS that overrides the breadcrumb separator with a font icon rule should be reviewed to avoid a visual conflict with the new border properties.
 
 ### Documentation
 
-- Writing guidelines updated with a "write for two audiences" principle — consumer docs lead with what it does and how to use it; maintainer context (design decisions, edge cases, history) goes in a separate section or callout. Applied to MegaMenu and ScrollContainer docs. ([#910](https://github.com/unisdr/undrr-mangrove/pull/910))
+- Writing guidelines updated with a "write for two audiences" principle. Applied to MegaMenu and ScrollContainer docs. ([#910](https://github.com/unisdr/undrr-mangrove/pull/910))
 
 ### Tooling
 
 - Storybook 10.3.5, postcss 8.5.9 ([#918](https://github.com/unisdr/undrr-mangrove/pull/918))
 - Batch dependency updates ([#904](https://github.com/unisdr/undrr-mangrove/pull/904), [#882](https://github.com/unisdr/undrr-mangrove/pull/882))
 
+## Breaking changes
+
+### `mg-button-arrow` CSS class removed
+
+The `.mg-button-arrow` CSS variant has been removed. Any Drupal Twig template, custom module, or JavaScript that constructs a button with `class="mg-button mg-button-arrow"` will silently degrade — the element will render as a plain button with no additional styling. Search your templates and custom CSS before upgrading:
+
+```bash
+grep -rn "mg-button-arrow" themes/custom/ --include="*.twig" --include="*.html.twig" --include="*.css"
+```
+
+### `For_Primary` React prop removed from CtaButton
+
+The `For_Primary` prop on the `CtaButton` component was a no-op and has been removed. Passing it no longer has any effect. If you spread props onto `CtaButton`, verify the prop is not in your spread.
+
 ## Coming up
 
 ### Content schemas
 
-We are authoring JSON Schema files that define the canonical data contract for each Mangrove component — the fields any consumer (Drupal, Astro, static HTML) needs to render the component correctly. These schemas will ship alongside component JS in the npm package and CDN, making it possible to validate content against them before rendering and giving AI coding tools a precise, structured description of each component's data model.
+We're writing JSON Schema files that define the data contract for each Mangrove component — the fields any consumer (Drupal, Astro, plain HTML) needs to render it correctly. They'll ship alongside component JS in the npm package and CDN, so you can validate content before rendering and give AI tools a precise description of each component's data model.
 
-The initial set covers cards, statistics, quotes, navigation items, and share actions. A follow-on phase will use the schemas to align component prop names — currently some React props (`imgback`, `imgAlt`) diverge from the semantic names the schemas will define. That alignment will happen with a migration path, not a surprise breaking change.
-
-This work is tracked in [#881](https://github.com/unisdr/undrr-mangrove/issues/881), [#883](https://github.com/unisdr/undrr-mangrove/issues/883), and [#884](https://github.com/unisdr/undrr-mangrove/issues/884).
+The initial set covers cards, statistics, quotes, navigation items, and share actions. A follow-on phase will use the schemas to align component prop names — some React props (`imgback`, `imgAlt`) diverge from the semantic names the schemas will define. That alignment will happen with a migration path, not a surprise breaking change. This work is tracked in [#881](https://github.com/unisdr/undrr-mangrove/issues/881), [#883](https://github.com/unisdr/undrr-mangrove/issues/883), and [#884](https://github.com/unisdr/undrr-mangrove/issues/884).
 
 ### Icon migration roadmap: `fa-*` → `mg-icon-*`
 
@@ -59,40 +95,58 @@ The icon font is still loaded in 1.5 and `fa-*` classes still work. The full mig
 | 3 — Drupal migration | All `fa-*` references in Drupal Twig, PHP, and stories migrated to `mg-icon-*` | Planned |
 | 4 — Font removal | `@font-face`, `fa-*` selectors, and font files removed from Mangrove | Planned (after phase 3 in production) |
 
-Phase 4 will not happen until phase 3 is deployed and verified in production. If your Drupal templates or custom modules reference `fa-*` classes directly, **now is the right time to start auditing them**. The full issue with known `fa-*` usage locations and icons that need Mangrove equivalents is tracked in [#906](https://github.com/unisdr/undrr-mangrove/issues/906).
+Phase 4 will not happen until phase 3 is deployed and verified in production. `fa-*` classes also appear in CKEditor content, contributed module overrides, and custom block templates — not just theme Twig files. Start your audit now:
+
+```bash
+# Twig templates and PHP
+grep -rn "fa-" themes/custom/ --include="*.twig" --include="*.html.twig" --include="*.php"
+# Custom CSS
+grep -rn "fa-" themes/custom/ --include="*.css" --include="*.scss"
+```
+
+The full issue with known `fa-*` usage locations in Drupal and icons that need Mangrove equivalents is tracked in [#906](https://github.com/unisdr/undrr-mangrove/issues/906).
+
+## Known issues
+
+The following pre-existing issues ship unresolved in 1.5.0. They are tracked in [#908](https://github.com/unisdr/undrr-mangrove/issues/908).
+
+- **Button focus indicator on PreventionWeb (WCAG 2.4.11):** The standard `.mg-button:focus-visible` rule uses a diffuse `box-shadow` glow. On the PreventionWeb/Delta theme, the hover color token resolves to near-transparent, making the focus indicator effectively invisible on white backgrounds. The hero/CTA dark-context focus ring added in this release does not affect this. A solid `outline`-based fix is planned.
+- **OnThisPageNav RTL gradient (WCAG 1.4.1):** The overflow fade uses a physical `to right` gradient direction and does not flip in RTL layouts. Arabic users whose nav bar overflows see the fade on the wrong edge.
 
 ## Migration: icon system change (1.5.0)
 
 ### What changed
 
-Mangrove icons previously rendered as font glyphs from a Fontello-generated icon font (`mangrove-icon-set`), which declared itself as `FontAwesome`. They now render using `mask-image` on `::before`, backed by SVG data URIs. The SVG acts as a stencil; `background-color: currentColor` fills the visible area. The `color` CSS property still controls icon color, exactly as before.
+Icons previously rendered as font glyphs from a Fontello-generated font (`mangrove-icon-set`, which declared itself as `FontAwesome`). They now render via `mask-image` on `::before`, backed by SVG data URIs — one fewer HTTP request and no FOUT on slow connections. `background-color: currentColor` fills the visible area; `color` still controls icon color.
 
 ### What to check
 
 **Markup**: no changes required. `<i class="mg-icon mg-icon-search"></i>` works unchanged.
 
-**`fa-*` classes**: still functional. The font still loads. If your Twig templates, PHP modules, or custom content use `fa-*` classes directly, they continue to render. See the [roadmap above](#icon-migration-roadmap-fa--mg-icon-) for when the font will be removed.
+> **For Drupal HTML authors:** when adding icons to markup manually, decorative icons should include `aria-hidden="true"` (WCAG 4.1.2). When an icon is the sole content of a `<button>` or `<a>`, the interactive element needs a visible or screen-reader label. The React `Icon` component handles this automatically; raw `<i>` elements in Twig templates do not.
 
-**Custom CSS targeting `::before`**: if you override `font-size` on `.mg-icon::before`, check icons still render at the intended size. The new base rule sets `width: 1em; height: 1em` on `::before` — `font-size` on the `.mg-icon` element controls the rendered size, same as before.
+**`fa-*` classes**: still functional. The font still loads. If your Twig templates, PHP modules, or custom content use `fa-*` classes directly, they continue to render. See the [roadmap](#icon-migration-roadmap-fa--mg-icon-) for when the font will be removed.
 
-**High Contrast Mode (Windows)**: icons include `forced-color-adjust: none` and an explicit `background-color: CanvasText` fallback in `@media (forced-colors: active)`. Icons remain visible in Edge forced-colors emulation and Windows High Contrast Mode.
+**Custom CSS targeting `::before`**: if you have CSS that overrides `width` or `height` on `.mg-icon::before` — for example, `{ width: 14px; height: 14px; }` — that now actively sizes the icon box. Previously such rules were harmless under the font system. Check that any fixed-size overrides still produce the intended result. To control icon size, set `font-size` on `.mg-icon` (the `::before` box is `1em × 1em`, so it scales with the parent).
+
+**Multicolor icons (`.mg-icon--multicolor`)**: the modifier renders the SVG with its original colors via `background-image`. Because the icon communicates meaning through color (e.g., the SDG color wheel), **always pair a multicolor icon with a visible text label** — WCAG 1.4.1 prohibits color as the sole means of conveying information.
+
+**High Contrast Mode (Windows)**: icons now include `forced-color-adjust: none` and an explicit `background-color: CanvasText` fallback. Icons are visible in Windows HCM without any action on your part.
+
+**Printing**: a `@media print` override ensures icons remain visible when pages are printed — standard print stylesheet resets (`background: transparent !important`) no longer affect mask-image icons.
 
 ### Visual style shift
 
-The old FontAwesome 4 glyphs were solid/filled. Lucide icons are stroked/outlined. OCHA icons are filled. This is intentional — Lucide is actively maintained with ~1,700 icons; FA4 is unmaintained and its `@font-face` declaration (which used the name `FontAwesome`) conflicted with any real FontAwesome installation in Drupal.
+FA4 glyphs were solid/filled; Lucide icons are stroked/outlined; OCHA domain icons are filled. The switch is intentional — Lucide has ~1,700 actively maintained icons, and FA4's `@font-face` (which declared itself as `FontAwesome`) conflicted with any real FontAwesome installation in Drupal.
 
-UI control icons (search, menu, arrows) are most visibly changed. Domain icons on cards and infographics use OCHA filled icons, which are visually similar to the previous FA4 glyphs.
-
-### Performance
-
-At 79 icons the inline SVG data URIs add roughly 18 KB to the CSS (~7 KB gzipped). This replaces a separate woff2 font file (~12 KB) that required its own HTTP request and could cause FOUT (flash of unstyled text) before loading. Net result: slightly more CSS, one fewer HTTP request, no FOUT.
+UI control icons (search, menu, arrows) are most visibly changed. Domain icons on cards and infographics use OCHA filled icons, visually similar to the previous FA4 glyphs.
 
 ## Upgrading from 1.4.x
 
 1. Update your dependency: `yarn add @undrr/undrr-mangrove@^1.5.0` (or update `package.json` and run `yarn install`)
 2. If you load Mangrove CSS from the CDN, update the version number in your `<link>` tags
-3. Copy the updated compiled CSS to your Drupal child themes
-4. No `data-mg-*` attribute changes, no React prop changes, no JavaScript changes
+3. Copy the updated compiled CSS to your Drupal child themes. **If you are on a legacy theme (`style-legacy.css`, `style-preventionweb-legacy.css`, etc.), copy the updated legacy file — not `style.css`.** See the [CDN reference](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-integration-cdn-reference--docs) for the full source-to-destination mapping.
+4. Check for `mg-button-arrow` and `For_Primary` usages — see [Breaking changes](#breaking-changes)
 
 ```
 # CDN
@@ -102,4 +156,6 @@ https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
 yarn add @undrr/undrr-mangrove@^1.5.0
 ```
 
-React component APIs are unchanged — same props, same exports, same `data-mg-*` attributes.
+Most React component APIs are unchanged. The exception is `CtaButton`, which no longer accepts the `For_Primary` prop (it was a no-op). All other props, exports, and `data-mg-*` attributes are the same.
+
+**Verifying the icon upgrade:** after copying updated CSS, open DevTools and inspect any `.mg-icon` element. Under Computed styles, look for `mask-image` on `::before`. A data URI confirms the new CSS is loaded. An empty value or `none` means you are still serving the old stylesheet.

--- a/docs/RELEASE-1.5.md
+++ b/docs/RELEASE-1.5.md
@@ -2,56 +2,86 @@
 
 > Edits to this file show up on both [GitHub](https://github.com/unisdr/undrr-mangrove/blob/main/docs/RELEASE-1.5.md) and in [Storybook](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-release-notes-v1-5--docs).
 
-The main change in 1.5: icons now render via CSS `mask-image` instead of a font. This is a visual improvement and a long-term maintenance improvement, not a breaking change — the `fa-*` fallback classes remain, and HTML markup does not change.
+The main change in 1.5: icons now render via CSS `mask-image` instead of a font. This is a visual improvement and a long-term maintenance win — the `fa-*` fallback classes remain in this release, and HTML markup does not change. **If you use `fa-*` classes directly in Drupal templates, this is your heads-up to begin planning a migration** — the font will be removed in a future release once Drupal-side references are cleaned up. See [the icon migration roadmap](#icon-migration-roadmap-fa--mg-icon-) for the full plan.
 
-> **If you manage a site that uses Mangrove:** your icons will look slightly different. Lucide icons are stroked/outlined; the old FontAwesome 4 icons were solid/filled. Both respond to the CSS `color` property. No HTML changes are required. If you use `fa-*` classes directly (outside Mangrove components), they continue to work — the font still loads.
+> **If you manage a site that uses Mangrove:** your icons will look slightly different. Lucide icons are stroked/outlined; the old FontAwesome 4 icons were solid/filled. Both respond to the CSS `color` property. No HTML changes are required now. If you use `fa-*` classes directly (outside Mangrove components), they continue to work for this release — the font still loads.
 
-## What else is in 1.5
+1.4.1 was a patch release that shipped shortly after 1.4.0. These release notes cover everything since 1.4.0. For the complete diff, see the [v1.4.0...v1.5.0 comparison on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.4.0...v1.5.0).
 
-Our last release was 1.4.1. For the complete diff, see the [v1.4.1...v1.5.0 comparison on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.4.1...v1.5.0).
+## What's new since 1.4.0
+
+### New components
+
+- **OnThisPageNav — sticky horizontal page navigation:** A new vanilla JS component that generates a sticky "On this page" bar from page headings (h2/h3/h4) or an explicit link list. Uses IntersectionObserver for scroll-spy, auto-scrolls the nav bar to keep the active link visible, and un-sticks on short viewports per [GOV.UK accessibility research](https://technology.blog.gov.uk/2018/05/21/sticky-elements-functionality-and-accessibility-testing/). Includes an optional pinned CTA, RTL support, configurable heading depth and content scope, and a `data-mg-on-this-page-nav-skip-auto-init` opt-out for manual initialization. ([#879](https://github.com/unisdr/undrr-mangrove/pull/879))
 
 ### New features
 
-- **Icon system overhaul — CSS mask-image rendering (phases 1–2):** Replaces Fontello/FontAwesome 4 glyph rendering with `mask-image` rules backed by inline SVG data URIs. Icon sources: [Lucide](https://lucide.dev) for UI icons (MIT licensed, 24×24 stroked paths), [OCHA Humanitarian Icons](https://github.com/UN-OCHA/humanitarian-icons) for domain-specific icons (CC0-1.0), and custom SVGs for social media brand logos (Facebook, X/Twitter, LinkedIn, YouTube, Flickr) and the SDG color wheel. The old `@font-face` and all `fa-*` alias selectors are kept — sites using `fa-*` directly are unaffected until the font removal in a future phase. No markup changes. ([#907](https://github.com/unisdr/undrr-mangrove/pull/907))
+- **Icon system overhaul — CSS mask-image rendering (phases 1–2):** Replaces Fontello/FontAwesome 4 glyph rendering with `mask-image` rules backed by inline SVG data URIs. Icon sources: [Lucide](https://lucide.dev) for UI icons (MIT licensed, 24×24 stroked paths), [OCHA Humanitarian Icons](https://github.com/UN-OCHA/humanitarian-icons) for domain icons (CC0-1.0), and custom SVGs for social media brand logos (Facebook, X/Twitter, LinkedIn, YouTube, Flickr) and the SDG color wheel. The old `@font-face` and all `fa-*` alias selectors are kept for backward compatibility. No markup changes. See [the full migration roadmap](#icon-migration-roadmap-fa--mg-icon-) below. ([#907](https://github.com/unisdr/undrr-mangrove/pull/907))
+- **TableOfContents: published as standalone vanilla JS asset:** `table-of-contents.js` is now auto-discovered by webpack and published to `dist/js/` and npm, following the same convention as `tabs.js` and `on-this-page-nav.js`. Supports auto-initialization from `data-mg-table-of-contents` and `data-mg-table-of-contents-skip-auto-init`. Enables Drupal to load it directly from the CDN import map. ([#901](https://github.com/unisdr/undrr-mangrove/pull/901))
+- **Named z-index tokens for global stacking contexts:** Nine new `$mg-z-index-*` SCSS variables replace the previous magic numbers scattered across component files. Nav-zone values (`nav: 10`, `sticky: 11`, `nav-toggle: 14`, `header: 22`) are frozen to avoid breaking Drupal theme CSS that was written against those values. Above that: `drawer: 2000`, `dropdown: 2500`, `modal: 5000`, `toast: 5500`. A new "Z-index layers" page in Storybook documents the full table and reasoning. ([#889](https://github.com/unisdr/undrr-mangrove/pull/889))
+- **OnThisPageNav: horizontal overflow scroll arrows:** Scroll `<` / `>` buttons appear when the nav bar has more items than fit in view, giving users a discoverable way to reach hidden links. Buttons are RTL-aware, manage keyboard focus when hidden, and respect `prefers-reduced-motion`. ([#888](https://github.com/unisdr/undrr-mangrove/pull/888))
+- **Vanilla JS lifecycle contract standardized:** `show-more.js`, `tabs.js`, and `on-this-page-nav.js` now share a consistent initialization contract: auto-init on `DOMContentLoaded`, `data-mg-*-skip-auto-init` opt-out for manual control, idempotency guard (safe to call init multiple times), and single-element scope. This makes all three safe to load as `type="module"` directly from the CDN without hand-copying the JS into Drupal. ([#886](https://github.com/unisdr/undrr-mangrove/pull/886))
 
 ### Fixes
 
-- **MegaMenu: mobile pointer-events via progressive enhancement** — `.mg-mega-topbar__item` no longer has `pointer-events: none` as a default style. The restriction is now gated behind `.mg-mega-wrapper--js-active`, a class the React component adds on mount via `useEffect`. Plain-HTML nav, no-JS environments, and failed/slow hydration now keep all links clickable on mobile. ([#916](https://github.com/unisdr/undrr-mangrove/pull/916))
-- **OnThisPageNav: scroll to headings inside collapsed tab panels** — clicking a heading link in the sticky "On this page" nav now opens any enclosing Mangrove tab panel before calculating scroll position. Previously, headings inside hidden panels had zero dimensions from `getBoundingClientRect()`, so the page scrolled to the top instead. Nested tab support included. ([#917](https://github.com/unisdr/undrr-mangrove/pull/917))
-- **SyndicationSearchWidget: `fromElement` parses `customFilters`, `customFacets`, `visibleTeaserFields`** — these three JSON props were previously silently ignored when mounting from HTML data attributes. They now parse correctly alongside the existing `defaultFilters` and `allowedTypes` props. ([#920](https://github.com/unisdr/undrr-mangrove/pull/920))
+- **Card alignment, button contrast, and theme tokens** — icon card images and icons are now start-aligned (were center-aligned); icon badge shape changed from circle to rounded square (`$mg-card-icon-badge-radius`). Secondary button color updated to meet WCAG AA contrast (was 3.99:1, now compliant). Disabled button updated from near-invisible neutral-400/neutral-300 to readable neutral-500/white. Hero and CTA buttons now show a `:focus-visible` ring in dark contexts. New tokens for secondary and hero button colors allow per-theme overrides. Dead `mg-button-arrow` variant removed. ([#872](https://github.com/unisdr/undrr-mangrove/pull/872))
+- **MegaMenu: mobile pointer-events via progressive enhancement** — the `pointer-events: none` restriction on `.mg-mega-topbar__item` is now gated behind `.mg-mega-wrapper--js-active`, a class added on mount. Plain-HTML nav, no-JS environments, and failed/slow hydration keep all links clickable on mobile. ([#916](https://github.com/unisdr/undrr-mangrove/pull/916))
+- **OnThisPageNav: scroll to headings inside collapsed tab panels** — the nav now opens any enclosing Mangrove tab panel before calculating scroll position. Headings inside hidden panels previously reported zero dimensions, causing the page to scroll to the top. Nested tab support included. ([#917](https://github.com/unisdr/undrr-mangrove/pull/917))
+- **SyndicationSearchWidget: `fromElement` parses `customFilters`, `customFacets`, `visibleTeaserFields`** — these three JSON props were previously silently ignored when mounting from HTML data attributes. ([#920](https://github.com/unisdr/undrr-mangrove/pull/920))
 
 ### Documentation
 
-- Writing guidelines updated with a "write for two audiences" principle — consumer docs lead with what it does and how to use it; maintainer context goes in a separate section or callout. Applied to MegaMenu and ScrollContainer docs. ([#910](https://github.com/unisdr/undrr-mangrove/pull/910))
+- Writing guidelines updated with a "write for two audiences" principle — consumer docs lead with what it does and how to use it; maintainer context (design decisions, edge cases, history) goes in a separate section or callout. Applied to MegaMenu and ScrollContainer docs. ([#910](https://github.com/unisdr/undrr-mangrove/pull/910))
 
 ### Tooling
 
 - Storybook 10.3.5, postcss 8.5.9 ([#918](https://github.com/unisdr/undrr-mangrove/pull/918))
-- Batch dependency updates 2026-04-03 ([#904](https://github.com/unisdr/undrr-mangrove/pull/904))
+- Batch dependency updates ([#904](https://github.com/unisdr/undrr-mangrove/pull/904), [#882](https://github.com/unisdr/undrr-mangrove/pull/882))
 
-## Migration: icon system change
+## Coming up
+
+### Content schemas
+
+We are authoring JSON Schema files that define the canonical data contract for each Mangrove component — the fields any consumer (Drupal, Astro, static HTML) needs to render the component correctly. These schemas will ship alongside component JS in the npm package and CDN, making it possible to validate content against them before rendering and giving AI coding tools a precise, structured description of each component's data model.
+
+The initial set covers cards, statistics, quotes, navigation items, and share actions. A follow-on phase will use the schemas to align component prop names — currently some React props (`imgback`, `imgAlt`) diverge from the semantic names the schemas will define. That alignment will happen with a migration path, not a surprise breaking change.
+
+This work is tracked in [#881](https://github.com/unisdr/undrr-mangrove/issues/881), [#883](https://github.com/unisdr/undrr-mangrove/issues/883), and [#884](https://github.com/unisdr/undrr-mangrove/issues/884).
+
+### Icon migration roadmap: `fa-*` → `mg-icon-*`
+
+The icon font is still loaded in 1.5 and `fa-*` classes still work. The full migration is four phases; phases 1 and 2 shipped in this release:
+
+| Phase | What happens | Status |
+|---|---|---|
+| 1 — Build pipeline | SVG sources, icon map, `yarn build:icons` generates `_icon-definitions.scss` | ✅ Done (1.5.0) |
+| 2 — Switch to mask-image | `mg-icon-*` classes render via mask-image; font kept as fallback | ✅ Done (1.5.0) |
+| 3 — Drupal migration | All `fa-*` references in Drupal Twig, PHP, and stories migrated to `mg-icon-*` | Planned |
+| 4 — Font removal | `@font-face`, `fa-*` selectors, and font files removed from Mangrove | Planned (after phase 3 in production) |
+
+Phase 4 will not happen until phase 3 is deployed and verified in production. If your Drupal templates or custom modules reference `fa-*` classes directly, **now is the right time to start auditing them**. The full issue with known `fa-*` usage locations and icons that need Mangrove equivalents is tracked in [#906](https://github.com/unisdr/undrr-mangrove/issues/906).
+
+## Migration: icon system change (1.5.0)
 
 ### What changed
 
-Mangrove icons previously rendered as font glyphs from a Fontello-generated icon font (`mangrove-icon-set`), which declared itself as `FontAwesome`. They now render using `mask-image` on `::before`, backed by SVG data URIs. The SVG acts as a stencil; `background-color: currentColor` fills the visible area.
-
-The `color` CSS property still controls icon color, exactly as before.
+Mangrove icons previously rendered as font glyphs from a Fontello-generated icon font (`mangrove-icon-set`), which declared itself as `FontAwesome`. They now render using `mask-image` on `::before`, backed by SVG data URIs. The SVG acts as a stencil; `background-color: currentColor` fills the visible area. The `color` CSS property still controls icon color, exactly as before.
 
 ### What to check
 
 **Markup**: no changes required. `<i class="mg-icon mg-icon-search"></i>` works unchanged.
 
-**`fa-*` classes**: still functional. The font still loads. If your Twig templates, PHP modules, or custom content use `fa-*` classes directly, they continue to render. A future phase (Mangrove 1.5.x or 1.6) will migrate `fa-*` references in Drupal to `mg-icon-*` and a subsequent phase will remove the font entirely. You will get advance notice before each step.
+**`fa-*` classes**: still functional. The font still loads. If your Twig templates, PHP modules, or custom content use `fa-*` classes directly, they continue to render. See the [roadmap above](#icon-migration-roadmap-fa--mg-icon-) for when the font will be removed.
 
-**Custom CSS targeting `::before`**: if you have custom CSS that overrides `font-size` on `.mg-icon::before` for sizing, check that the icons still render at the intended size. The new base rule sets `width: 1em; height: 1em` on `::before` — `font-size` on the `.mg-icon` element controls the rendered size, same as before.
+**Custom CSS targeting `::before`**: if you override `font-size` on `.mg-icon::before`, check icons still render at the intended size. The new base rule sets `width: 1em; height: 1em` on `::before` — `font-size` on the `.mg-icon` element controls the rendered size, same as before.
 
-**High Contrast Mode (Windows)**: icons include `forced-color-adjust: none` and an explicit `background-color: CanvasText` fallback in `@media (forced-colors: active)`. If you test with Edge forced-colors emulation or Windows High Contrast Mode, icons should remain visible.
+**High Contrast Mode (Windows)**: icons include `forced-color-adjust: none` and an explicit `background-color: CanvasText` fallback in `@media (forced-colors: active)`. Icons remain visible in Edge forced-colors emulation and Windows High Contrast Mode.
 
 ### Visual style shift
 
-The old FontAwesome 4 glyphs were solid/filled. Lucide icons are stroked/outlined. OCHA icons are filled. This is an intentional change — Lucide is actively maintained and has far more icons; FA4 is unmaintained and was a source of `@font-face` conflicts with any real FontAwesome installation in Drupal.
+The old FontAwesome 4 glyphs were solid/filled. Lucide icons are stroked/outlined. OCHA icons are filled. This is intentional — Lucide is actively maintained with ~1,700 icons; FA4 is unmaintained and its `@font-face` declaration (which used the name `FontAwesome`) conflicted with any real FontAwesome installation in Drupal.
 
-In practice the visual change is most visible on UI control icons (search, menu, arrows). Domain icons on cards and infographics use OCHA filled icons, which are visually similar to the previous FA4 glyphs.
+UI control icons (search, menu, arrows) are most visibly changed. Domain icons on cards and infographics use OCHA filled icons, which are visually similar to the previous FA4 glyphs.
 
 ### Performance
 
@@ -64,7 +94,7 @@ At 79 icons the inline SVG data URIs add roughly 18 KB to the CSS (~7 KB gzipped
 3. Copy the updated compiled CSS to your Drupal child themes
 4. No `data-mg-*` attribute changes, no React prop changes, no JavaScript changes
 
-```bash
+```
 # CDN
 https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
 

--- a/docs/RELEASE-1.5.md
+++ b/docs/RELEASE-1.5.md
@@ -1,0 +1,75 @@
+# Mangrove 1.5 release notes
+
+> Edits to this file show up on both [GitHub](https://github.com/unisdr/undrr-mangrove/blob/main/docs/RELEASE-1.5.md) and in [Storybook](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-release-notes-v1-5--docs).
+
+The main change in 1.5: icons now render via CSS `mask-image` instead of a font. This is a visual improvement and a long-term maintenance improvement, not a breaking change — the `fa-*` fallback classes remain, and HTML markup does not change.
+
+> **If you manage a site that uses Mangrove:** your icons will look slightly different. Lucide icons are stroked/outlined; the old FontAwesome 4 icons were solid/filled. Both respond to the CSS `color` property. No HTML changes are required. If you use `fa-*` classes directly (outside Mangrove components), they continue to work — the font still loads.
+
+## What else is in 1.5
+
+Our last release was 1.4.1. For the complete diff, see the [v1.4.1...v1.5.0 comparison on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.4.1...v1.5.0).
+
+### New features
+
+- **Icon system overhaul — CSS mask-image rendering (phases 1–2):** Replaces Fontello/FontAwesome 4 glyph rendering with `mask-image` rules backed by inline SVG data URIs. Icon sources: [Lucide](https://lucide.dev) for UI icons (MIT licensed, 24×24 stroked paths), [OCHA Humanitarian Icons](https://github.com/UN-OCHA/humanitarian-icons) for domain-specific icons (CC0-1.0), and custom SVGs for social media brand logos (Facebook, X/Twitter, LinkedIn, YouTube, Flickr) and the SDG color wheel. The old `@font-face` and all `fa-*` alias selectors are kept — sites using `fa-*` directly are unaffected until the font removal in a future phase. No markup changes. ([#907](https://github.com/unisdr/undrr-mangrove/pull/907))
+
+### Fixes
+
+- **MegaMenu: mobile pointer-events via progressive enhancement** — `.mg-mega-topbar__item` no longer has `pointer-events: none` as a default style. The restriction is now gated behind `.mg-mega-wrapper--js-active`, a class the React component adds on mount via `useEffect`. Plain-HTML nav, no-JS environments, and failed/slow hydration now keep all links clickable on mobile. ([#916](https://github.com/unisdr/undrr-mangrove/pull/916))
+- **OnThisPageNav: scroll to headings inside collapsed tab panels** — clicking a heading link in the sticky "On this page" nav now opens any enclosing Mangrove tab panel before calculating scroll position. Previously, headings inside hidden panels had zero dimensions from `getBoundingClientRect()`, so the page scrolled to the top instead. Nested tab support included. ([#917](https://github.com/unisdr/undrr-mangrove/pull/917))
+- **SyndicationSearchWidget: `fromElement` parses `customFilters`, `customFacets`, `visibleTeaserFields`** — these three JSON props were previously silently ignored when mounting from HTML data attributes. They now parse correctly alongside the existing `defaultFilters` and `allowedTypes` props. ([#920](https://github.com/unisdr/undrr-mangrove/pull/920))
+
+### Documentation
+
+- Writing guidelines updated with a "write for two audiences" principle — consumer docs lead with what it does and how to use it; maintainer context goes in a separate section or callout. Applied to MegaMenu and ScrollContainer docs. ([#910](https://github.com/unisdr/undrr-mangrove/pull/910))
+
+### Tooling
+
+- Storybook 10.3.5, postcss 8.5.9 ([#918](https://github.com/unisdr/undrr-mangrove/pull/918))
+- Batch dependency updates 2026-04-03 ([#904](https://github.com/unisdr/undrr-mangrove/pull/904))
+
+## Migration: icon system change
+
+### What changed
+
+Mangrove icons previously rendered as font glyphs from a Fontello-generated icon font (`mangrove-icon-set`), which declared itself as `FontAwesome`. They now render using `mask-image` on `::before`, backed by SVG data URIs. The SVG acts as a stencil; `background-color: currentColor` fills the visible area.
+
+The `color` CSS property still controls icon color, exactly as before.
+
+### What to check
+
+**Markup**: no changes required. `<i class="mg-icon mg-icon-search"></i>` works unchanged.
+
+**`fa-*` classes**: still functional. The font still loads. If your Twig templates, PHP modules, or custom content use `fa-*` classes directly, they continue to render. A future phase (Mangrove 1.5.x or 1.6) will migrate `fa-*` references in Drupal to `mg-icon-*` and a subsequent phase will remove the font entirely. You will get advance notice before each step.
+
+**Custom CSS targeting `::before`**: if you have custom CSS that overrides `font-size` on `.mg-icon::before` for sizing, check that the icons still render at the intended size. The new base rule sets `width: 1em; height: 1em` on `::before` — `font-size` on the `.mg-icon` element controls the rendered size, same as before.
+
+**High Contrast Mode (Windows)**: icons include `forced-color-adjust: none` and an explicit `background-color: CanvasText` fallback in `@media (forced-colors: active)`. If you test with Edge forced-colors emulation or Windows High Contrast Mode, icons should remain visible.
+
+### Visual style shift
+
+The old FontAwesome 4 glyphs were solid/filled. Lucide icons are stroked/outlined. OCHA icons are filled. This is an intentional change — Lucide is actively maintained and has far more icons; FA4 is unmaintained and was a source of `@font-face` conflicts with any real FontAwesome installation in Drupal.
+
+In practice the visual change is most visible on UI control icons (search, menu, arrows). Domain icons on cards and infographics use OCHA filled icons, which are visually similar to the previous FA4 glyphs.
+
+### Performance
+
+At 79 icons the inline SVG data URIs add roughly 18 KB to the CSS (~7 KB gzipped). This replaces a separate woff2 font file (~12 KB) that required its own HTTP request and could cause FOUT (flash of unstyled text) before loading. Net result: slightly more CSS, one fewer HTTP request, no FOUT.
+
+## Upgrading from 1.4.x
+
+1. Update your dependency: `yarn add @undrr/undrr-mangrove@^1.5.0` (or update `package.json` and run `yarn install`)
+2. If you load Mangrove CSS from the CDN, update the version number in your `<link>` tags
+3. Copy the updated compiled CSS to your Drupal child themes
+4. No `data-mg-*` attribute changes, no React prop changes, no JavaScript changes
+
+```bash
+# CDN
+https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
+
+# npm
+yarn add @undrr/undrr-mangrove@^1.5.0
+```
+
+React component APIs are unchanged — same props, same exports, same `data-mg-*` attributes.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -153,9 +153,9 @@ https://assets.undrr.org/testing/static/mangrove/latest/css/style.css
 https://assets.undrr.org/testing/static/mangrove/latest/components/MegaMenu.js
 
 # Versioned (from tagged releases)
-https://assets.undrr.org/static/mangrove/1.4.1/css/style.css
-https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js
-https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js
+https://assets.undrr.org/static/mangrove/1.5.0/css/style.css
+https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js
+https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js
 ```
 
 ## CI/CD configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@undrr/undrr-mangrove",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Mangrove design System for UNDRR",
   "main": "src/index.js",
   "type": "module",

--- a/scripts/update-cdn-version.js
+++ b/scripts/update-cdn-version.js
@@ -59,6 +59,22 @@ const allowedExtensions = new Set([
 ]);
 
 /**
+ * Returns true if the file should be excluded from CDN version rewriting.
+ * Historical release notes (docs/RELEASE-X.Y.md for older versions) contain
+ * fixed CDN URLs that document a specific release and must not be updated.
+ */
+function isIgnoredFile(filePath) {
+  const rel = path.relative(rootDir, filePath).replace(/\\/g, '/');
+  const releaseNoteMatch = rel.match(/^docs\/RELEASE-(.+)\.md$/);
+  if (releaseNoteMatch) {
+    const fileVersion = releaseNoteMatch[1]; // e.g. "1.4"
+    const currentMajorMinor = version.split('.').slice(0, 2).join('.'); // e.g. "1.5"
+    return fileVersion !== currentMajorMinor;
+  }
+  return false;
+}
+
+/**
  * Recursively gather file paths under a directory.
  */
 function listFilesRecursively(startDir) {
@@ -109,6 +125,7 @@ let changedCount = 0;
 const changedFiles = [];
 
 for (const filePath of files) {
+  if (isIgnoredFile(filePath)) continue;
   let content;
   try {
     content = fs.readFileSync(filePath, 'utf8');

--- a/stories/Atom/Icons/icons.scss
+++ b/stories/Atom/Icons/icons.scss
@@ -175,6 +175,19 @@
   }
 }
 
+// Print: restore background-color so mask-image icons remain visible.
+// Generic print resets (e.g. HTML5 Boilerplate) set `background: transparent !important`
+// on all elements. Font glyphs were unaffected because they use `color`, but mask-image
+// icons are painted via `background-color: currentColor` — without this override every
+// icon is invisible when printing.
+@media print {
+  .mg-icon:not([class*="fa-"])::before {
+    // Specificity 0,2,1 with !important beats any 0,0,1 universal reset.
+    background-color: #000 !important; // sass-lint:disable-line no-important
+    print-color-adjust: exact;
+  }
+}
+
 // Icon size modifiers
 
 .mg-icon--sm {

--- a/stories/Atom/Layout/Grid/Grid.mdx
+++ b/stories/Atom/Layout/Grid/Grid.mdx
@@ -42,7 +42,7 @@ Use the grid to create a layout of your choice based on the design you want to a
 
 Add the base layout style from
 
-- https://assets.undrr.org/static/mangrove/1.4.1/assets/css/grid.min.css
+- https://assets.undrr.org/static/mangrove/1.5.0/assets/css/grid.min.css
 
 ## Changelog
 

--- a/stories/Components/Breadcrumbs/Breadcrumbs.jsx
+++ b/stories/Components/Breadcrumbs/Breadcrumbs.jsx
@@ -25,7 +25,7 @@ export function Breadcrumbcomponent({ data, Color, ...args }) {
         {data.map((item, i) => {
           if (i === lastIndex) {
             return (
-              <li key={i} aria-current={item.text}>
+              <li key={i} aria-current="page">
                 {item.text}
               </li>
             );
@@ -33,7 +33,7 @@ export function Breadcrumbcomponent({ data, Color, ...args }) {
 
           return (
             <li key={i}>
-              <a href="#" aria-label={item.text}>
+              <a href="#">
                 {item.text}
               </a>
             </li>

--- a/stories/Components/Breadcrumbs/Breadcrumbs.mdx
+++ b/stories/Components/Breadcrumbs/Breadcrumbs.mdx
@@ -119,5 +119,6 @@ There is only a Default state.
 
 ## Changelog
 
+- **1.2** — 2026-04-09: Fixed invalid `aria-current` value (now correctly set to `"page"` on the active item); removed redundant `aria-label` from non-active breadcrumb links
 - **1.1** — 2026-03-21: Removed stale `data-viewport` animation reference from documentation.
 - **1.0** — 2022-12-12: Released component

--- a/stories/Components/Buttons/ShareButtons/ShareButtons.jsx
+++ b/stories/Components/Buttons/ShareButtons/ShareButtons.jsx
@@ -520,7 +520,7 @@ export function CopyButton({ copiedLabel, sharedLink, className }) {
         {coppied ? copiedLabel : visibleLink}
       </div>
       <div className="mg-share__stack-icon">
-        <span className="mg-icon mg-icon-clone" alt="Copy icon"></span>
+        <span className="mg-icon mg-icon-clone" aria-hidden="true"></span>
       </div>
     </button>
   );

--- a/stories/Components/Buttons/ShareButtons/ShareButtons.mdx
+++ b/stories/Components/Buttons/ShareButtons/ShareButtons.mdx
@@ -117,6 +117,7 @@ See the [Hydration guide](https://github.com/unisdr/undrr-mangrove/blob/main/doc
 
 ## Changelog
 
+- **1.5** — 2026-04-09: Fixed invalid `alt` attribute on icon `<span>` — replaced with `aria-hidden="true"` (WCAG 4.1.2)
 - **1.4** — 2026-03-03: Added hydration support with `fromElement` prop extraction and `createHydrator` integration
 - **1.3** — 2026-02-09: Migrated icon classes from `fa-*` to `mg-icon-*` namespace
 - **1.2** — 2025-08-06: Added QR code sharing with responsive modal, UTM tracking, copy-to-clipboard, and keyboard navigation

--- a/stories/Components/Cards/IconCard/IconCard.mdx
+++ b/stories/Components/Cards/IconCard/IconCard.mdx
@@ -253,8 +253,8 @@ IconCard supports [layered hydration](https://github.com/unisdr/undrr-mangrove/b
 | `data-variant` | `'default'` | `'default'` or `'negative'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import IconCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/IconCard.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import IconCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/IconCard.js";
 createHydrator({ selector: "[data-mg-icon-card]", component: IconCard, fromElement });
 ```
 

--- a/stories/Components/Cards/StatsCard/StatsCard.mdx
+++ b/stories/Components/Cards/StatsCard/StatsCard.mdx
@@ -149,8 +149,8 @@ StatsCard supports [layered hydration](https://github.com/unisdr/undrr-mangrove/
 | `data-class-name` | `''` | Additional CSS class names |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import StatsCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/StatsCard.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import StatsCard, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/StatsCard.js";
 createHydrator({ selector: "[data-mg-stats-card]", component: StatsCard, fromElement });
 ```
 

--- a/stories/Components/ErrorPages/ErrorPage.mdx
+++ b/stories/Components/ErrorPages/ErrorPage.mdx
@@ -179,21 +179,21 @@ Use these static HTML pages directly from the CDN when integrating with CDNs or 
 
 **Cloudflare-specific templates:**
 ```text
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/5xx.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/challenge.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/managed-challenge.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/5xx.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/challenge.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/managed-challenge.html
 ```
 
 **Individual error pages** (for platforms that support per-code configuration):
 ```text
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/401.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/403.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/404.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/429.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/500.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/502.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/503.html
-https://assets.undrr.org/static/mangrove/1.4.1/error-pages/504.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/401.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/403.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/404.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/429.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/500.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/502.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/503.html
+https://assets.undrr.org/static/mangrove/1.5.0/error-pages/504.html
 ```
 
 ## CSS and JS references

--- a/stories/Components/ErrorPages/static/401.html
+++ b/stories/Components/ErrorPages/static/401.html
@@ -88,7 +88,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/403.html
+++ b/stories/Components/ErrorPages/static/403.html
@@ -84,7 +84,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/404.html
+++ b/stories/Components/ErrorPages/static/404.html
@@ -96,7 +96,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/429.html
+++ b/stories/Components/ErrorPages/static/429.html
@@ -91,7 +91,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/500.html
+++ b/stories/Components/ErrorPages/static/500.html
@@ -87,7 +87,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/502.html
+++ b/stories/Components/ErrorPages/static/502.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/503.html
+++ b/stories/Components/ErrorPages/static/503.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/504.html
+++ b/stories/Components/ErrorPages/static/504.html
@@ -87,7 +87,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/5xx.html
+++ b/stories/Components/ErrorPages/static/5xx.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/challenge.html
+++ b/stories/Components/ErrorPages/static/challenge.html
@@ -88,7 +88,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/ErrorPages/static/managed-challenge.html
+++ b/stories/Components/ErrorPages/static/managed-challenge.html
@@ -90,7 +90,7 @@
           document.head.appendChild(el);
         }
         // Load full CSS from CDN (includes fonts)
-        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.4.1/css/style.css'});
+        load('link',{rel:'stylesheet',href:'https://assets.undrr.org/static/mangrove/1.5.0/css/style.css'});
         // Load analytics
         load('script',{src:'https://assets.undrr.org/static/analytics/v1.0.0/google_analytics_enhancements.js',crossorigin:'anonymous'});
         load('script',{src:'https://messaging.undrr.org/src/undrr-messaging.js',defer:''});

--- a/stories/Components/Gallery/Gallery.mdx
+++ b/stories/Components/Gallery/Gallery.mdx
@@ -290,8 +290,8 @@ Gallery supports [layered hydration](https://github.com/unisdr/undrr-mangrove/bl
 | `data-loop` | `'false'` | Enable infinite loop navigation |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import { Gallery, fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/Gallery.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import { Gallery, fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/Gallery.js";
 createHydrator({ selector: "[data-mg-gallery]", component: Gallery, fromElement });
 ```
 

--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -156,8 +156,8 @@ MegaMenu supports [layered hydration](https://github.com/unisdr/undrr-mangrove/b
 > **Drupal note:** The Drupal wrapper reads prefixed attribute names (`data-mg-mega-menu-logo-src`, etc.) and falls back to a `SITE_LOGOS` body-class map when no logo attributes are set. CDN / vanilla HTML consumers use the short `data-logo-*` names above.
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import MegaMenu, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import MegaMenu, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js";
 createHydrator({ selector: "[data-mg-mega-menu]", component: MegaMenu, fromElement });
 ```
 

--- a/stories/Components/OnThisPageNav/OnThisPageNav.mdx
+++ b/stories/Components/OnThisPageNav/OnThisPageNav.mdx
@@ -147,7 +147,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 </nav>
 
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/on-this-page-nav.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.5.0/js/on-this-page-nav.js"></script>
 ```
 
 ## Skipping auto-initialization
@@ -162,7 +162,7 @@ Add `data-mg-on-this-page-nav-skip-auto-init` to skip a nav during auto-init. Th
 </nav>
 
 <script type="module">
-  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/on-this-page-nav.js';
+  import { mgOnThisPageNav } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/on-this-page-nav.js';
   // Initialize after other setup is complete
   mgOnThisPageNav([document.querySelector('[data-mg-on-this-page-nav-skip-auto-init]')]);
 </script>

--- a/stories/Components/QuoteHighlight/QuoteHighlight.mdx
+++ b/stories/Components/QuoteHighlight/QuoteHighlight.mdx
@@ -189,8 +189,8 @@ QuoteHighlight supports [layered hydration](https://github.com/unisdr/undrr-mang
 | `data-alignment` | `'full'` | `'full'`, `'left'`, or `'right'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import QuoteHighlight, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/QuoteHighlight.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import QuoteHighlight, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/QuoteHighlight.js";
 createHydrator({ selector: "[data-mg-quote-highlight]", component: QuoteHighlight, fromElement });
 ```
 

--- a/stories/Components/ScrollContainer/ScrollContainer.mdx
+++ b/stories/Components/ScrollContainer/ScrollContainer.mdx
@@ -242,8 +242,8 @@ ScrollContainer supports [layered hydration](https://github.com/unisdr/undrr-man
 Child elements are extracted from a `.mg-scroll__content` wrapper inside the container. If no wrapper is found, the container's `innerHTML` is used directly.
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import ScrollContainer, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/ScrollContainer.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import ScrollContainer, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/ScrollContainer.js";
 createHydrator({ selector: "[data-mg-scroll-container]", component: ScrollContainer, fromElement });
 ```
 

--- a/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
+++ b/stories/Components/SyndicationSearchWidget/SyndicationSearchWidget.mdx
@@ -415,8 +415,8 @@ SyndicationSearchWidget supports [layered hydration](https://github.com/unisdr/u
 All attributes are optional. Only attributes present on the container are included in the config; the component uses its own defaults for anything missing.
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import SyndicationSearchWidget, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/SyndicationSearchWidget.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import SyndicationSearchWidget, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/SyndicationSearchWidget.js";
 createHydrator({ selector: "[data-mg-search-widget]", component: SyndicationSearchWidget, fromElement });
 ```
 

--- a/stories/Components/Tab/Tab.mdx
+++ b/stories/Components/Tab/Tab.mdx
@@ -72,7 +72,7 @@ Tabs are vanilla JavaScript. No React, no build step, just HTML and a script imp
 Pick the Mangrove theme stylesheet for your site ([CDN reference](/?path=/docs/getting-started-integration-cdn-reference--docs) lists all themes).
 
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css" />
 ```
 
 #### 2. Include the JavaScript
@@ -81,7 +81,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 
 ```html
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js"></script>
 ```
 
 The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is already parsed). Module scripts are deferred by default, so `mgTabs()` runs after the DOM is available.
@@ -90,7 +90,7 @@ For manual or dynamic initialization, import the function:
 
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js';
   mgTabs();
 </script>
 ```
@@ -237,7 +237,7 @@ Add `data-mg-js-tabs-skip-auto-init` to skip a container during auto-init. This 
 </article>
 
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js';
   // Initialize after other setup is complete
   mgTabs([document.querySelector('[data-mg-js-tabs-skip-auto-init]')]);
 </script>

--- a/stories/Components/TableOfContents/TableOfContents.mdx
+++ b/stories/Components/TableOfContents/TableOfContents.mdx
@@ -81,7 +81,7 @@ standalone script from the UNDRR CDN (or npm as
 ```html
 <script
   type="module"
-  src="https://assets.undrr.org/static/mangrove/1.4.1/js/table-of-contents.js"
+  src="https://assets.undrr.org/static/mangrove/1.5.0/js/table-of-contents.js"
 ></script>
 ```
 
@@ -115,7 +115,7 @@ The script auto-initializes on `DOMContentLoaded`. For manual control, import th
 function directly:
 
 ```js
-import { mgTableOfContents } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/table-of-contents.js';
+import { mgTableOfContents } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/table-of-contents.js';
 
 const contentElement = document.querySelector('.mg-content');
 const tocElement = document.querySelector('[data-mg-table-of-contents]');

--- a/stories/Components/TextCta/TextCta.mdx
+++ b/stories/Components/TextCta/TextCta.mdx
@@ -108,8 +108,8 @@ TextCta supports [layered hydration](https://github.com/unisdr/undrr-mangrove/bl
 | `data-centered` | `'true'` | `'true'` or `'false'` |
 
 ```js
-import createHydrator from "https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js";
-import TextCta, { fromElement } from "https://assets.undrr.org/static/mangrove/1.4.1/components/TextCta.js";
+import createHydrator from "https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js";
+import TextCta, { fromElement } from "https://assets.undrr.org/static/mangrove/1.5.0/components/TextCta.js";
 createHydrator({ selector: "[data-mg-text-cta]", component: TextCta, fromElement });
 ```
 

--- a/stories/Documentation/GettingStarted.mdx
+++ b/stories/Documentation/GettingStarted.mdx
@@ -47,7 +47,7 @@ Choose the approach that fits your project. Each guide has its own quick start w
 Include CSS via CDN and copy HTML structures from the component docs. No build step, no JavaScript required for most components.
 
 ```html
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css" />
 ```
 
 - [See on CodePen](https://codepen.io/khawkins98/pen/MYwbKwe) — a working page with footer widget, analytics, and messaging

--- a/stories/Documentation/ReactIntegration.mdx
+++ b/stories/Documentation/ReactIntegration.mdx
@@ -69,10 +69,10 @@ Load the compiled CSS from UNDRR's CDN. Pick the theme that matches your site:
 
 ```html
 <!-- UNDRR default theme -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css" />
 
 <!-- Or a site-specific theme -->
-<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css" />
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-preventionweb.css" />
 ```
 
 Available theme files: `style.css`, `style-preventionweb.css`, `style-mcr.css`, `style-irp.css`, `style-delta.css`. Legacy variants (`style-legacy.css`, `style-preventionweb-legacy.css`, `style-mcr-legacy.css`, `style-irp-legacy.css`) are available for sites with custom CSS written for the pre-1.4 10px root. See the [v1.4 release notes](/docs/getting-started-release-notes-v1-4--docs) for details.

--- a/stories/Documentation/Release15.mdx
+++ b/stories/Documentation/Release15.mdx
@@ -1,0 +1,12 @@
+import { Meta, Markdown } from '@storybook/addon-docs/blocks';
+import ReleaseNotes from '../../docs/RELEASE-1.5.md?raw';
+
+<Meta
+  title="Getting started/Release notes: v1.5"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: { canvas: { hidden: true } },
+  }}
+/>
+
+<Markdown>{ReleaseNotes}</Markdown>

--- a/stories/Documentation/VanillaHtmlCss.mdx
+++ b/stories/Documentation/VanillaHtmlCss.mdx
@@ -49,11 +49,11 @@ Add these `<link>` tags to your HTML `<head>`:
     <!-- UNDRR Theme (Choose one) -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css"
     />
 
     <!-- Alternative: Prevention Web Theme -->
-    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css"> -->
+    <!-- <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-preventionweb.css"> -->
   </head>
   <body>
     <!-- Your content here -->
@@ -103,7 +103,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
+  href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css"
 />
 ```
 
@@ -112,7 +112,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-preventionweb.css"
+  href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-preventionweb.css"
 />
 ```
 
@@ -121,7 +121,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-mcr.css"
+  href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-mcr.css"
 />
 ```
 
@@ -130,7 +130,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-irp.css"
+  href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-irp.css"
 />
 ```
 
@@ -139,7 +139,7 @@ Choose the theme that matches your UNDRR property:
 ```html
 <link
   rel="stylesheet"
-  href="https://assets.undrr.org/static/mangrove/1.4.1/css/style-delta.css"
+  href="https://assets.undrr.org/static/mangrove/1.5.0/css/style-delta.css"
 />
 ```
 
@@ -231,7 +231,7 @@ Some components (like Tabs) have lightweight JavaScript modules:
 
 ```html
 <script type="module">
-  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/tabs.js';
+  import { mgTabs } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/tabs.js';
 
   document.addEventListener('DOMContentLoaded', () => {
     mgTabs();
@@ -288,7 +288,7 @@ React 19 dropped UMD builds, so we use [import maps](https://developer.mozilla.o
 
     // Load component from CDN
     const MegaMenuModule = await import(
-      'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
+      'https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js'
     );
 
     // Unwrap ESM/CJS interop - bundle may be double-wrapped as { default: { default: Component } }
@@ -334,8 +334,8 @@ Components that support hydration (ShareButtons, ScrollContainer, QuoteHighlight
 
 ```html
 <script type="module">
-  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
-  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
+  import createHydrator from 'https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js';
+  import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.5.0/components/ShareButtons.js';
 
   createHydrator({
     selector: '[data-mg-share-buttons]',
@@ -367,7 +367,7 @@ Components that don't yet export `fromElement` (BarChart, MapComponent, etc.) ca
   import React from 'react';
   import { createRoot } from 'react-dom/client';
   const MegaMenuModule = await import(
-    'https://assets.undrr.org/static/mangrove/1.4.1/components/MegaMenu.js'
+    'https://assets.undrr.org/static/mangrove/1.5.0/components/MegaMenu.js'
   );
   let MegaMenu = MegaMenuModule?.default ?? MegaMenuModule;
   if (typeof MegaMenu !== 'function' && MegaMenu?.default) {
@@ -402,7 +402,7 @@ A self-contained page you can save as an `.html` file and open in a browser. It 
     <!-- Mangrove CSS theme -->
     <link
       rel="stylesheet"
-      href="https://assets.undrr.org/static/mangrove/1.4.1/css/style.css"
+      href="https://assets.undrr.org/static/mangrove/1.5.0/css/style.css"
     />
 
     <!-- Import map: provides React to Mangrove ES module bundles -->
@@ -432,8 +432,8 @@ A self-contained page you can save as an `.html` file and open in a browser. It 
 
     <!-- Load the hydration runtime and component, then mount -->
     <script type="module">
-      import createHydrator from 'https://assets.undrr.org/static/mangrove/1.4.1/components/hydrate.js';
-      import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.4.1/components/ShareButtons.js';
+      import createHydrator from 'https://assets.undrr.org/static/mangrove/1.5.0/components/hydrate.js';
+      import ShareButtons, { fromElement } from 'https://assets.undrr.org/static/mangrove/1.5.0/components/ShareButtons.js';
 
       createHydrator({
         selector: '[data-mg-share-buttons]',

--- a/stories/Utilities/ShowMore/ShowMore.mdx
+++ b/stories/Utilities/ShowMore/ShowMore.mdx
@@ -60,7 +60,7 @@ The script file uses ES module `export` statements, so you **must** load it with
 
 <Source language="html" code={`
 <!-- JS: type="module" is required -->
-<script type="module" src="https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js"></script>
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.5.0/js/show-more.js"></script>
 `} />
 
 The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is already parsed). Module scripts are deferred by default, so no wrapper is needed.
@@ -68,7 +68,7 @@ The script auto-initializes on `DOMContentLoaded` (or immediately if the DOM is 
 For dynamically added content, import and call the init function:
 
 <Source language="js" code={`
-import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js';
+import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/show-more.js';
 
 // Initialize specific buttons
 mgShowMore([myButton]);
@@ -89,7 +89,7 @@ Add `data-mg-show-more-skip-auto-init` to skip a button during auto-init. This i
    data-mg-show-more-target=".my-content">Show more</a>
 
 <script type="module">
-  import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.4.1/js/show-more.js';
+  import { mgShowMore } from 'https://assets.undrr.org/static/mangrove/1.5.0/js/show-more.js';
   // Initialize after other setup is complete
   mgShowMore([document.querySelector('[data-mg-show-more-skip-auto-init]')]);
 </script>


### PR DESCRIPTION
## Summary

Release orchestration PR for v1.5.0. Updated release notes (`docs/RELEASE-1.5.md`) with the full changelog since v1.4.1, grouped by type.

### Headline change

Icon system overhaul (phases 1–2, #907): CSS `mask-image` rendering replaces the Fontello/FontAwesome 4 icon font. 79 icons from Lucide, OCHA Humanitarian Icons, and custom SVGs. The `fa-*` fallback classes remain; markup is unchanged. Phases 3 (Drupal `fa-*` migration) and 4 (font removal) are tracked in #906 for future releases.

### Also included

- MegaMenu mobile pointer-events progressive enhancement (#916)
- OnThisPageNav opens collapsed tab panels before scrolling (#917)
- SyndicationSearchWidget `fromElement` parses three previously-ignored JSON props (#920)
- Writing guidelines: write for two audiences (#910)
- Dependency updates (#904, #918)

### Checklist items remaining (can be done on this branch or as follow-ups)

- [ ] Tag `v1.5.0` and push
- [ ] GitHub Release from the tag
- [ ] Update Drupal theme CSS files