### PR TITLE
docs: add favicon documentation to Storybook

### DIFF
--- a/docs/CDN-REFERENCE.md
+++ b/docs/CDN-REFERENCE.md
@@ -137,6 +137,14 @@ Base URL: `https://assets.undrr.org/static/analytics/{version}/`
 
 See [Analytics enhancements](https://unisdr.github.io/undrr-mangrove/?path=/docs/platform-services-analytics-enhancements--docs) for configuration options.
 
+## Favicons
+
+Base URL: `https://assets.undrr.org/static/favicons/{brand}/v1/`
+
+Canonical favicon sets for all 10 UNDRR brands. Each brand directory contains `favicon.ico`, `apple-touch-icon.png`, `favicon-192.png`, and `favicon-512.png`.
+
+See [Favicons](https://unisdr.github.io/undrr-mangrove/?path=/docs/design-decisions-favicons--docs) for the full brand list, recommended markup, and integration details.
+
 ## Logos
 
 Base URL: `https://assets.undrr.org/static/logos/`
@@ -216,6 +224,13 @@ https://assets.undrr.org/static/
 │   └── {version}/
 │       ├── google_analytics_enhancements.js
 │       └── index.html
+├── favicons/
+│   └── {brand}/
+│       └── v1/
+│           ├── favicon.ico
+│           ├── apple-touch-icon.png
+│           ├── favicon-192.png
+│           └── favicon-512.png
 ├── logos/
 │   └── undrr/
 │       ├── undrr-logo-horizontal.svg
@@ -225,6 +240,7 @@ https://assets.undrr.org/static/
 
 ## See also
 
+- [Favicons](https://unisdr.github.io/undrr-mangrove/?path=/docs/design-decisions-favicons--docs) — brand favicon sets for all UNDRR properties
 - [Vanilla HTML/CSS integration](https://unisdr.github.io/undrr-mangrove/?path=/docs/getting-started-integration-vanilla-html-and-css--docs)
 - [Analytics enhancements](https://unisdr.github.io/undrr-mangrove/?path=/docs/platform-services-analytics-enhancements--docs)
 - [Critical messaging](https://unisdr.github.io/undrr-mangrove/?path=/docs/platform-services-critical-messaging--docs)

--- a/stories/Documentation/Favicons.mdx
+++ b/stories/Documentation/Favicons.mdx
@@ -1,0 +1,134 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Design decisions/Favicons" />
+
+# Favicons
+
+Canonical favicon sets for UNDRR web properties, hosted on the CDN at `assets.undrr.org/static/favicons/`. All Drupal sites and static microsites share a single source of truth for favicons.
+
+See [web-backlog#2757](https://gitlab.com/undrr/web-backlog/-/work_items/2757) for the full initiative.
+
+## Brands
+
+| Brand | Preview | CDN path |
+|-------|---------|----------|
+| ARISE | <img src="https://assets.undrr.org/static/favicons/arise/v1/favicon-192.png" width="32" height="32" alt="ARISE" /> | [`arise/v1/`](https://assets.undrr.org/static/favicons/arise/v1/) |
+| Global Platform | <img src="https://assets.undrr.org/static/favicons/gp/v1/favicon-192.png" width="32" height="32" alt="GP" /> | [`gp/v1/`](https://assets.undrr.org/static/favicons/gp/v1/) |
+| IDDRR | <img src="https://assets.undrr.org/static/favicons/iddrr/v1/favicon-192.png" width="32" height="32" alt="IDDRR" /> | [`iddrr/v1/`](https://assets.undrr.org/static/favicons/iddrr/v1/) |
+| IRP | <img src="https://assets.undrr.org/static/favicons/irp/v1/favicon-192.png" width="32" height="32" alt="IRP" /> | [`irp/v1/`](https://assets.undrr.org/static/favicons/irp/v1/) |
+| MCR2030 | <img src="https://assets.undrr.org/static/favicons/mcr/v1/favicon-192.png" width="32" height="32" alt="MCR2030" /> | [`mcr/v1/`](https://assets.undrr.org/static/favicons/mcr/v1/) |
+| PreventionWeb | <img src="https://assets.undrr.org/static/favicons/pw/v1/favicon-192.png" width="32" height="32" alt="PW" /> | [`pw/v1/`](https://assets.undrr.org/static/favicons/pw/v1/) |
+| SFVC | <img src="https://assets.undrr.org/static/favicons/sfvc/v1/favicon-192.png" width="32" height="32" alt="SFVC" /> | [`sfvc/v1/`](https://assets.undrr.org/static/favicons/sfvc/v1/) |
+| Stop Disasters | <img src="https://assets.undrr.org/static/favicons/stop-disasters/v1/favicon-192.png" width="32" height="32" alt="Stop Disasters" /> | [`stop-disasters/v1/`](https://assets.undrr.org/static/favicons/stop-disasters/v1/) |
+| UNDRR | <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png" width="32" height="32" alt="UNDRR" /> | [`undrr/v1/`](https://assets.undrr.org/static/favicons/undrr/v1/) |
+| WTAD | <img src="https://assets.undrr.org/static/favicons/wtad/v1/favicon-192.png" width="32" height="32" alt="WTAD" /> | [`wtad/v1/`](https://assets.undrr.org/static/favicons/wtad/v1/) |
+
+## Files per brand
+
+Each brand directory contains:
+
+| File | Size | Purpose |
+|------|------|---------|
+| `source-icon.png` | 512px | Source artwork (for regeneration, not served) |
+| `favicon.ico` | 32x32 | Legacy browser fallback |
+| `apple-touch-icon.png` | 180x180 | iOS home screen |
+| `favicon-192.png` | 192x192 | Android / PWA |
+| `favicon-512.png` | 512x512 | PWA splash screen |
+
+## Example: UNDRR
+
+The full set of files for the UNDRR brand:
+
+| File | URL |
+|------|-----|
+| favicon.ico | [assets.undrr.org/static/favicons/undrr/v1/favicon.ico](https://assets.undrr.org/static/favicons/undrr/v1/favicon.ico) |
+| apple-touch-icon.png | [assets.undrr.org/static/favicons/undrr/v1/apple-touch-icon.png](https://assets.undrr.org/static/favicons/undrr/v1/apple-touch-icon.png) |
+| favicon-192.png | [assets.undrr.org/static/favicons/undrr/v1/favicon-192.png](https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png) |
+| favicon-512.png | [assets.undrr.org/static/favicons/undrr/v1/favicon-512.png](https://assets.undrr.org/static/favicons/undrr/v1/favicon-512.png) |
+
+Preview at each size:
+
+<div style={{display: 'flex', gap: '2rem', alignItems: 'end', padding: '1rem', background: '#f5f5f5', borderRadius: '8px'}}>
+  <div style={{textAlign: 'center'}}>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon.ico" width="32" height="32" alt="32px" />
+    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>32px (.ico)</div>
+  </div>
+  <div style={{textAlign: 'center'}}>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/apple-touch-icon.png" width="90" height="90" alt="180px" />
+    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>180px (apple-touch)</div>
+  </div>
+  <div style={{textAlign: 'center'}}>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png" width="96" height="96" alt="192px" />
+    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>192px (Android)</div>
+  </div>
+  <div style={{textAlign: 'center'}}>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-512.png" width="128" height="128" alt="512px" />
+    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>512px (PWA splash)</div>
+  </div>
+</div>
+
+## Recommended markup
+
+Replace `{brand}` with the directory name (e.g. `undrr`, `pw`, `mcr`):
+
+```html
+<link rel="icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/favicon.ico" sizes="32x32">
+<link rel="icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/favicon-192.png" sizes="192x192" type="image/png">
+<link rel="apple-touch-icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/apple-touch-icon.png">
+```
+
+For PWA `manifest.json`:
+
+```json
+{
+  "icons": [
+    { "src": "https://assets.undrr.org/static/favicons/{brand}/v1/favicon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "https://assets.undrr.org/static/favicons/{brand}/v1/favicon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}
+```
+
+## Integration
+
+### Drupal themes
+
+CDN favicons are injected automatically by `undrr_common_page_attachments_alter()` for all child themes. The active Drupal theme is mapped to its favicon brand. Uses the `mangrove_cdn_environment` setting to toggle testing/production CDN paths.
+
+### Astro microsites
+
+`BaseLayout.astro` maps the `theme` prop to CDN favicon URLs via `faviconBaseUrl()` in `src/lib/mangrove.ts`. An optional `favicon` prop overrides the default mapping when the visual theme differs from the favicon brand.
+
+```astro
+<!-- Default: favicon matches theme -->
+<BaseLayout theme="preventionweb">
+
+<!-- Override: IRP styling but UNDRR favicon -->
+<BaseLayout theme="irp" favicon="undrr">
+```
+
+### Other consumers
+
+Any site can reference the CDN paths directly. Use the recommended markup above with the appropriate brand directory.
+
+## Adding a new brand
+
+1. Add a `favicons/{brand}/v1/` directory in the [shared-web-assets](https://gitlab.com/undrr/common/shared-web-assets) repo
+2. Place a square `source-icon.png` (512px minimum, transparent background)
+3. Run `npm run generate-favicons -- {brand}` (requires ImageMagick 7+)
+4. Commit and push — CI deploys to CDN
+5. Update the Drupal theme mapping in `undrr_common.theme` and/or the microsites mapping in `src/lib/mangrove.ts`
+
+## Versioning
+
+Follow the CDN repo's immutability rule: never modify files in an existing version directory. To update a brand's favicons, create a `v2/` directory.
+
+---
+
+## References
+
+- [Favicon CDN source repo](https://gitlab.com/undrr/common/shared-web-assets/-/tree/main/favicons)
+- [Web Backlog Issue #2757](https://gitlab.com/undrr/web-backlog/-/work_items/2757)
+
+---
+
+Last updated: 10 April 2026 · <a href="https://github.com/unisdr/undrr-mangrove/blob/main/stories/Documentation/Favicons.mdx" target="_blank" rel="noopener noreferrer">View source on GitHub</a>

--- a/stories/Documentation/Favicons.mdx
+++ b/stories/Documentation/Favicons.mdx
@@ -13,15 +13,17 @@ See [web-backlog#2757](https://gitlab.com/undrr/web-backlog/-/work_items/2757) f
 | Brand | Preview | CDN path |
 |-------|---------|----------|
 | ARISE | <img src="https://assets.undrr.org/static/favicons/arise/v1/favicon-192.png" width="32" height="32" alt="ARISE" /> | [`arise/v1/`](https://assets.undrr.org/static/favicons/arise/v1/) |
-| Global Platform | <img src="https://assets.undrr.org/static/favicons/gp/v1/favicon-192.png" width="32" height="32" alt="GP" /> | [`gp/v1/`](https://assets.undrr.org/static/favicons/gp/v1/) |
+| Global Platform | <img src="https://assets.undrr.org/static/favicons/gp/v1/favicon-192.png" width="32" height="32" alt="Global Platform" /> | [`gp/v1/`](https://assets.undrr.org/static/favicons/gp/v1/) |
 | IDDRR | <img src="https://assets.undrr.org/static/favicons/iddrr/v1/favicon-192.png" width="32" height="32" alt="IDDRR" /> | [`iddrr/v1/`](https://assets.undrr.org/static/favicons/iddrr/v1/) |
 | IRP | <img src="https://assets.undrr.org/static/favicons/irp/v1/favicon-192.png" width="32" height="32" alt="IRP" /> | [`irp/v1/`](https://assets.undrr.org/static/favicons/irp/v1/) |
 | MCR2030 | <img src="https://assets.undrr.org/static/favicons/mcr/v1/favicon-192.png" width="32" height="32" alt="MCR2030" /> | [`mcr/v1/`](https://assets.undrr.org/static/favicons/mcr/v1/) |
-| PreventionWeb | <img src="https://assets.undrr.org/static/favicons/pw/v1/favicon-192.png" width="32" height="32" alt="PW" /> | [`pw/v1/`](https://assets.undrr.org/static/favicons/pw/v1/) |
+| PreventionWeb | <img src="https://assets.undrr.org/static/favicons/pw/v1/favicon-192.png" width="32" height="32" alt="PreventionWeb" /> | [`pw/v1/`](https://assets.undrr.org/static/favicons/pw/v1/) |
 | SFVC | <img src="https://assets.undrr.org/static/favicons/sfvc/v1/favicon-192.png" width="32" height="32" alt="SFVC" /> | [`sfvc/v1/`](https://assets.undrr.org/static/favicons/sfvc/v1/) |
 | Stop Disasters | <img src="https://assets.undrr.org/static/favicons/stop-disasters/v1/favicon-192.png" width="32" height="32" alt="Stop Disasters" /> | [`stop-disasters/v1/`](https://assets.undrr.org/static/favicons/stop-disasters/v1/) |
 | UNDRR | <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png" width="32" height="32" alt="UNDRR" /> | [`undrr/v1/`](https://assets.undrr.org/static/favicons/undrr/v1/) |
 | WTAD | <img src="https://assets.undrr.org/static/favicons/wtad/v1/favicon-192.png" width="32" height="32" alt="WTAD" /> | [`wtad/v1/`](https://assets.undrr.org/static/favicons/wtad/v1/) |
+
+> **Note:** DELTA Resilience does not have its own favicon set — it uses the UNDRR favicon.
 
 ## Files per brand
 
@@ -29,15 +31,15 @@ Each brand directory contains:
 
 | File | Size | Purpose |
 |------|------|---------|
-| `source-icon.png` | 512px | Source artwork (for regeneration, not served) |
+| `source-icon.png` | 512px+ | Source artwork for regeneration — not intended for use in markup |
 | `favicon.ico` | 32x32 | Legacy browser fallback |
 | `apple-touch-icon.png` | 180x180 | iOS home screen |
 | `favicon-192.png` | 192x192 | Android / PWA |
 | `favicon-512.png` | 512x512 | PWA splash screen |
 
-## Example: UNDRR
+## Example
 
-The full set of files for the UNDRR brand:
+The full set of files for the UNDRR brand (the same structure applies to every brand — substitute the directory name):
 
 | File | URL |
 |------|-----|
@@ -50,31 +52,39 @@ Preview at each size:
 
 <div style={{display: 'flex', gap: '2rem', alignItems: 'end', padding: '1rem', background: '#f5f5f5', borderRadius: '8px'}}>
   <div style={{textAlign: 'center'}}>
-    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon.ico" width="32" height="32" alt="32px" />
-    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>32px (.ico)</div>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon.ico" width="32" height="32" alt="UNDRR favicon at 32 pixels" />
+    <div style={{fontSize: '0.8125rem', marginTop: '0.25rem', color: '#333'}}>32px (.ico)</div>
   </div>
   <div style={{textAlign: 'center'}}>
-    <img src="https://assets.undrr.org/static/favicons/undrr/v1/apple-touch-icon.png" width="90" height="90" alt="180px" />
-    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>180px (apple-touch)</div>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/apple-touch-icon.png" width="90" height="90" alt="UNDRR favicon at 180 pixels" />
+    <div style={{fontSize: '0.8125rem', marginTop: '0.25rem', color: '#333'}}>180px (apple-touch)</div>
   </div>
   <div style={{textAlign: 'center'}}>
-    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png" width="96" height="96" alt="192px" />
-    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>192px (Android)</div>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png" width="96" height="96" alt="UNDRR favicon at 192 pixels" />
+    <div style={{fontSize: '0.8125rem', marginTop: '0.25rem', color: '#333'}}>192px (Android)</div>
   </div>
   <div style={{textAlign: 'center'}}>
-    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-512.png" width="128" height="128" alt="512px" />
-    <div style={{fontSize: '0.75rem', marginTop: '0.25rem'}}>512px (PWA splash)</div>
+    <img src="https://assets.undrr.org/static/favicons/undrr/v1/favicon-512.png" width="128" height="128" alt="UNDRR favicon at 512 pixels" />
+    <div style={{fontSize: '0.8125rem', marginTop: '0.25rem', color: '#333'}}>512px (PWA splash)</div>
   </div>
 </div>
 
 ## Recommended markup
 
-Replace `{brand}` with the directory name (e.g. `undrr`, `pw`, `mcr`):
+Replace `{brand}` with the directory name from the table above (`arise`, `gp`, `iddrr`, `irp`, `mcr`, `pw`, `sfvc`, `stop-disasters`, `undrr`, `wtad`):
 
 ```html
 <link rel="icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/favicon.ico" sizes="32x32">
 <link rel="icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/favicon-192.png" sizes="192x192" type="image/png">
 <link rel="apple-touch-icon" href="https://assets.undrr.org/static/favicons/{brand}/v1/apple-touch-icon.png">
+```
+
+For example, PreventionWeb:
+
+```html
+<link rel="icon" href="https://assets.undrr.org/static/favicons/pw/v1/favicon.ico" sizes="32x32">
+<link rel="icon" href="https://assets.undrr.org/static/favicons/pw/v1/favicon-192.png" sizes="192x192" type="image/png">
+<link rel="apple-touch-icon" href="https://assets.undrr.org/static/favicons/pw/v1/apple-touch-icon.png">
 ```
 
 For PWA `manifest.json`:
@@ -92,7 +102,9 @@ For PWA `manifest.json`:
 
 ### Drupal themes
 
-CDN favicons are injected automatically by `undrr_common_page_attachments_alter()` for all child themes. The active Drupal theme is mapped to its favicon brand. Uses the `mangrove_cdn_environment` setting to toggle testing/production CDN paths.
+No action required — CDN favicons are injected automatically by `undrr_common_page_attachments_alter()` for all child themes. The active Drupal theme is mapped to its favicon brand.
+
+The `mangrove_cdn_environment` Drupal setting controls whether favicons load from the production CDN (`assets.undrr.org/static/favicons/`) or the testing CDN (`assets.undrr.org/testing/static/favicons/`). This is configured in each environment's `settings.php`.
 
 ### Astro microsites
 
@@ -123,6 +135,11 @@ Any site can reference the CDN paths directly. Use the recommended markup above 
 Follow the CDN repo's immutability rule: never modify files in an existing version directory. To update a brand's favicons, create a `v2/` directory.
 
 ---
+
+## See also
+
+- [Fonts](?path=/docs/design-decisions-fonts--docs) — CDN-hosted web fonts using the same `assets.undrr.org` infrastructure
+- [CDN reference](?path=/docs/getting-started-integration-cdn-reference--docs) — full index of all CDN-hosted assets
 
 ## References
 

--- a/stories/Documentation/Fonts.mdx
+++ b/stories/Documentation/Fonts.mdx
@@ -143,6 +143,10 @@ When creating components that explicitly set `font-family`, add language-specifi
 
 ---
 
+## See also
+
+- [Favicons](?path=/docs/design-decisions-favicons--docs) — brand favicon sets hosted on the same CDN
+
 ## References
 
 - [OCHA Brand Guidelines - Fonts](https://brand.unocha.org/document/281801#/fonts/fonts)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[x] Documentation content changes
```

## What's this PR addressing?

- Adds `Favicons.mdx` under "Design decisions" in Storybook documenting the canonical CDN-hosted favicon sets for all 10 UNDRR brands
- Includes inline previews loaded from CDN, clickable links, visual size comparison
- Covers recommended `<link>` markup, PWA manifest examples, and integration notes for Drupal themes and Astro microsites
- Documents how to add new brands

## Link to ticket

https://gitlab.com/undrr/web-backlog/-/work_items/2757

## Resources

- CDN source: https://gitlab.com/undrr/common/shared-web-assets/-/tree/main/favicons
- Example URL: https://assets.undrr.org/static/favicons/undrr/v1/favicon-192.png

## Review checklist

Complete the items that apply to this PR:

- [ ] MDX docs follow standard structure
- [ ] Sentence case for all headings and UI text