### PR TITLE
fix: add !default to $mgIconFontPath so Drupal themes can override it

### DIFF
--- a/stories/assets/scss/_variables.scss
+++ b/stories/assets/scss/_variables.scss
@@ -29,7 +29,7 @@ $mg-html-font-size: 16 !default;
 
 // font file variables
 // Path adjusted for Storybook staticDirs (serves assets/ at root, not /assets/)
-$mgIconFontPath: "../fonts/mangrove-icon-set/font";
+$mgIconFontPath: "../fonts/mangrove-icon-set/font" !default;
 
 // image variables
 $img-path: "~/stories/assets/images";


### PR DESCRIPTION
## Problem

After PR #907 (icon build pipeline), `fa-*` font glyphs (e.g. `fa-search`) rendered as broken boxes on Drupal sites.

The root cause: `$mgIconFontPath` in `_variables.scss` was not declared with `!default`, so Drupal themes using `@use ... with ()` syntax got a Sass error and fell back to the compiled default path (`../fonts/mangrove-icon-set/font`), which does not resolve correctly from the theme CSS output directory.

## Fix

Add `!default` to `$mgIconFontPath` so Drupal themes can override it to point at the correct path:

```
/libraries/undrr-mangrove/stories/assets/fonts/mangrove-icon-set/font
```

## Testing

Rebuild Drupal theme CSS (`npm run build` from the Drupal repo root) — font path in compiled CSS should read `/libraries/undrr-mangrove/stories/assets/fonts/mangrove-icon-set/font/...` instead of `../fonts/mangrove-icon-set/font/...`.

For https://gitlab.com/undrr/web-backlog/-/work_items/2759