### PR TITLE
feat: brand guide for non-technical users (#925)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ CONTRIBUTING_ISSUES.md
 # Ignore npm's package lock, we use yarn
 package-lock.json
 npm-debug.log
+.gstack/

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -179,6 +179,7 @@ const preview = {
           [
             'About this guide',
             'Brand identity',
+            'Brand guidelines',
             'Common patterns',
             'Component gallery',
           ],

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -175,6 +175,13 @@ const preview = {
         method: 'alphabetical',
         order: [
           'Introduction',
+          'Brand',
+          [
+            'About this guide',
+            'Brand identity',
+            'Common patterns',
+            'Component gallery',
+          ],
           'Getting started',
           [
             'About Mangrove',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -247,7 +247,7 @@ const preview = {
       defaultValue: 'Global UNDRR Theme',
       toolbar: {
         icon: 'paintbrush',
-        items: Object.keys(themeStyles).map((name) => ({
+        items: Object.keys(themeStyles).map(name => ({
           value: name,
           title: name,
         })),

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Start here when building a new component. Follow these guides in order:
 ## Releasing
 
 - [Release process](RELEASES.md) — versioning, tagging, and publishing to npm
+- [Release 1.5](RELEASE-1.5.md) — icon system change, new OnThisPageNav component, 1.5.1 brand guide addendum
 - [Release 1.4](RELEASE-1.4.md) — migration notes for the 1.4 release (may be removed after 2026)
 
 ## Other guides

--- a/docs/RELEASE-1.5.md
+++ b/docs/RELEASE-1.5.md
@@ -19,6 +19,20 @@ The main change in 1.5: icons now render via CSS `mask-image` instead of a font.
 | Planning the `fa-*` → `mg-icon-*` migration | [Icon migration roadmap](#icon-migration-roadmap-fa--mg-icon-) |
 | A React / npm consumer | [Upgrading from 1.4.x](#upgrading-from-14x) — note the [breaking changes](#breaking-changes) |
 
+## 1.5.1 addendum
+
+Released April 2026. Two changes:
+
+1. **New Brand section in Storybook** ([#925](https://github.com/unisdr/undrr-mangrove/issues/925), [#927](https://github.com/unisdr/undrr-mangrove/pull/927)): A brand guide aimed at non-technical UNDRR colleagues (content editors, brand managers, external partners). Five new pages: About this guide, Brand identity (theme-aware, responds to the theme picker), Brand guidelines (editorial content migrated from SharePoint), Common patterns (shared foundations), and Component gallery (curated catalog of 40+ components). Replaces the outdated Google Sites / SharePoint web style guide references.
+
+2. **Heading font fix** (visual change for all sites): Headings now render in Roboto Condensed as originally specified. Previously h1-h6 inherited the body font (Roboto Regular). This affects every UNDRR site that ships the compiled CSS.
+
+   > **If you manage a site that uses Mangrove:** Your headings will look slightly narrower and more authoritative after this update. The character metrics match the existing brand specification — you're now seeing the intended typography.
+
+   The change is controlled by a new SCSS token `$mg-font-family-headings` (defaults to `$mg-font-family-condensed`). Theme authors can override it if needed.
+
+Full diff: [v1.5.0...v1.5.1 on GitHub](https://github.com/unisdr/undrr-mangrove/compare/v1.5.0...v1.5.1).
+
 ## What's new since 1.4.0
 
 ### New components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@undrr/undrr-mangrove",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Mangrove design System for UNDRR",
   "main": "src/index.js",
   "type": "module",

--- a/scripts/ai-manifest/generate-ai-manifest.js
+++ b/scripts/ai-manifest/generate-ai-manifest.js
@@ -164,51 +164,302 @@ function buildSampleProps(React) {
   return {
     Chips: { label: 'Flood' },
     CtaButton: { label: 'Take action' },
-    TextInput: { label: 'Organization name', required: true, placeholder: 'Enter organization name', helpText: 'Full legal name of your organization.' },
-    Select: { label: 'Country', options: [{ value: 'JP', label: 'Japan' }, { value: 'NP', label: 'Nepal' }, { value: 'PH', label: 'Philippines' }], placeholder: 'Select a country' },
+    TextInput: {
+      label: 'Organization name',
+      required: true,
+      placeholder: 'Enter organization name',
+      helpText: 'Full legal name of your organization.',
+    },
+    Select: {
+      label: 'Country',
+      options: [
+        { value: 'JP', label: 'Japan' },
+        { value: 'NP', label: 'Nepal' },
+        { value: 'PH', label: 'Philippines' },
+      ],
+      placeholder: 'Select a country',
+    },
     Checkbox: { label: 'I agree to the terms and conditions', name: 'terms' },
     Radio: { label: 'Government', name: 'role', value: 'government' },
-    Textarea: { label: 'Message', name: 'message', rows: 5, placeholder: 'Your message here', helpText: 'Max 500 characters.' },
+    Textarea: {
+      label: 'Message',
+      name: 'message',
+      rows: 5,
+      placeholder: 'Your message here',
+      helpText: 'Max 500 characters.',
+    },
     FormGroup: {
       legend: 'What is your role?',
-      children: React.createElement('div', null,
-        React.createElement('div', { className: 'mg-radio', key: '1' },
-          React.createElement('input', { type: 'radio', id: 'r1', name: 'role', value: 'researcher' }),
-          React.createElement('label', { htmlFor: 'r1' }, 'Researcher')),
-        React.createElement('div', { className: 'mg-radio', key: '2' },
-          React.createElement('input', { type: 'radio', id: 'r2', name: 'role', value: 'practitioner' }),
-          React.createElement('label', { htmlFor: 'r2' }, 'Practitioner'))),
+      children: React.createElement(
+        'div',
+        null,
+        React.createElement(
+          'div',
+          { className: 'mg-radio', key: '1' },
+          React.createElement('input', {
+            type: 'radio',
+            id: 'r1',
+            name: 'role',
+            value: 'researcher',
+          }),
+          React.createElement('label', { htmlFor: 'r1' }, 'Researcher')
+        ),
+        React.createElement(
+          'div',
+          { className: 'mg-radio', key: '2' },
+          React.createElement('input', {
+            type: 'radio',
+            id: 'r2',
+            name: 'role',
+            value: 'practitioner',
+          }),
+          React.createElement('label', { htmlFor: 'r2' }, 'Practitioner')
+        )
+      ),
     },
-    FormErrorSummary: { title: 'There is a problem', errors: [{ id: 'email', message: 'Enter a valid email address' }, { id: 'org', message: 'Organization name is required' }] },
-    VerticalCard: { data: [{ title: 'Building resilience through early warning systems', link: '/news/resilience', imgback: 'https://picsum.photos/600/400', imgalt: 'Workshop', label1: 'Early warning', summaryText: 'New partnerships strengthen disaster preparedness.' }] },
-    HorizontalCard: { data: [{ title: 'Climate adaptation strategies', link: '/news/climate', imgback: 'https://picsum.photos/400/300', imgalt: 'Meeting', label1: 'Climate', summaryText: 'Integrated approaches to climate resilience.' }] },
-    BookCard: { data: [{ title: 'Global Assessment Report 2024', link: '/publications/gar-2024', imgback: 'https://picsum.photos/300/400', imgalt: 'GAR 2024 cover' }] },
-    HorizontalBookCard: { data: [{ title: 'Sendai Framework Monitor Report', link: '/publications/sendai', imgback: 'https://picsum.photos/300/400', imgalt: 'Cover', label1: 'DRR', summaryText: 'Progress on implementation.' }] },
-    IconCard: { data: [{ icon: 'mg-icon mg-icon-globe', imageScale: 'medium', title: 'Global risk assessment', summaryText: 'Analysis of disaster risk trends.', link: '/risk', linkText: 'Learn more' }] },
-    StatsCard: { title: 'Key figures', stats: [{ value: '1.23 million', bottomLabel: 'People affected' }, { value: '195', bottomLabel: 'Countries reporting' }, { value: '$2.8 trillion', bottomLabel: 'Economic losses' }] },
-    Breadcrumbs: { data: [{ text: 'Home' }, { text: 'Publications' }, { text: 'Global Assessment Report 2024' }] },
+    FormErrorSummary: {
+      title: 'There is a problem',
+      errors: [
+        { id: 'email', message: 'Enter a valid email address' },
+        { id: 'org', message: 'Organization name is required' },
+      ],
+    },
+    VerticalCard: {
+      data: [
+        {
+          title: 'Building resilience through early warning systems',
+          link: '/news/resilience',
+          imgback: 'https://picsum.photos/600/400',
+          imgalt: 'Workshop',
+          label1: 'Early warning',
+          summaryText: 'New partnerships strengthen disaster preparedness.',
+        },
+      ],
+    },
+    HorizontalCard: {
+      data: [
+        {
+          title: 'Climate adaptation strategies',
+          link: '/news/climate',
+          imgback: 'https://picsum.photos/400/300',
+          imgalt: 'Meeting',
+          label1: 'Climate',
+          summaryText: 'Integrated approaches to climate resilience.',
+        },
+      ],
+    },
+    BookCard: {
+      data: [
+        {
+          title: 'Global Assessment Report 2024',
+          link: '/publications/gar-2024',
+          imgback: 'https://picsum.photos/300/400',
+          imgalt: 'GAR 2024 cover',
+        },
+      ],
+    },
+    HorizontalBookCard: {
+      data: [
+        {
+          title: 'Sendai Framework Monitor Report',
+          link: '/publications/sendai',
+          imgback: 'https://picsum.photos/300/400',
+          imgalt: 'Cover',
+          label1: 'DRR',
+          summaryText: 'Progress on implementation.',
+        },
+      ],
+    },
+    IconCard: {
+      data: [
+        {
+          icon: 'mg-icon mg-icon-globe',
+          imageScale: 'medium',
+          title: 'Global risk assessment',
+          summaryText: 'Analysis of disaster risk trends.',
+          link: '/risk',
+          linkText: 'Learn more',
+        },
+      ],
+    },
+    StatsCard: {
+      title: 'Key figures',
+      stats: [
+        { value: '1.23 million', bottomLabel: 'People affected' },
+        { value: '195', bottomLabel: 'Countries reporting' },
+        { value: '$2.8 trillion', bottomLabel: 'Economic losses' },
+      ],
+    },
+    Breadcrumbs: {
+      data: [
+        { text: 'Home' },
+        { text: 'Publications' },
+        { text: 'Global Assessment Report 2024' },
+      ],
+    },
     Pagination: { text: 'Page', text2: 'of' },
-    Tab: { tabdata: [{ text: 'Overview', text_id: 'overview', is_default: 'true', data: '<p>Overview of disaster risk reduction.</p>' }, { text: 'Details', text_id: 'details', data: '<p>Implementation guidance.</p>' }], variant: 'horizontal' },
-    Hero: { data: [{ title: 'Reducing disaster risk for a resilient future', imgback: 'https://picsum.photos/1600/600', summaryText: 'The Sendai Framework guides global efforts.', label: 'Featured', primary_button: 'Learn more' }] },
-    PageHeader: { variant: 'default', logoUrl: 'https://assets.undrr.org/static/logos/undrr/undrr-logo-horizontal.svg', homeUrl: '/', languages: [{ value: 'en', label: 'English', selected: true }, { value: 'ar', label: 'Arabic' }] },
+    Tab: {
+      tabdata: [
+        {
+          text: 'Overview',
+          text_id: 'overview',
+          is_default: 'true',
+          data: '<p>Overview of disaster risk reduction.</p>',
+        },
+        {
+          text: 'Details',
+          text_id: 'details',
+          data: '<p>Implementation guidance.</p>',
+        },
+      ],
+      variant: 'horizontal',
+    },
+    Hero: {
+      data: [
+        {
+          title: 'Reducing disaster risk for a resilient future',
+          imgback: 'https://picsum.photos/1600/600',
+          summaryText: 'The Sendai Framework guides global efforts.',
+          label: 'Featured',
+          primary_button: 'Learn more',
+        },
+      ],
+    },
+    PageHeader: {
+      variant: 'default',
+      logoUrl:
+        'https://assets.undrr.org/static/logos/undrr/undrr-logo-horizontal.svg',
+      homeUrl: '/',
+      languages: [
+        { value: 'en', label: 'English', selected: true },
+        { value: 'ar', label: 'Arabic' },
+      ],
+    },
     Footer: { enableSyndication: false },
-    QuoteHighlight: { quote: 'Prevention is not a cost. It is an investment in our common future.', attribution: 'Mami Mizutori', attributionTitle: 'SRSG for Disaster Risk Reduction', backgroundColor: 'light', variant: 'line', alignment: 'full' },
-    HighlightBox: { children: React.createElement('div', null, React.createElement('h3', null, 'Key information'), React.createElement('p', null, 'Highlighted content draws attention to important information.')) },
-    EmbedContainer: { children: React.createElement('iframe', { src: 'https://www.youtube-nocookie.com/embed/bIpPtHJbV-Q', title: 'UNDRR video', loading: 'lazy', allowFullScreen: true }) },
-    FullWidth: { children: React.createElement('p', null, 'This section spans the full viewport width.') },
+    QuoteHighlight: {
+      quote:
+        'Prevention is not a cost. It is an investment in our common future.',
+      attribution: 'Mami Mizutori',
+      attributionTitle: 'SRSG for Disaster Risk Reduction',
+      backgroundColor: 'light',
+      variant: 'line',
+      alignment: 'full',
+    },
+    HighlightBox: {
+      children: React.createElement(
+        'div',
+        null,
+        React.createElement('h3', null, 'Key information'),
+        React.createElement(
+          'p',
+          null,
+          'Highlighted content draws attention to important information.'
+        )
+      ),
+    },
+    EmbedContainer: {
+      children: React.createElement('iframe', {
+        src: 'https://www.youtube-nocookie.com/embed/bIpPtHJbV-Q',
+        title: 'UNDRR video',
+        loading: 'lazy',
+        allowFullScreen: true,
+      }),
+    },
+    FullWidth: {
+      children: React.createElement(
+        'p',
+        null,
+        'This section spans the full viewport width.'
+      ),
+    },
     Loader: { label: 'Loading content' },
-    ShowMore: { data: [{ button_text: 'Show more', collapsable_wrapper_class: 'mg-show-more--collapsed', collapsable_text: 'Additional content revealed on toggle.' }] },
-    Pager: { page: 3, totalPages: 12, onPageChange: () => {}, layout: 'centered', ariaLabel: 'Search results pages' },
-    MegaMenu: { sections: [{ items: [{ title: 'About', url: '/about', items: [{ title: 'Our mission', url: '/about/mission' }] }, { title: 'Topics', url: '/topics', items: [{ title: 'Early warning', url: '/topics/early-warning' }] }] }] },
+    ShowMore: {
+      data: [
+        {
+          button_text: 'Show more',
+          collapsable_wrapper_class: 'mg-show-more--collapsed',
+          collapsable_text: 'Additional content revealed on toggle.',
+        },
+      ],
+    },
+    Pager: {
+      page: 3,
+      totalPages: 12,
+      onPageChange: () => {},
+      layout: 'centered',
+      ariaLabel: 'Search results pages',
+    },
+    MegaMenu: {
+      sections: [
+        {
+          items: [
+            {
+              title: 'About',
+              url: '/about',
+              items: [{ title: 'Our mission', url: '/about/mission' }],
+            },
+            {
+              title: 'Topics',
+              url: '/topics',
+              items: [{ title: 'Early warning', url: '/topics/early-warning' }],
+            },
+          ],
+        },
+      ],
+    },
     ScrollContainer: {
       showArrows: true,
       children: [
-        React.createElement('div', { key: '1', style: { minWidth: '200px', padding: '1rem', background: '#f0f0f0' } }, 'Item 1'),
-        React.createElement('div', { key: '2', style: { minWidth: '200px', padding: '1rem', background: '#e0e0e0' } }, 'Item 2'),
-        React.createElement('div', { key: '3', style: { minWidth: '200px', padding: '1rem', background: '#d0d0d0' } }, 'Item 3'),
+        React.createElement(
+          'div',
+          {
+            key: '1',
+            style: {
+              minWidth: '200px',
+              padding: '1rem',
+              background: '#f0f0f0',
+            },
+          },
+          'Item 1'
+        ),
+        React.createElement(
+          'div',
+          {
+            key: '2',
+            style: {
+              minWidth: '200px',
+              padding: '1rem',
+              background: '#e0e0e0',
+            },
+          },
+          'Item 2'
+        ),
+        React.createElement(
+          'div',
+          {
+            key: '3',
+            style: {
+              minWidth: '200px',
+              padding: '1rem',
+              background: '#d0d0d0',
+            },
+          },
+          'Item 3'
+        ),
       ],
     },
-    Gallery: { media: [{ id: '1', type: 'image', src: 'https://picsum.photos/800/600', alt: 'Disaster risk reduction', title: 'Building resilience', description: 'Communities working to reduce disaster risk.' }] },
+    Gallery: {
+      media: [
+        {
+          id: '1',
+          type: 'image',
+          src: 'https://picsum.photos/800/600',
+          alt: 'Disaster risk reduction',
+          title: 'Building resilience',
+          description: 'Communities working to reduce disaster risk.',
+        },
+      ],
+    },
   };
 }
 
@@ -217,7 +468,9 @@ function buildSampleProps(React) {
 // ---------------------------------------------------------------------------
 
 const args = process.argv.slice(2);
-const buildDirArg = (args.find(a => a.startsWith('--build-dir=')) || '').split('=')[1];
+const buildDirArg = (args.find(a => a.startsWith('--build-dir=')) || '').split(
+  '='
+)[1];
 const buildDir = path.resolve(process.cwd(), buildDirArg || 'docs-build-temp');
 const validateOnly = args.includes('--validate');
 
@@ -232,13 +485,14 @@ if (!fs.existsSync(manifestPath)) {
   process.exit(1);
 }
 
-const pkg = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf8'));
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf8')
+);
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
 // Replace {{version}} tokens with actual version from package.json
-const replaceVersion = obj => JSON.parse(
-  JSON.stringify(obj).replaceAll('{{version}}', pkg.version),
-);
+const replaceVersion = obj =>
+  JSON.parse(JSON.stringify(obj).replaceAll('{{version}}', pkg.version));
 
 const curatedData = replaceVersion(htmlExamples);
 const themeCss = replaceVersion(THEME_CSS);
@@ -281,7 +535,7 @@ const npmExports = parseNpmExports();
 // components are added. Used as a fallback when Storybook's internal function
 // name (e.g. BarChartProcessor) differs from the npm export (e.g. BarChart).
 const storybookIdToWebpackName = Object.fromEntries(
-  Object.entries(COMPONENT_IDS).map(([name, id]) => [id, name]),
+  Object.entries(COMPONENT_IDS).map(([name, id]) => [id, name])
 );
 
 // Manual overrides for npm-only components (no webpack entry in COMPONENT_IDS)
@@ -410,7 +664,8 @@ async function renderComponents() {
   const HTMLParser = (await import('prettier/parser-html')).default;
   const SAMPLE_PROPS = buildSampleProps(React);
 
-  const distFiles = fs.readdirSync(distDir)
+  const distFiles = fs
+    .readdirSync(distDir)
     .filter(f => f.endsWith('.js'))
     .map(f => f.replace('.js', ''));
 
@@ -430,9 +685,12 @@ async function renderComponents() {
     try {
       const mod = await import(modulePath);
       const isComponentLike = v =>
-        typeof v === 'function' || (v != null && typeof v === 'object' && v.$$typeof != null);
-      const Component = mod.default || mod[fileName]
-        || mod[Object.keys(mod).find(k => isComponentLike(mod[k]))];
+        typeof v === 'function' ||
+        (v != null && typeof v === 'object' && v.$$typeof != null);
+      const Component =
+        mod.default ||
+        mod[fileName] ||
+        mod[Object.keys(mod).find(k => isComponentLike(mod[k]))];
 
       if (!isComponentLike(Component)) {
         console.warn(`  skip ${fileName}: no renderable export`);
@@ -443,14 +701,20 @@ async function renderComponents() {
       const props = SAMPLE_PROPS[fileName] || {};
       const html = renderToStaticMarkup(React.createElement(Component, props));
       if (html.length < 30) {
-        console.warn(`  skip ${fileName}: rendered HTML too short (${html.length} chars)`);
+        console.warn(
+          `  skip ${fileName}: rendered HTML too short (${html.length} chars)`
+        );
         failed++;
         continue;
       }
 
       let formatted;
       try {
-        formatted = await prettier.format(html, { parser: 'html', plugins: [HTMLParser], printWidth: 100 });
+        formatted = await prettier.format(html, {
+          parser: 'html',
+          plugins: [HTMLParser],
+          printWidth: 100,
+        });
       } catch {
         formatted = html;
       }
@@ -463,7 +727,9 @@ async function renderComponents() {
     }
   }
 
-  console.log(`Rendered component HTML: ${rendered} components, ${failed} skipped`);
+  console.log(
+    `Rendered component HTML: ${rendered} components, ${failed} skipped`
+  );
   return results;
 }
 
@@ -476,8 +742,8 @@ const manifestIds = new Set(Object.values(manifest.components).map(c => c.id));
 // Check curated data keys (component-data.js entries)
 const curatedKeys = Object.keys(curatedData);
 const unmatchedKeys = curatedKeys.filter(k => !manifestIds.has(k));
-const uncoveredIds = [...manifestIds].filter(id =>
-  !curatedData[id] && !REQUIRES_REACT[id] && !id.startsWith('example-'),
+const uncoveredIds = [...manifestIds].filter(
+  id => !curatedData[id] && !REQUIRES_REACT[id] && !id.startsWith('example-')
 );
 
 if (unmatchedKeys.length > 0) {
@@ -485,7 +751,9 @@ if (unmatchedKeys.length > 0) {
   for (const k of unmatchedKeys) console.warn(`  - ${k}`);
 }
 if (uncoveredIds.length > 0) {
-  console.warn(`Note: ${uncoveredIds.length} component(s) have no entry in component-data:`);
+  console.warn(
+    `Note: ${uncoveredIds.length} component(s) have no entry in component-data:`
+  );
   for (const id of uncoveredIds) console.warn(`  - ${id}`);
 }
 
@@ -494,7 +762,9 @@ const orphanedIds = Object.entries(COMPONENT_IDS)
   .filter(([, id]) => !curatedData[id] && !REQUIRES_REACT[id])
   .map(([fileName, id]) => `${fileName} → ${id}`);
 if (orphanedIds.length > 0) {
-  console.warn('Warning: COMPONENT_IDS entries with no component-data or REQUIRES_REACT match (will be skipped):');
+  console.warn(
+    'Warning: COMPONENT_IDS entries with no component-data or REQUIRES_REACT match (will be skipped):'
+  );
   for (const entry of orphanedIds) console.warn(`  - ${entry}`);
 }
 
@@ -507,15 +777,18 @@ const a11yRules = [
     id: 'role-button-on-link',
     label: 'role="button" on link element',
     test(html) {
-      return /<a[^>]*role="button"[^>]*href=/.test(html)
-        || /<a[^>]*href=[^>]*role="button"/.test(html);
+      return (
+        /<a[^>]*role="button"[^>]*href=/.test(html) ||
+        /<a[^>]*href=[^>]*role="button"/.test(html)
+      );
     },
   },
   {
     id: 'icon-missing-aria-hidden',
     label: 'icon element missing aria-hidden="true"',
     test(html) {
-      const iconPattern = /<(?:i|span)\b[^>]*class="[^"]*\bmg-icon\b(?!-wrap)[^"]*"[^>]*>/g;
+      const iconPattern =
+        /<(?:i|span)\b[^>]*class="[^"]*\bmg-icon\b(?!-wrap)[^"]*"[^>]*>/g;
       let match;
       while ((match = iconPattern.exec(html)) !== null) {
         if (!/aria-hidden\s*=\s*"true"/.test(match[0])) return true;
@@ -580,7 +853,8 @@ const a11yRules = [
   },
   {
     id: 'role-img-with-interactive-children',
-    label: 'role="img" on element containing interactive content (hides children from AT)',
+    label:
+      'role="img" on element containing interactive content (hides children from AT)',
     test(html) {
       const roleImgPattern = /<(\w+)\b[^>]*role="img"[^>]*>[\s\S]*?<\/\1>/g;
       let match;
@@ -624,14 +898,13 @@ if (a11yViolations.length > 0) {
 
 const totalComponents = Object.keys(manifest.components).length;
 const withProps = Object.values(manifest.components).filter(
-  c => c.reactDocgen?.props && Object.keys(c.reactDocgen.props).length > 0,
+  c => c.reactDocgen?.props && Object.keys(c.reactDocgen.props).length > 0
 ).length;
-const coverage = totalComponents > 0
-  ? Math.round((withProps / totalComponents) * 100)
-  : 0;
+const coverage =
+  totalComponents > 0 ? Math.round((withProps / totalComponents) * 100) : 0;
 
 console.log(
-  `PropTypes coverage: ${withProps} of ${totalComponents} components have props documented (${coverage}%)`,
+  `PropTypes coverage: ${withProps} of ${totalComponents} components have props documented (${coverage}%)`
 );
 
 // ---------------------------------------------------------------------------
@@ -670,7 +943,8 @@ async function checkCuratedDrift() {
   const SAMPLE_PROPS = buildSampleProps(React);
   const warnings = [];
 
-  const distFiles = fs.readdirSync(distDir)
+  const distFiles = fs
+    .readdirSync(distDir)
     .filter(f => f.endsWith('.js'))
     .map(f => f.replace('.js', ''));
 
@@ -687,14 +961,19 @@ async function checkCuratedDrift() {
     try {
       const mod = await import(modulePath);
       const isComponentLike = v =>
-        typeof v === 'function' || (v != null && typeof v === 'object' && v.$$typeof != null);
-      const Component = mod.default || mod[fileName]
-        || mod[Object.keys(mod).find(k => isComponentLike(mod[k]))];
+        typeof v === 'function' ||
+        (v != null && typeof v === 'object' && v.$$typeof != null);
+      const Component =
+        mod.default ||
+        mod[fileName] ||
+        mod[Object.keys(mod).find(k => isComponentLike(mod[k]))];
 
       if (!isComponentLike(Component)) continue;
 
       const props = SAMPLE_PROPS[fileName] || {};
-      const rendered = renderToStaticMarkup(React.createElement(Component, props));
+      const rendered = renderToStaticMarkup(
+        React.createElement(Component, props)
+      );
       if (rendered.length < 30) continue;
 
       const renderedClasses = extractBemClasses(rendered);
@@ -706,13 +985,19 @@ async function checkCuratedDrift() {
       // Compare only BEM blocks/elements (not modifiers, which are prop-dependent).
       // Curated HTML often shows multiple variants, but auto-render only produces one,
       // so modifier differences (mg-card--secondary etc.) are expected noise.
-      const staleInCurated = [...curatedClasses].filter(c => !isBemModifier(c) && !renderedClasses.has(c));
-      const missingFromCurated = [...renderedClasses].filter(c => !isBemModifier(c) && !curatedClasses.has(c));
+      const staleInCurated = [...curatedClasses].filter(
+        c => !isBemModifier(c) && !renderedClasses.has(c)
+      );
+      const missingFromCurated = [...renderedClasses].filter(
+        c => !isBemModifier(c) && !curatedClasses.has(c)
+      );
 
       if (staleInCurated.length > 0 || missingFromCurated.length > 0) {
         const parts = [];
-        if (staleInCurated.length > 0) parts.push(`curated has: ${staleInCurated.join(', ')}`);
-        if (missingFromCurated.length > 0) parts.push(`rendered has: ${missingFromCurated.join(', ')}`);
+        if (staleInCurated.length > 0)
+          parts.push(`curated has: ${staleInCurated.join(', ')}`);
+        if (missingFromCurated.length > 0)
+          parts.push(`rendered has: ${missingFromCurated.join(', ')}`);
         warnings.push(`  ${componentId}: ${parts.join(' | ')}`);
       }
     } catch {
@@ -730,18 +1015,26 @@ if (validateOnly) {
   let failed = false;
 
   if (unmatchedKeys.length > 0) {
-    console.error('Validation failed: component-data keys do not match manifest.');
+    console.error(
+      'Validation failed: component-data keys do not match manifest.'
+    );
     failed = true;
   }
   if (a11yViolations.length > 0) {
-    console.error(`Validation failed: ${a11yViolations.length} a11y violation(s) in curated HTML.`);
+    console.error(
+      `Validation failed: ${a11yViolations.length} a11y violation(s) in curated HTML.`
+    );
     failed = true;
   }
 
   // Fail if any Storybook component has no manifest entry at all
   if (uncoveredIds.length > 0) {
-    console.error(`Validation failed: ${uncoveredIds.length} component(s) have no entry in component-data or REQUIRES_REACT.`);
-    console.error('Add an entry to scripts/ai-manifest/component-data.js or REQUIRES_REACT for each:');
+    console.error(
+      `Validation failed: ${uncoveredIds.length} component(s) have no entry in component-data or REQUIRES_REACT.`
+    );
+    console.error(
+      'Add an entry to scripts/ai-manifest/component-data.js or REQUIRES_REACT for each:'
+    );
     for (const id of uncoveredIds) console.error(`  - ${id}`);
     failed = true;
   }
@@ -749,9 +1042,13 @@ if (validateOnly) {
   // Run drift check (warnings only — does not fail the build)
   const driftWarnings = await checkCuratedDrift();
   if (driftWarnings.length > 0) {
-    console.warn('Curated HTML drift detected (BEM classes differ from auto-rendered output):');
+    console.warn(
+      'Curated HTML drift detected (BEM classes differ from auto-rendered output):'
+    );
     for (const w of driftWarnings) console.warn(w);
-    console.warn('Review component-data.js entries above — curated HTML may be stale.');
+    console.warn(
+      'Review component-data.js entries above — curated HTML may be stale.'
+    );
   }
 
   if (failed) {
@@ -771,7 +1068,9 @@ async function main() {
   try {
     renderedHtml = await renderComponents();
   } catch (e) {
-    console.warn(`Warning: auto-render failed (${e.message}). Continuing with curated HTML only.`);
+    console.warn(
+      `Warning: auto-render failed (${e.message}). Continuing with curated HTML only.`
+    );
     renderedHtml = new Map();
   }
 
@@ -828,9 +1127,14 @@ async function main() {
     }
 
     // Props
-    if (component.reactDocgen?.props && Object.keys(component.reactDocgen.props).length > 0) {
+    if (
+      component.reactDocgen?.props &&
+      Object.keys(component.reactDocgen.props).length > 0
+    ) {
       detail.props = {};
-      for (const [propName, propDef] of Object.entries(component.reactDocgen.props)) {
+      for (const [propName, propDef] of Object.entries(
+        component.reactDocgen.props
+      )) {
         const prop = {
           type: flattenType(propDef.type),
           required: propDef.required || false,
@@ -889,10 +1193,11 @@ async function main() {
   const reactCount = indexEntries.filter(e => e.requiresReact).length;
 
   const index = {
-    _ai: 'Component index for the UNDRR Mangrove library. '
-      + 'Most components work as vanilla HTML with CSS classes (vanillaHtml: true). '
-      + 'Some require React (requiresReact: true). '
-      + 'Each entry has a detailsUrl with full props, rendered HTML examples, and code snippets.',
+    _ai:
+      'Component index for the UNDRR Mangrove library. ' +
+      'Most components work as vanilla HTML with CSS classes (vanillaHtml: true). ' +
+      'Some require React (requiresReact: true). ' +
+      'Each entry has a detailsUrl with full props, rendered HTML examples, and code snippets.',
     library: {
       name: pkg.name,
       version: pkg.version,
@@ -918,7 +1223,8 @@ async function main() {
         cssThemes: themeCss,
       },
       requiredAssets: {
-        _note: 'Every UNDRR-branded page should include these assets. Order matters.',
+        _note:
+          'Every UNDRR-branded page should include these assets. Order matters.',
         stylesheets: requiredStylesheets,
         scripts: requiredScripts,
         logos,
@@ -938,7 +1244,7 @@ async function main() {
   for (const { id, content } of componentFiles) {
     fs.writeFileSync(
       path.join(outputDir, `${id}.json`),
-      JSON.stringify(content, null, 2),
+      JSON.stringify(content, null, 2)
     );
   }
 
@@ -947,8 +1253,9 @@ async function main() {
   // -------------------------------------------------------------------------
 
   const utilities = replaceVersion({
-    _ai: 'CSS utility classes for the UNDRR Mangrove library. '
-      + 'Include the Mangrove CSS bundle to use these classes in plain HTML.',
+    _ai:
+      'CSS utility classes for the UNDRR Mangrove library. ' +
+      'Include the Mangrove CSS bundle to use these classes in plain HTML.',
     ...cssUtilities,
     generatedAt,
   });
@@ -956,7 +1263,10 @@ async function main() {
   const utilitiesJson = JSON.stringify(utilities, null, 2);
   fs.writeFileSync(path.join(outputDir, 'utilities.json'), utilitiesJson);
 
-  const utilityClassCount = cssUtilities.categories.reduce((sum, cat) => sum + cat.classes.length, 0);
+  const utilityClassCount = cssUtilities.categories.reduce(
+    (sum, cat) => sum + cat.classes.length,
+    0
+  );
 
   // -------------------------------------------------------------------------
   // Write llms.txt
@@ -1061,35 +1371,48 @@ Key brand facts:
   // Write llms.json
   // -------------------------------------------------------------------------
 
-  const llmsJson = JSON.stringify({
-    name: 'UNDRR Mangrove',
-    description: `UI component library for UNDRR disaster risk reduction websites. ${vanillaCount} vanilla HTML components, ${reactCount} React-only.`,
-    version: pkg.version,
-    package: pkg.name,
-    license: pkg.license || 'See LICENSE file',
-    urls: {
-      storybook: DOCS_BASE,
-      repository: 'https://github.com/unisdr/undrr-mangrove',
-      npm: `https://www.npmjs.com/package/${pkg.name}`,
-      componentIndex: `${DOCS_BASE}ai-components/index.json`,
-      utilities: `${DOCS_BASE}ai-components/utilities.json`,
-      css: themeCss,
+  const llmsJson = JSON.stringify(
+    {
+      name: 'UNDRR Mangrove',
+      description: `UI component library for UNDRR disaster risk reduction websites. ${vanillaCount} vanilla HTML components, ${reactCount} React-only.`,
+      version: pkg.version,
+      package: pkg.name,
+      license: pkg.license || 'See LICENSE file',
+      urls: {
+        storybook: DOCS_BASE,
+        repository: 'https://github.com/unisdr/undrr-mangrove',
+        npm: `https://www.npmjs.com/package/${pkg.name}`,
+        componentIndex: `${DOCS_BASE}ai-components/index.json`,
+        utilities: `${DOCS_BASE}ai-components/utilities.json`,
+        css: themeCss,
+      },
+      requiredAssets: {
+        _note:
+          'Every UNDRR-branded page should include these. The page header and footer structures are non-negotiable branding elements — use them exactly as documented.',
+        stylesheets: requiredStylesheets.map(s => s.url),
+        scripts: requiredScripts.map(s => ({
+          url: s.url,
+          defer: s.attributes === 'defer',
+        })),
+        logos,
+      },
+      conventions: {
+        cssPrefix: 'mg-',
+        naming: 'BEM',
+        themes: ['undrr', 'preventionweb', 'irp', 'mcr2030'],
+        locales: ['en', 'ar', 'my', 'ja'],
+        breakpoints: {
+          mobile: '480px',
+          tablet: '900px',
+          desktop: '1164px',
+          wide: '1440px',
+        },
+      },
+      generatedAt,
     },
-    requiredAssets: {
-      _note: 'Every UNDRR-branded page should include these. The page header and footer structures are non-negotiable branding elements — use them exactly as documented.',
-      stylesheets: requiredStylesheets.map(s => s.url),
-      scripts: requiredScripts.map(s => ({ url: s.url, defer: s.attributes === 'defer' })),
-      logos,
-    },
-    conventions: {
-      cssPrefix: 'mg-',
-      naming: 'BEM',
-      themes: ['undrr', 'preventionweb', 'irp', 'mcr2030'],
-      locales: ['en', 'ar', 'my', 'ja'],
-      breakpoints: { mobile: '480px', tablet: '900px', desktop: '1164px', wide: '1440px' },
-    },
-    generatedAt,
-  }, null, 2);
+    null,
+    2
+  );
 
   fs.writeFileSync(path.join(buildDir, 'llms.json'), llmsJson);
 
@@ -1098,19 +1421,32 @@ Key brand facts:
   // -------------------------------------------------------------------------
 
   const indexSizeKB = (Buffer.byteLength(indexJson) / 1024).toFixed(1);
-  const totalDetailKB = componentFiles
-    .reduce((sum, { content }) => sum + Buffer.byteLength(JSON.stringify(content, null, 2)), 0);
+  const totalDetailKB = componentFiles.reduce(
+    (sum, { content }) =>
+      sum + Buffer.byteLength(JSON.stringify(content, null, 2)),
+    0
+  );
   const utilitiesSizeKB = (Buffer.byteLength(utilitiesJson) / 1024).toFixed(1);
 
   console.log('AI manifest generated:');
   console.log(`  ${llmsTxtPath} (llms.txt + llms.json)`);
-  console.log(`  ${outputDir}/index.json (${indexEntries.length} components, ${indexSizeKB} KB)`);
-  console.log(`  ${outputDir}/*.json (${componentFiles.length} component files, ${(totalDetailKB / 1024).toFixed(1)} KB total)`);
+  console.log(
+    `  ${outputDir}/index.json (${indexEntries.length} components, ${indexSizeKB} KB)`
+  );
+  console.log(
+    `  ${outputDir}/*.json (${componentFiles.length} component files, ${(totalDetailKB / 1024).toFixed(1)} KB total)`
+  );
   console.log(`  ${outputDir}/utilities.json (${utilitiesSizeKB} KB)`);
-  console.log(`  ${vanillaCount} vanilla HTML components, ${reactCount} React-only components`);
-  console.log(`  ${renderedHtml.size} auto-rendered, ${componentFiles.filter(c => c.content.renderedHtml && !c.content.renderedHtmlSource).length} curated HTML`);
+  console.log(
+    `  ${vanillaCount} vanilla HTML components, ${reactCount} React-only components`
+  );
+  console.log(
+    `  ${renderedHtml.size} auto-rendered, ${componentFiles.filter(c => c.content.renderedHtml && !c.content.renderedHtmlSource).length} curated HTML`
+  );
   if (droppedImportCount > 0) {
-    console.log(`  ${droppedImportCount} Storybook-generated import(s) removed (not exported from src/index.js)`);
+    console.log(
+      `  ${droppedImportCount} Storybook-generated import(s) removed (not exported from src/index.js)`
+    );
   }
 }
 

--- a/scripts/ai-manifest/generate-ai-manifest.js
+++ b/scripts/ai-manifest/generate-ai-manifest.js
@@ -1341,20 +1341,40 @@ Use $mg-z-index-* tokens from _variables.scss for global stacking contexts (fixe
 
 ### Brand guide
 
-The Storybook includes a Brand section for non-technical users (content editors, brand managers, external partners):
+The Storybook includes a Brand section for non-technical users (content editors, brand managers, external partners). Five pages:
 
-- **Brand identity** (${DOCS_BASE}?path=/story/brand-brand-identity--docs): Theme-aware page showing colors, typography, logos, buttons, and icons for each UNDRR property. Switch themes in the toolbar to see different brands.
-- **Brand guidelines** (${DOCS_BASE}?path=/docs/brand-brand-guidelines--docs): Editorial guidance including brand positioning, communication rules, logo usage, and photography standards.
-- **About this guide** (${DOCS_BASE}?path=/docs/brand-about-this-guide--docs): Overview of all five UNDRR web properties with links.
+- **About this guide** (${DOCS_BASE}?path=/docs/brand-about-this-guide--docs): Overview with theme-map cards linking to each UNDRR property's brand identity preset.
+- **Brand identity** (${DOCS_BASE}?path=/story/brand-brand-identity--docs): Theme-aware page showing colors, typography, logos, buttons, and icons. Switch themes via toolbar or append \`&globals=theme:<Theme Name>\` to the URL. Colors are probed live from compiled CSS via \`getComputedStyle\`, so they stay in sync with SCSS.
+- **Brand guidelines** (${DOCS_BASE}?path=/docs/brand-brand-guidelines--docs): Editorial guidance — brand positioning, communication rules, logo usage, photography standards, web elements. Migrated from UNDRR SharePoint.
+- **Common patterns** (${DOCS_BASE}?path=/docs/brand-common-patterns--docs): Plain-language reference for foundations shared across all themes — breakpoints, grid classes (\`mg-grid__col-{N}\`), accessibility standards, language support (\`lang="ar"\` mechanism), icon sources, z-index.
+- **Component gallery** (${DOCS_BASE}?path=/docs/brand-component-gallery--docs): Curated catalog of ~40 components in 8 categories (page structure, hero, content cards, interactive, data viz, typography, layout helpers, platform features). Each row links to the full component docs. Useful first stop when navigating what exists.
 
-Key brand facts:
-- UNDRR brand characteristics: Knowledgeable, Approachable, Collaborative
-- Communication: avoid UN jargon, use the inverted pyramid, make stories around real people, portray prevention positively
-- Typography: Roboto Condensed for headings, Roboto for body text, Noto Kufi Arabic for Arabic headings
-- Five themed properties: UNDRR (blue #004f91), PreventionWeb (teal #0a6969), MCR2030 (purple #591a61), IRP (blue #0f78bf), DELTA Resilience (navy #132e48)
-- Photo sizes: Hero 1440x540 (16:6), News 1164x665 (16:9), Publication 176x235 (3:4), Thumbnail 176x176 (1:1)
-- Logo safety zone: width of the "U" in UNDRR
-- OCHA humanitarian icons for hazard-related content, Mangrove icon set for web UI
+Theme key facts:
+- Five themed properties with resolved primary colors: UNDRR (blue #004f91), PreventionWeb (teal #0a6969), MCR2030 (purple #591a61), IRP (bright blue #0f78bf), DELTA Resilience (navy #132e48).
+- Neutrals are shared across all themes — only brand/accent colors change per property.
+
+Brand characteristics (UNDRR voice): Knowledgeable, Approachable, Collaborative.
+
+Editorial rules:
+- Avoid UN jargon. Lead with people, not issues. Use inverted pyramid. Positive framing for prevention content.
+
+Typography:
+- Headings: Roboto Condensed (via \`$mg-font-family-headings\` token, defaults to \`$mg-font-family-condensed\`). Applied to h1-h6 globally.
+- Body: Roboto (\`$mg-font-family\`).
+- Arabic: Noto Kufi Arabic (headings) + Dubai (body), applied automatically via \`:lang(ar)\` selectors when \`lang="ar"\` is set on a container.
+
+Photo sizes (credit/source required on every image):
+- Hero 1440x540 (16:6), News 1164x665 (16:9), Publication 176x235 (3:4), Thumbnail 176x176 (1:1).
+
+Logos (hosted on CDN for hotlinking or download):
+- UNDRR: https://assets.undrr.org/static/logos/undrr/undrr-logo-blue.svg (blue, white, square variants)
+- PreventionWeb: https://assets.undrr.org/static/logos/pw/pw-logo.svg
+- IRP: https://assets.undrr.org/static/logos/irp/irp-logo.svg
+- MCR2030 and DELTA: not yet on CDN
+- Safety zone equals the width of the "U" in UNDRR. Do not place on busy backgrounds. Use inverse (white) variant on dark backgrounds.
+
+Icons:
+- Lucide for general UI icons, OCHA for humanitarian/hazard icons (earthquake, tsunami, flood, cyclone, drought, resilience), plus custom UNDRR icons. Use via \`<Icon name="..."/>\` or CSS classes \`mg-icon mg-icon-{name}\`.
 
 ### Source layout
 

--- a/scripts/ai-manifest/generate-ai-manifest.js
+++ b/scripts/ai-manifest/generate-ai-manifest.js
@@ -1029,6 +1029,23 @@ Use $mg-z-index-* tokens from _variables.scss for global stacking contexts (fixe
 4. Fetch its detailsUrl for rendered HTML, props, and code examples
 5. For CSS utilities, fetch ${DOCS_BASE}ai-components/utilities.json
 
+### Brand guide
+
+The Storybook includes a Brand section for non-technical users (content editors, brand managers, external partners):
+
+- **Brand identity** (${DOCS_BASE}?path=/story/brand-brand-identity--docs): Theme-aware page showing colors, typography, logos, buttons, and icons for each UNDRR property. Switch themes in the toolbar to see different brands.
+- **Brand guidelines** (${DOCS_BASE}?path=/docs/brand-brand-guidelines--docs): Editorial guidance including brand positioning, communication rules, logo usage, and photography standards.
+- **About this guide** (${DOCS_BASE}?path=/docs/brand-about-this-guide--docs): Overview of all five UNDRR web properties with links.
+
+Key brand facts:
+- UNDRR brand characteristics: Knowledgeable, Approachable, Collaborative
+- Communication: avoid UN jargon, use the inverted pyramid, make stories around real people, portray prevention positively
+- Typography: Roboto Condensed for headings, Roboto for body text, Noto Kufi Arabic for Arabic headings
+- Five themed properties: UNDRR (blue #004f91), PreventionWeb (teal #0a6969), MCR2030 (purple #591a61), IRP (blue #0f78bf), DELTA Resilience (navy #132e48)
+- Photo sizes: Hero 1440x540 (16:6), News 1164x665 (16:9), Publication 176x235 (3:4), Thumbnail 176x176 (1:1)
+- Logo safety zone: width of the "U" in UNDRR
+- OCHA humanitarian icons for hazard-related content, Mangrove icon set for web UI
+
 ### Source layout
 
 - stories/Atom/          Typography, images, layout, navigation

--- a/stories/Documentation/Brand/AboutThisGuide.mdx
+++ b/stories/Documentation/Brand/AboutThisGuide.mdx
@@ -1,0 +1,103 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { VerticalCard } from '../../Components/Cards/Card/VerticalCard';
+
+<Meta
+  title="Brand/About this guide"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# UNDRR web style guide
+
+Colors, fonts, and components used across UNDRR websites.
+
+---
+
+## Who this is for
+
+For content editors, designers, and partners who work with UNDRR web properties.
+This guide shows the visual identity of each property so you can stay on-brand
+without needing to read code or install anything. For developers, see
+<LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started</LinkTo>.
+
+---
+
+## Choose your property
+
+Each UNDRR web property has its own visual identity. Click a card to see that
+property's colors, fonts, and component styles on the
+<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
+  <VerticalCard
+    data={[{
+      title: 'UNDRR',
+      summaryText: 'undrr.org',
+      link: '/?path=/story/brand-brand-identity--docs&globals=theme:Global+UNDRR+Theme',
+      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23004f91' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EUNDRR%3C/text%3E%3C/svg%3E",
+      imgalt: 'UNDRR primary blue'
+    }]}
+  />
+  <VerticalCard
+    data={[{
+      title: 'PreventionWeb',
+      summaryText: 'preventionweb.net',
+      link: '/?path=/story/brand-brand-identity--docs&globals=theme:PreventionWeb+Theme',
+      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230a6969' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EPreventionWeb%3C/text%3E%3C/svg%3E",
+      imgalt: 'PreventionWeb primary teal'
+    }]}
+  />
+  <VerticalCard
+    data={[{
+      title: 'MCR2030',
+      summaryText: 'mcr2030.undrr.org',
+      link: '/?path=/story/brand-brand-identity--docs&globals=theme:MCR2030+Theme',
+      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23591a61' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EMCR2030%3C/text%3E%3C/svg%3E",
+      imgalt: 'MCR2030 primary purple'
+    }]}
+  />
+  <VerticalCard
+    data={[{
+      title: 'IRP',
+      summaryText: 'International Recovery Platform',
+      link: '/?path=/story/brand-brand-identity--docs&globals=theme:IRP+Theme',
+      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230f78bf' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EIRP%3C/text%3E%3C/svg%3E",
+      imgalt: 'IRP primary bright blue'
+    }]}
+  />
+  <VerticalCard
+    data={[{
+      title: 'DELTA Resilience',
+      summaryText: 'deltaresilience.org',
+      link: '/?path=/story/brand-brand-identity--docs&globals=theme:DELTA+Resilience+Theme',
+      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23132e48' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EDELTA%3C/text%3E%3C/svg%3E",
+      imgalt: 'DELTA Resilience primary dark navy'
+    }]}
+  />
+</div>
+
+---
+
+## How to use the theme switcher
+
+Use the **theme selector** in the toolbar above to see how components look in each
+property's style. When browsing a brand page, switch to that property's theme for
+the most accurate preview.
+
+---
+
+## Quick links
+
+- <LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started guide</LinkTo> (for developers)
+- <LinkTo kind="design-decisions-colors" story="docs">Full color reference</LinkTo> (all tokens, developer-oriented)
+- <LinkTo kind="design-decisions-typography" story="docs">Full typography reference</LinkTo>
+- [Report an issue](https://github.com/unisdr/undrr-mangrove/issues)
+
+---
+
+Last updated: {new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}

--- a/stories/Documentation/Brand/AboutThisGuide.mdx
+++ b/stories/Documentation/Brand/AboutThisGuide.mdx
@@ -100,4 +100,4 @@ the most accurate preview.
 
 ---
 
-Last updated: {new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+Last updated: 11 April 2026

--- a/stories/Documentation/Brand/AboutThisGuide.mdx
+++ b/stories/Documentation/Brand/AboutThisGuide.mdx
@@ -122,17 +122,10 @@ the most accurate preview.
 
 ## Quick links
 
-- <LinkTo kind="getting-started-getting-started-guide" story="docs">
-    Getting started guide
-  </LinkTo>
-  (for developers)
-- <LinkTo kind="design-decisions-colors" story="docs">
-    Full color reference
-  </LinkTo>
-  (all tokens, developer-oriented)
-- <LinkTo kind="design-decisions-typography" story="docs">
-    Full typography reference
-  </LinkTo>
+{/* prettier-ignore */}
+- <LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started guide</LinkTo> (for developers)
+- <LinkTo kind="design-decisions-colors" story="docs">Full color reference</LinkTo> (all tokens, developer-oriented)
+- <LinkTo kind="design-decisions-typography" story="docs">Full typography reference</LinkTo>
 - [Report an issue](https://github.com/unisdr/undrr-mangrove/issues)
 
 ---

--- a/stories/Documentation/Brand/AboutThisGuide.mdx
+++ b/stories/Documentation/Brand/AboutThisGuide.mdx
@@ -23,7 +23,11 @@ Colors, fonts, and components used across UNDRR websites.
 For content editors, designers, and partners who work with UNDRR web properties.
 This guide shows the visual identity of each property so you can stay on-brand
 without needing to read code or install anything. For developers, see
-<LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started</LinkTo>.
+
+<LinkTo kind="getting-started-getting-started-guide" story="docs">
+  Getting started
+</LinkTo>
+.
 
 ---
 
@@ -31,53 +35,78 @@ without needing to read code or install anything. For developers, see
 
 Each UNDRR web property has its own visual identity. Click a card to see that
 property's colors, fonts, and component styles on the
-<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
 
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
+<LinkTo kind="brand-brand-identity" story="docs">
+  Brand identity
+</LinkTo>
+page.
+
+<div
+  style={{
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: '1rem',
+  }}
+>
   <VerticalCard
-    data={[{
-      title: 'UNDRR',
-      summaryText: 'undrr.org',
-      link: '/?path=/story/brand-brand-identity--docs&globals=theme:Global+UNDRR+Theme',
-      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23004f91' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EUNDRR%3C/text%3E%3C/svg%3E",
-      imgalt: 'UNDRR primary blue'
-    }]}
+    data={[
+      {
+        title: 'UNDRR',
+        summaryText: 'undrr.org',
+        link: '/?path=/story/brand-brand-identity--docs&globals=theme:Global+UNDRR+Theme',
+        imgback:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23004f91' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EUNDRR%3C/text%3E%3C/svg%3E",
+        imgalt: 'UNDRR primary blue',
+      },
+    ]}
   />
   <VerticalCard
-    data={[{
-      title: 'PreventionWeb',
-      summaryText: 'preventionweb.net',
-      link: '/?path=/story/brand-brand-identity--docs&globals=theme:PreventionWeb+Theme',
-      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230a6969' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EPreventionWeb%3C/text%3E%3C/svg%3E",
-      imgalt: 'PreventionWeb primary teal'
-    }]}
+    data={[
+      {
+        title: 'PreventionWeb',
+        summaryText: 'preventionweb.net',
+        link: '/?path=/story/brand-brand-identity--docs&globals=theme:PreventionWeb+Theme',
+        imgback:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230a6969' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EPreventionWeb%3C/text%3E%3C/svg%3E",
+        imgalt: 'PreventionWeb primary teal',
+      },
+    ]}
   />
   <VerticalCard
-    data={[{
-      title: 'MCR2030',
-      summaryText: 'mcr2030.undrr.org',
-      link: '/?path=/story/brand-brand-identity--docs&globals=theme:MCR2030+Theme',
-      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23591a61' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EMCR2030%3C/text%3E%3C/svg%3E",
-      imgalt: 'MCR2030 primary purple'
-    }]}
+    data={[
+      {
+        title: 'MCR2030',
+        summaryText: 'mcr2030.undrr.org',
+        link: '/?path=/story/brand-brand-identity--docs&globals=theme:MCR2030+Theme',
+        imgback:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23591a61' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EMCR2030%3C/text%3E%3C/svg%3E",
+        imgalt: 'MCR2030 primary purple',
+      },
+    ]}
   />
   <VerticalCard
-    data={[{
-      title: 'IRP',
-      summaryText: 'International Recovery Platform',
-      link: '/?path=/story/brand-brand-identity--docs&globals=theme:IRP+Theme',
-      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230f78bf' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EIRP%3C/text%3E%3C/svg%3E",
-      imgalt: 'IRP primary bright blue'
-    }]}
+    data={[
+      {
+        title: 'IRP',
+        summaryText: 'International Recovery Platform',
+        link: '/?path=/story/brand-brand-identity--docs&globals=theme:IRP+Theme',
+        imgback:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%230f78bf' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='32' font-family='sans-serif' text-anchor='middle'%3EIRP%3C/text%3E%3C/svg%3E",
+        imgalt: 'IRP primary bright blue',
+      },
+    ]}
   />
   <VerticalCard
-    data={[{
-      title: 'DELTA Resilience',
-      summaryText: 'deltaresilience.org',
-      link: '/?path=/story/brand-brand-identity--docs&globals=theme:DELTA+Resilience+Theme',
-      imgback: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23132e48' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EDELTA%3C/text%3E%3C/svg%3E",
-      imgalt: 'DELTA Resilience primary dark navy'
-    }]}
+    data={[
+      {
+        title: 'DELTA Resilience',
+        summaryText: 'deltaresilience.org',
+        link: '/?path=/story/brand-brand-identity--docs&globals=theme:DELTA+Resilience+Theme',
+        imgback:
+          "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23132e48' width='400' height='200'/%3E%3Ctext x='200' y='110' fill='white' font-size='24' font-family='sans-serif' text-anchor='middle'%3EDELTA%3C/text%3E%3C/svg%3E",
+        imgalt: 'DELTA Resilience primary dark navy',
+      },
+    ]}
   />
 </div>
 
@@ -93,9 +122,17 @@ the most accurate preview.
 
 ## Quick links
 
-- <LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started guide</LinkTo> (for developers)
-- <LinkTo kind="design-decisions-colors" story="docs">Full color reference</LinkTo> (all tokens, developer-oriented)
-- <LinkTo kind="design-decisions-typography" story="docs">Full typography reference</LinkTo>
+- <LinkTo kind="getting-started-getting-started-guide" story="docs">
+    Getting started guide
+  </LinkTo>
+  (for developers)
+- <LinkTo kind="design-decisions-colors" story="docs">
+    Full color reference
+  </LinkTo>
+  (all tokens, developer-oriented)
+- <LinkTo kind="design-decisions-typography" story="docs">
+    Full typography reference
+  </LinkTo>
 - [Report an issue](https://github.com/unisdr/undrr-mangrove/issues)
 
 ---

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -91,7 +91,7 @@ UNDRR's brand is defined by three core characteristics:
 - **Communicate on prevention in a positive way** — use positive images
 - **Make stories around real people**, not just issues
 - **Be short and concise on the web** — use the inverted pyramid structure
-- For detailed writing guidance, see the <LinkTo kind="getting-started-contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo>
+- For detailed writing guidance, see the <LinkTo kind="contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo>
 
 ---
 
@@ -167,13 +167,13 @@ UNDRR uses two icon sets:
 UNDRR's web presences should be consistent and connected. The following components
 are shared across all UNDRR sites:
 
-### Global header
+### Page header
 
-The global navigation should appear on all UNDRR sites and tools. It displays the
-language selector, login icon, and global menu linking to core resources. The main
-navigation often uses a sticky header with the Sendai color stripe.
+The page header displays the Sendai color stripe, UNDRR logo, and global navigation
+on every page. It includes the language selector, login icon, and links to core
+resources and tools.
 
-See: <LinkTo kind="components-mega-menu" story="docs">Mega menu component</LinkTo>
+See: <LinkTo kind="components-pageheader" story="docs">Page header component</LinkTo> | <LinkTo kind="components-mega-menu" story="docs">Mega menu component</LinkTo>
 
 ### Footer
 
@@ -190,11 +190,15 @@ See: <LinkTo kind="components-footer" story="docs">Footer component</LinkTo>
 ### Typography
 
 All external-facing print and web material should use **Roboto** (the UN official typeface).
-For internal communication and email, Arial can be used as a substitute.
+Headings use **Roboto Condensed**. For internal communication and email, Arial can be used as a substitute.
 
-Language-specific fonts:
-- **Arabic**: Noto Kufi Arabic
-- **Chinese**: Helvetica Neue
+**Language-specific fonts:** Mangrove supports automatic font overrides for scripts that
+require specialized typography. When content is marked with a language attribute
+(e.g., `lang="ar"`), CSS `:lang()` selectors apply the appropriate fonts automatically.
+
+| Language | Selector | Font override |
+|----------|----------|---------------|
+| Arabic | `:lang(ar)` | Noto Kufi Arabic (headings), Dubai (body) |
 
 See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</LinkTo>
 
@@ -204,7 +208,7 @@ See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</Lin
 
 - <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> — theme-specific colors, typography, logos, buttons, and icons
 - <LinkTo kind="brand-about-this-guide" story="docs">About this guide</LinkTo> — overview of all UNDRR web properties
-- <LinkTo kind="getting-started-contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
+- <LinkTo kind="contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
 - [UN web standards](https://www.un.org/styleguide/) — UN-wide branding and style guidance
 
 ---

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -1,6 +1,4 @@
-{/*
-  Source: Migrated from UNDRR SharePoint style guide pages, April 2026.
-  Original URLs:
+{/* Source: Migrated from UNDRR SharePoint style guide pages, April 2026. Original URLs:
   - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/UNDRR-Brand-Positioning.aspx
   - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Logos.aspx
   - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Colors-typography.aspx
@@ -26,8 +24,11 @@ import { HighlightBox } from '../../Components/HighlightBox/HighlightBox';
 
 Editorial and visual identity guidelines for all UNDRR communications. For
 theme-specific colors, typography, and component previews, see the
-<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page
-and use the theme picker in the toolbar.
+
+<LinkTo kind="brand-brand-identity" story="docs">
+  Brand identity
+</LinkTo>
+page and use the theme picker in the toolbar.
 
 ---
 
@@ -35,23 +36,37 @@ and use the theme picker in the toolbar.
 
 UNDRR's brand is defined by three core characteristics:
 
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem', marginBottom: '2rem' }}>
+<div
+  style={{
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: '1rem',
+    marginBottom: '2rem',
+  }}
+>
   <HighlightBox variant="primary">
     <span style={{ color: 'white' }}>
       <strong>Knowledgeable</strong>
-      <p>Convince people with credible knowledge of what may and will happen.</p>
+      <p>
+        Convince people with credible knowledge of what may and will happen.
+      </p>
     </span>
   </HighlightBox>
   <HighlightBox variant="primary">
     <span style={{ color: 'white' }}>
       <strong>Approachable</strong>
-      <p>We need to work with all the different stakeholders to complete our mission.</p>
+      <p>
+        We need to work with all the different stakeholders to complete our
+        mission.
+      </p>
     </span>
   </HighlightBox>
   <HighlightBox variant="primary">
     <span style={{ color: 'white' }}>
       <strong>Collaborative</strong>
-      <p>We need to be seen at the same level as the people we are working with.</p>
+      <p>
+        We need to be seen at the same level as the people we are working with.
+      </p>
     </span>
   </HighlightBox>
 </div>
@@ -80,9 +95,9 @@ UNDRR's brand is defined by three core characteristics:
 ## Communication guidelines
 
 <HighlightBox>
-  <strong>The inverted pyramid:</strong> Lead with the most important information.
-  Supporting details follow. Background and context come last. Readers should get
-  the key message even if they only read the first paragraph.
+  <strong>The inverted pyramid:</strong> Lead with the most important
+  information. Supporting details follow. Background and context come last.
+  Readers should get the key message even if they only read the first paragraph.
 </HighlightBox>
 
 **Effective communication rules:**
@@ -100,7 +115,11 @@ UNDRR's brand is defined by three core characteristics:
 {/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Logos.aspx */}
 
 For logo files and downloads, switch to your property's theme on the
-<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
+
+<LinkTo kind="brand-brand-identity" story="docs">
+  Brand identity
+</LinkTo>
+page.
 
 ### UNDRR logo rules
 
@@ -127,7 +146,14 @@ For logo files and downloads, switch to your property's theme on the
 
 {/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Photography-and-Icons.aspx */}
 
-<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
+<div
+  style={{
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, 1fr)',
+    gap: '1rem',
+    marginBottom: '1.5rem',
+  }}
+>
   <HighlightBox>
     <strong>Do:</strong> Illustrations and photography should portray a positive
     image of disaster prevention and recovery. Human faces and stories should be
@@ -135,8 +161,9 @@ For logo files and downloads, switch to your property's theme on the
   </HighlightBox>
   <HighlightBox variant="secondary">
     <span style={{ color: 'white' }}>
-      <strong>Don't:</strong> Conference pictures should be kept to the strict minimum.
-      We do not want to convey a conference-focused image of the organization.
+      <strong>Don't:</strong> Conference pictures should be kept to the strict
+      minimum. We do not want to convey a conference-focused image of the
+      organization.
     </span>
   </HighlightBox>
 </div>
@@ -146,12 +173,12 @@ For logo files and downloads, switch to your property's theme on the
 
 ### Photo sizes
 
-| Use case | Aspect ratio | Dimensions |
-|----------|-------------|------------|
-| Hero banner | 16:6 | 1440 x 540 px |
-| News image | 16:9 | 1164 x 665 px |
-| Publication cover | 3:4 | 176 x 235 px |
-| People thumbnail | 1:1 | 176 x 176 px |
+| Use case          | Aspect ratio | Dimensions    |
+| ----------------- | ------------ | ------------- |
+| Hero banner       | 16:6         | 1440 x 540 px |
+| News image        | 16:9         | 1164 x 665 px |
+| Publication cover | 3:4          | 176 x 235 px  |
+| People thumbnail  | 1:1          | 176 x 176 px  |
 
 ### Icons
 
@@ -198,9 +225,9 @@ Headings use **Roboto Condensed**. For internal communication and email, Arial c
 require specialized typography. When content is marked with a language attribute
 (e.g., `lang="ar"`), CSS `:lang()` selectors apply the appropriate fonts automatically.
 
-| Language | Selector | Font override |
-|----------|----------|---------------|
-| Arabic | `:lang(ar)` | Noto Kufi Arabic (headings), Dubai (body) |
+| Language | Selector    | Font override                             |
+| -------- | ----------- | ----------------------------------------- |
+| Arabic   | `:lang(ar)` | Noto Kufi Arabic (headings), Dubai (body) |
 
 See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</LinkTo>
 
@@ -208,9 +235,18 @@ See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</Lin
 
 ## Resources
 
-- <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> — theme-specific colors, typography, logos, buttons, and icons
-- <LinkTo kind="brand-about-this-guide" story="docs">About this guide</LinkTo> — overview of all UNDRR web properties
-- <LinkTo kind="contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
+- <LinkTo kind="brand-brand-identity" story="docs">
+    Brand identity
+  </LinkTo>
+  — theme-specific colors, typography, logos, buttons, and icons
+- <LinkTo kind="brand-about-this-guide" story="docs">
+    About this guide
+  </LinkTo>
+  — overview of all UNDRR web properties
+- <LinkTo kind="contributing-writing-guidelines" story="docs">
+    Writing guidelines
+  </LinkTo>
+  — editorial standards for web content
 - [UNDRR Style Guides (intranet)](https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Style-Guides.aspx) — additional communications guidance for internal UNDRR users (requires UN SharePoint access)
 - [UN web standards](https://www.un.org/styleguide/) — UN-wide branding and style guidance
 

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -133,9 +133,11 @@ For logo files and downloads, switch to your property's theme on the
     image of disaster prevention and recovery. Human faces and stories should be
     the focus.
   </HighlightBox>
-  <HighlightBox>
-    <strong>Don't:</strong> Conference pictures should be kept to the strict minimum.
-    We do not want to convey a conference-focused image of the organization.
+  <HighlightBox variant="secondary">
+    <span style={{ color: 'white' }}>
+      <strong>Don't:</strong> Conference pictures should be kept to the strict minimum.
+      We do not want to convey a conference-focused image of the organization.
+    </span>
   </HighlightBox>
 </div>
 

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -211,6 +211,7 @@ See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</Lin
 - <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> — theme-specific colors, typography, logos, buttons, and icons
 - <LinkTo kind="brand-about-this-guide" story="docs">About this guide</LinkTo> — overview of all UNDRR web properties
 - <LinkTo kind="contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
+- [UNDRR Style Guides (intranet)](https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Style-Guides.aspx) — additional communications guidance for internal UNDRR users (requires UN SharePoint access)
 - [UN web standards](https://www.un.org/styleguide/) — UN-wide branding and style guidance
 
 ---

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -235,18 +235,10 @@ See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</Lin
 
 ## Resources
 
-- <LinkTo kind="brand-brand-identity" story="docs">
-    Brand identity
-  </LinkTo>
-  — theme-specific colors, typography, logos, buttons, and icons
-- <LinkTo kind="brand-about-this-guide" story="docs">
-    About this guide
-  </LinkTo>
-  — overview of all UNDRR web properties
-- <LinkTo kind="contributing-writing-guidelines" story="docs">
-    Writing guidelines
-  </LinkTo>
-  — editorial standards for web content
+{/* prettier-ignore */}
+- <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> — theme-specific colors, typography, logos, buttons, and icons
+- <LinkTo kind="brand-about-this-guide" story="docs">About this guide</LinkTo> — overview of all UNDRR web properties
+- <LinkTo kind="contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
 - [UNDRR Style Guides (intranet)](https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Style-Guides.aspx) — additional communications guidance for internal UNDRR users (requires UN SharePoint access)
 - [UN web standards](https://www.un.org/styleguide/) — UN-wide branding and style guidance
 

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -1,0 +1,212 @@
+{/*
+  Source: Migrated from UNDRR SharePoint style guide pages, April 2026.
+  Original URLs:
+  - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/UNDRR-Brand-Positioning.aspx
+  - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Logos.aspx
+  - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Colors-typography.aspx
+  - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Photography-and-Icons.aspx
+  - https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Web-Style-Guide.aspx
+*/}
+
+import { Meta } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { HighlightBox } from '../../Components/HighlightBox/HighlightBox';
+
+<Meta
+  title="Brand/Brand guidelines"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# Brand guidelines
+
+Editorial and visual identity guidelines for all UNDRR communications. For
+theme-specific colors, typography, and component previews, see the
+<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page
+and use the theme picker in the toolbar.
+
+---
+
+## Brand positioning
+
+UNDRR's brand is defined by three core characteristics:
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem', marginBottom: '2rem' }}>
+  <HighlightBox variant="primary">
+    <span style={{ color: 'white' }}>
+      <strong>Knowledgeable</strong>
+      <p>Convince people with credible knowledge of what may and will happen.</p>
+    </span>
+  </HighlightBox>
+  <HighlightBox variant="primary">
+    <span style={{ color: 'white' }}>
+      <strong>Approachable</strong>
+      <p>We need to work with all the different stakeholders to complete our mission.</p>
+    </span>
+  </HighlightBox>
+  <HighlightBox variant="primary">
+    <span style={{ color: 'white' }}>
+      <strong>Collaborative</strong>
+      <p>We need to be seen at the same level as the people we are working with.</p>
+    </span>
+  </HighlightBox>
+</div>
+
+### Brand awareness
+
+> "Awareness should be enhanced because frequency and severity of disasters
+> are increasing. However, it is not so much about the organization but more
+> about the agenda."
+>
+> — Mami Mizutori
+
+**How to increase brand awareness:**
+
+- More targeted communication for different stakeholders
+- Reach out to specific groups who can make an impact (private sector, UN country representatives, media)
+- Measure effectiveness of outreach and workshops (surveys, stats, feedback on progress)
+- Make it clear that UNDRR is at the heart of the UN (use of UN logo, branding, positioning)
+- Bring PreventionWeb and other tools closer under the umbrella of undrr.org
+- Be inclusive and promote other players (this is part of the organization's mandate), but claim ownership when appropriate
+- Increase social media presence and communicate rapidly when disasters occur (with emphasis on prevention and recovery)
+- Harmonize digital design around Sendai branding (colorful and recognizable)
+
+---
+
+## Communication guidelines
+
+<HighlightBox>
+  <strong>The inverted pyramid:</strong> Lead with the most important information.
+  Supporting details follow. Background and context come last. Readers should get
+  the key message even if they only read the first paragraph.
+</HighlightBox>
+
+**Effective communication rules:**
+
+- **Avoid UN jargon** whenever possible
+- **Communicate on prevention in a positive way** — use positive images
+- **Make stories around real people**, not just issues
+- **Be short and concise on the web** — use the inverted pyramid structure
+- For detailed writing guidance, see the <LinkTo kind="getting-started-contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo>
+
+---
+
+## Logo usage
+
+{/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Logos.aspx */}
+
+For logo files and downloads, switch to your property's theme on the
+<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
+
+### UNDRR logo rules
+
+- The organisation officially changed its name from UNISDR to UNDRR. All communication material must display the new name.
+- On the web, the horizontal version may be used for efficient use of screen space. The logo may appear without the full name on sub-sites of UNDRR.
+- **Safety zone**: The safe area around the UNDRR logo equals the width of the "U" in UNDRR.
+- **Background**: Do not display the logo on a busy background. Use the inverse (white) logo on dark backgrounds.
+
+### Sendai Framework logo
+
+- The Sendai Framework logo should appear on all official publications and online sites.
+- The inverse logo should be placed on dark backgrounds.
+- The Sendai Framework logo can be used to create sub-brands. The sub-brand should appear above the color stripe to separate it from the overall concept.
+
+### UN and SDG logos
+
+- When using the UN logo, it takes precedence over UNDRR.
+- UNDRR can be used in conjunction with the SDG logo and wheel.
+- Access the official UN/SDG artwork at [United Nations brand resources](https://www.un.org/styleguide/).
+
+---
+
+## Photography guidelines
+
+{/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Photography-and-Icons.aspx */}
+
+<div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginBottom: '1.5rem' }}>
+  <HighlightBox>
+    <strong>Do:</strong> Illustrations and photography should portray a positive
+    image of disaster prevention and recovery. Human faces and stories should be
+    the focus.
+  </HighlightBox>
+  <HighlightBox>
+    <strong>Don't:</strong> Conference pictures should be kept to the strict minimum.
+    We do not want to convey a conference-focused image of the organization.
+  </HighlightBox>
+</div>
+
+- Photos must always display the credit and source information.
+- Use imagery from the [UNDRR photo selection guide](https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS) (intranet) for Sendai Targets and DRR themes.
+
+### Photo sizes
+
+| Use case | Aspect ratio | Dimensions |
+|----------|-------------|------------|
+| Hero banner | 16:6 | 1440 x 540 px |
+| News image | 16:9 | 1164 x 665 px |
+| Publication cover | 3:4 | 176 x 235 px |
+| People thumbnail | 1:1 | 176 x 176 px |
+
+### Icons
+
+UNDRR uses two icon sets:
+
+- **OCHA humanitarian icons** for natural hazards and disaster-related content. Available free from [ReliefWeb](https://reliefweb.int) and [The Noun Project](https://thenounproject.com).
+- **Mangrove icon set** for web UI. See the full icon set in the <LinkTo kind="components-icons" story="docs">Icons documentation</LinkTo>.
+
+---
+
+## Web elements
+
+{/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Web-Style-Guide.aspx */}
+
+UNDRR's web presences should be consistent and connected. The following components
+are shared across all UNDRR sites:
+
+### Global header
+
+The global navigation should appear on all UNDRR sites and tools. It displays the
+language selector, login icon, and global menu linking to core resources. The main
+navigation often uses a sticky header with the Sendai color stripe.
+
+See: <LinkTo kind="components-mega-menu" story="docs">Mega menu component</LinkTo>
+
+### Footer
+
+The footer is common across all UNDRR sites in appearance, with customizable link sections:
+
+- **Stay in touch**: Social channel icons (default: UNDRR channels, can link to sub-channels)
+- **Custom links**: Shortcuts and additional information specific to each site
+- **UNDRR tools**: Same list on all sites
+- **Contact us**: Links to the corporate contact page unless the sub-site has its own
+- **Global footer banner**: Sendai Framework and SDG logos, copyright notice, privacy policy, terms of use
+
+See: <LinkTo kind="components-footer" story="docs">Footer component</LinkTo>
+
+### Typography
+
+All external-facing print and web material should use **Roboto** (the UN official typeface).
+For internal communication and email, Arial can be used as a substitute.
+
+Language-specific fonts:
+- **Arabic**: Noto Kufi Arabic
+- **Chinese**: Helvetica Neue
+
+See: <LinkTo kind="design-decisions-fonts" story="docs">Fonts documentation</LinkTo>
+
+---
+
+## Resources
+
+- <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> — theme-specific colors, typography, logos, buttons, and icons
+- <LinkTo kind="brand-about-this-guide" story="docs">About this guide</LinkTo> — overview of all UNDRR web properties
+- <LinkTo kind="getting-started-contributing-writing-guidelines" story="docs">Writing guidelines</LinkTo> — editorial standards for web content
+- [UN web standards](https://www.un.org/styleguide/) — UN-wide branding and style guidance
+
+---
+
+Last updated: 11 April 2026

--- a/stories/Documentation/Brand/BrandIdentity.stories.jsx
+++ b/stories/Documentation/Brand/BrandIdentity.stories.jsx
@@ -5,7 +5,7 @@
  * hook issues in docs mode.
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ColorSwatch } from './components/ColorSwatch';
 import { TypographySample } from './components/TypographySample';
 import { HighlightBox } from '../../Components/HighlightBox/HighlightBox';
@@ -14,14 +14,43 @@ import { CtaButton } from '../../Components/Buttons/CtaButton/CtaButton';
 import { Icon } from '../../Atom/Icons/Icon';
 import { P } from '../../Atom/BaseTypography/Paragraph/Paragraph';
 import { Small } from '../../Atom/BaseTypography/Small/Small';
-import { getTheme } from './data/themes';
+import { getTheme, colorProbes } from './data/themes';
 
 const grid4 = { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem' };
 const grid2 = { display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem' };
 
+/**
+ * Reads a CSS color value from the DOM by creating a temporary probe element.
+ */
+function probeColor(className, property = 'background-color') {
+  const el = document.createElement('div');
+  el.className = className;
+  el.style.position = 'absolute';
+  el.style.visibility = 'hidden';
+  document.body.appendChild(el);
+  const val = window.getComputedStyle(el).getPropertyValue(property);
+  document.body.removeChild(el);
+  return val;
+}
+
+function rgbToHex(rgb) {
+  if (!rgb) return null;
+  const match = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) return null;
+  return '#' + [1, 2, 3].map(i => parseInt(match[i], 10).toString(16).padStart(2, '0')).join('');
+}
+
 function BrandIdentityPage({ themeName }) {
+  // Re-render after CSS is loaded by the theme decorator.
+  // The decorator's useEffect injects CSS after the first render,
+  // so we need a second pass to probe the correct values.
+  const [, rerender] = useState(0);
+  useEffect(() => {
+    requestAnimationFrame(() => rerender((n) => n + 1));
+  }, [themeName]);
+
   const theme = getTheme(themeName);
-  const primaryColor = theme.colors.brand[0]?.color || '#004f91';
+  const primaryColor = rgbToHex(probeColor('mg-button-primary')) || '#004f91';
 
   return (
     <div style={{ fontFamily: "'Roboto', sans-serif", maxWidth: 900 }}>
@@ -111,27 +140,28 @@ function BrandIdentityPage({ themeName }) {
         </>
       )}
 
-      {/* Color palette */}
+      {/* Color palette — probed live from compiled theme CSS */}
       <h2>Color palette</h2>
-      <p>Colors used across {theme.url}. Click any swatch to copy its hex value.</p>
+      <p>Colors used across {theme.url}. Click any swatch to copy its hex value.
+        These values are read directly from the active theme's compiled CSS.</p>
 
       <h3>Brand and interactive colors</h3>
       <div style={grid4}>
-        {theme.colors.brand.map((c, i) => (
-          <ColorSwatch key={`brand-${i}`} color={c.color} name={c.name} usage={c.usage} />
+        {colorProbes.brand.map((c, i) => (
+          <ColorSwatch key={`brand-${i}`} color={rgbToHex(probeColor(c.probe, c.property))} name={c.name} usage={c.usage} />
         ))}
       </div>
 
       <h3>Accent colors</h3>
       <div style={grid4}>
-        {theme.colors.accent.map((c, i) => (
-          <ColorSwatch key={`accent-${i}`} color={c.color} name={c.name} usage={c.usage} />
+        {colorProbes.accent.map((c, i) => (
+          <ColorSwatch key={`accent-${i}`} color={rgbToHex(probeColor(c.probe, c.property))} name={c.name} usage={c.usage} />
         ))}
       </div>
 
       <h3>Neutral colors</h3>
       <div style={grid4}>
-        {theme.colors.neutral.map((c, i) => (
+        {colorProbes.neutral.map((c, i) => (
           <ColorSwatch key={`neutral-${i}`} color={c.color} name={c.name} usage={c.usage} />
         ))}
       </div>
@@ -218,7 +248,7 @@ function BrandIdentityPage({ themeName }) {
       <h2>Usage guidelines</h2>
       <div style={grid2}>
         <HighlightBox>
-          <strong>Do:</strong> Use {theme.colors.brand[0]?.name} ({primaryColor}) for
+          <strong>Do:</strong> Use the primary brand color ({primaryColor}) for
           navigation headers and brand elements on {theme.url}.
         </HighlightBox>
         <HighlightBox variant="secondary">

--- a/stories/Documentation/Brand/BrandIdentity.stories.jsx
+++ b/stories/Documentation/Brand/BrandIdentity.stories.jsx
@@ -114,28 +114,45 @@ function BrandIdentityPage({ themeName }) {
               </div>
             )}
           </div>
-          <p style={{ fontSize: '0.875rem', marginBottom: '0.5rem' }}>Download logo files:</p>
-          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
-            {theme.logo.variants.map((v) => (
-              <a
-                key={v.url}
-                href={v.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  padding: '0.5rem 1rem',
-                  border: '1px solid #e0e0e0',
-                  borderRadius: '4px',
-                  textDecoration: 'none',
-                  color: primaryColor,
-                  fontSize: '0.8125rem',
-                  fontWeight: 500,
-                }}
-              >
-                {v.label}
-              </a>
-            ))}
-          </div>
+          <p style={{ fontSize: '0.875rem', marginBottom: '0.5rem' }}>
+            Download a copy or hotlink directly to the CDN:
+          </p>
+          <table style={{ width: '100%', fontSize: '0.8125rem', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid #e0e0e0' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem 0.5rem 0', fontWeight: 600 }}>
+                  Variant
+                </th>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', fontWeight: 600 }}>
+                  CDN URL (copy to hotlink)
+                </th>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0', fontWeight: 600 }}>
+                  Download
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {theme.logo.variants.map((v) => (
+                <tr key={v.url} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                  <td style={{ padding: '0.5rem 0.75rem 0.5rem 0' }}>{v.label}</td>
+                  <td style={{ padding: '0.5rem 0.75rem', fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-all' }}>
+                    <code>{v.url}</code>
+                  </td>
+                  <td style={{ padding: '0.5rem 0' }}>
+                    <a
+                      href={v.url}
+                      download
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: primaryColor, fontWeight: 500, whiteSpace: 'nowrap' }}
+                    >
+                      Download ↓
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
           <hr style={{ margin: '2rem 0' }} />
         </>
       )}

--- a/stories/Documentation/Brand/BrandIdentity.stories.jsx
+++ b/stories/Documentation/Brand/BrandIdentity.stories.jsx
@@ -1,0 +1,260 @@
+/**
+ * @file BrandIdentity.stories.jsx
+ * @description Dynamic brand identity page that responds to the Storybook theme picker.
+ * Uses a decorator to pass the active theme name as a prop, avoiding useGlobals
+ * hook issues in docs mode.
+ */
+
+import React from 'react';
+import { ColorSwatch } from './components/ColorSwatch';
+import { TypographySample } from './components/TypographySample';
+import { HighlightBox } from '../../Components/HighlightBox/HighlightBox';
+import { Heading } from '../../Atom/Typography/Heading/Heading';
+import { CtaButton } from '../../Components/Buttons/CtaButton/CtaButton';
+import { Icon } from '../../Atom/Icons/Icon';
+import { P } from '../../Atom/BaseTypography/Paragraph/Paragraph';
+import { Small } from '../../Atom/BaseTypography/Small/Small';
+import { getTheme } from './data/themes';
+
+const grid4 = { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem' };
+const grid2 = { display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem' };
+
+function BrandIdentityPage({ themeName }) {
+  const theme = getTheme(themeName);
+  const primaryColor = theme.colors.brand[0]?.color || '#004f91';
+
+  return (
+    <div style={{ fontFamily: "'Roboto', sans-serif", maxWidth: 900 }}>
+      {/* Hero */}
+      <div style={{
+        background: primaryColor,
+        color: 'white',
+        padding: '3rem 2.5rem',
+        borderRadius: '4px',
+        marginBottom: '2rem',
+      }}>
+        <h1 style={{
+          fontFamily: "'Roboto Condensed', sans-serif",
+          fontSize: '2.625rem',
+          fontWeight: 700,
+          margin: 0,
+          letterSpacing: '-0.5px',
+        }}>
+          {theme.name}
+        </h1>
+        <p style={{ fontSize: '1.125rem', opacity: 0.9, margin: '0.5rem 0 0.25rem' }}>
+          {theme.tagline}
+        </p>
+        <span style={{ fontSize: '0.875rem', opacity: 0.7 }}>{theme.url}</span>
+      </div>
+
+      <p style={{ color: '#666', marginBottom: '2rem' }}>
+        Use the <strong>theme selector</strong> in the toolbar above to switch between
+        UNDRR properties. The entire page updates to show that property's colors,
+        typography, and guidelines.
+      </p>
+
+      {/* Logo */}
+      {theme.logo && (
+        <>
+          <h2>Logo</h2>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '2rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
+            <div style={{
+              background: '#f5f5f5',
+              padding: '2rem 3rem',
+              borderRadius: '4px',
+              border: '1px solid #e0e0e0',
+            }}>
+              <img
+                src={theme.logo.src}
+                alt={theme.logo.alt}
+                style={{ height: '45px', width: 'auto' }}
+              />
+            </div>
+            {theme.logo.srcWhite && (
+              <div style={{
+                background: primaryColor,
+                padding: '2rem 3rem',
+                borderRadius: '4px',
+              }}>
+                <img
+                  src={theme.logo.srcWhite}
+                  alt={`${theme.logo.alt} (white variant)`}
+                  style={{ height: '45px', width: 'auto' }}
+                />
+              </div>
+            )}
+          </div>
+          <p style={{ fontSize: '0.875rem', marginBottom: '0.5rem' }}>Download logo files:</p>
+          <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+            {theme.logo.variants.map((v) => (
+              <a
+                key={v.url}
+                href={v.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  padding: '0.5rem 1rem',
+                  border: '1px solid #e0e0e0',
+                  borderRadius: '4px',
+                  textDecoration: 'none',
+                  color: primaryColor,
+                  fontSize: '0.8125rem',
+                  fontWeight: 500,
+                }}
+              >
+                {v.label}
+              </a>
+            ))}
+          </div>
+          <hr style={{ margin: '2rem 0' }} />
+        </>
+      )}
+
+      {/* Color palette */}
+      <h2>Color palette</h2>
+      <p>Colors used across {theme.url}. Click any swatch to copy its hex value.</p>
+
+      <h3>Brand and interactive colors</h3>
+      <div style={grid4}>
+        {theme.colors.brand.map((c, i) => (
+          <ColorSwatch key={`brand-${i}`} color={c.color} name={c.name} usage={c.usage} />
+        ))}
+      </div>
+
+      <h3>Accent colors</h3>
+      <div style={grid4}>
+        {theme.colors.accent.map((c, i) => (
+          <ColorSwatch key={`accent-${i}`} color={c.color} name={c.name} usage={c.usage} />
+        ))}
+      </div>
+
+      <h3>Neutral colors</h3>
+      <div style={grid4}>
+        {theme.colors.neutral.map((c, i) => (
+          <ColorSwatch key={`neutral-${i}`} color={c.color} name={c.name} usage={c.usage} />
+        ))}
+      </div>
+
+      <hr style={{ margin: '2rem 0' }} />
+
+      {/* Typography */}
+      <h2>Typography</h2>
+      <p>{theme.name} uses Roboto for body text and Roboto Condensed for headings.</p>
+
+      <TypographySample fontFamily="Roboto Condensed" fontSize="2.625rem" fontWeight={700} label="Page title" lineHeight="1.1">
+        <Heading type="1">Page title</Heading>
+      </TypographySample>
+      <TypographySample fontFamily="Roboto Condensed" fontSize="1.75rem" fontWeight={700} label="Section heading" lineHeight="1.2">
+        <Heading type="2">Section heading</Heading>
+      </TypographySample>
+      <TypographySample fontFamily="Roboto Condensed" fontSize="1.375rem" fontWeight={600} label="Subsection heading" lineHeight="1.3">
+        <Heading type="3">Subsection heading</Heading>
+      </TypographySample>
+      <TypographySample fontFamily="Roboto" fontSize="1rem" fontWeight={400} label="Body text" lineHeight="1.5">
+        <P detail={`Body text looks like this. It's used for descriptions, paragraphs, and general content across ${theme.url}.`} />
+      </TypographySample>
+      <TypographySample fontFamily="Roboto" fontSize="0.8125rem" fontWeight={400} label="Small text" lineHeight="1.4">
+        <Small detail="Small text for metadata, dates, and captions" />
+      </TypographySample>
+
+      <hr style={{ margin: '2rem 0' }} />
+
+      {/* Buttons */}
+      <h2>Buttons</h2>
+      <p>Primary buttons use the brand color. Secondary buttons use an outline style.</p>
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+        <CtaButton label="Primary action" Type="Primary" />
+        <CtaButton label="Secondary action" Type="Secondary" />
+        <CtaButton label="Disabled" Type="Primary" State="Disabled" />
+      </div>
+
+      <hr style={{ margin: '2rem 0' }} />
+
+      {/* Icons */}
+      <h2>Icons</h2>
+      <p>
+        Mangrove includes a custom icon set. Use <code>mg-icon mg-icon-name</code> classes
+        in HTML, or the <code>{'<Icon name="..." />'}</code> React component.
+      </p>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '1rem', marginBottom: '1rem' }}>
+        {[
+          { name: 'globe', label: 'Globe' },
+          { name: 'search', label: 'Search' },
+          { name: 'envelope', label: 'Email' },
+          { name: 'calendar-alt', label: 'Calendar' },
+          { name: 'chart-bar', label: 'Chart' },
+          { name: 'user', label: 'User' },
+          { name: 'file-alt', label: 'Document' },
+          { name: 'share', label: 'Share' },
+          { name: 'link', label: 'Link' },
+          { name: 'lightbulb', label: 'Idea' },
+          { name: 'newspaper', label: 'News' },
+          { name: 'building', label: 'Building' },
+          { name: 'graduation-cap', label: 'Education' },
+          { name: 'life-ring', label: 'Support' },
+          { name: 'tags', label: 'Tags' },
+          { name: 'earthquake', label: 'Earthquake' },
+          { name: 'tsunami', label: 'Tsunami' },
+          { name: 'flood', label: 'Flood' },
+          { name: 'cyclone', label: 'Cyclone' },
+          { name: 'drought', label: 'Drought' },
+          { name: 'resilience', label: 'Resilience' },
+        ].map(icon => (
+          <div key={icon.name} style={{ textAlign: 'center', padding: '0.75rem 0' }}>
+            <Icon name={icon.name} size="lg" />
+            <div style={{ fontSize: '0.6875rem', color: '#666', marginTop: '0.25rem' }}>{icon.label}</div>
+          </div>
+        ))}
+      </div>
+      <p style={{ fontSize: '0.875rem', color: '#666' }}>
+        Showing 21 of 80+ icons, including OCHA humanitarian icons. See the full set in the{' '}
+        <a href="/?path=/docs/components-icons--docs">Icons documentation</a>.
+      </p>
+
+      <hr style={{ margin: '2rem 0' }} />
+
+      {/* Usage guidelines */}
+      <h2>Usage guidelines</h2>
+      <div style={grid2}>
+        <HighlightBox>
+          <strong>Do:</strong> Use {theme.colors.brand[0]?.name} ({primaryColor}) for
+          navigation headers and brand elements on {theme.url}.
+        </HighlightBox>
+        <HighlightBox>
+          <strong>Don't:</strong> Mix brand colors from other UNDRR properties.
+          Each property has its own identity.
+        </HighlightBox>
+      </div>
+      <div style={{ ...grid2, marginTop: '1rem' }}>
+        <HighlightBox>
+          <strong>Do:</strong> Use Roboto Condensed for headings and Roboto Regular for body text.
+        </HighlightBox>
+        <HighlightBox>
+          <strong>Don't:</strong> Use Arial, Helvetica, or other system fonts.
+          Stick to the specified font families.
+        </HighlightBox>
+      </div>
+    </div>
+  );
+}
+
+export default {
+  title: 'Brand/Brand identity',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      canvas: { hidden: true },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const themeName = context.globals.theme || 'Global UNDRR Theme';
+      return <Story args={{ ...context.args, themeName }} />;
+    },
+  ],
+};
+
+export const Docs = {
+  render: (args) => <BrandIdentityPage themeName={args.themeName} />,
+};

--- a/stories/Documentation/Brand/BrandIdentity.stories.jsx
+++ b/stories/Documentation/Brand/BrandIdentity.stories.jsx
@@ -221,18 +221,22 @@ function BrandIdentityPage({ themeName }) {
           <strong>Do:</strong> Use {theme.colors.brand[0]?.name} ({primaryColor}) for
           navigation headers and brand elements on {theme.url}.
         </HighlightBox>
-        <HighlightBox>
-          <strong>Don't:</strong> Mix brand colors from other UNDRR properties.
-          Each property has its own identity.
+        <HighlightBox variant="secondary">
+          <span style={{ color: 'white' }}>
+            <strong>Don't:</strong> Mix brand colors from other UNDRR properties.
+            Each property has its own identity.
+          </span>
         </HighlightBox>
       </div>
       <div style={{ ...grid2, marginTop: '1rem' }}>
         <HighlightBox>
           <strong>Do:</strong> Use Roboto Condensed for headings and Roboto Regular for body text.
         </HighlightBox>
-        <HighlightBox>
-          <strong>Don't:</strong> Use Arial, Helvetica, or other system fonts.
-          Stick to the specified font families.
+        <HighlightBox variant="secondary">
+          <span style={{ color: 'white' }}>
+            <strong>Don't:</strong> Use Arial, Helvetica, or other system fonts.
+            Stick to the specified font families.
+          </span>
         </HighlightBox>
       </div>
     </div>

--- a/stories/Documentation/Brand/BrandIdentity.stories.jsx
+++ b/stories/Documentation/Brand/BrandIdentity.stories.jsx
@@ -16,8 +16,16 @@ import { P } from '../../Atom/BaseTypography/Paragraph/Paragraph';
 import { Small } from '../../Atom/BaseTypography/Small/Small';
 import { getTheme, colorProbes } from './data/themes';
 
-const grid4 = { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem' };
-const grid2 = { display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem' };
+const grid4 = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, 1fr)',
+  gap: '1rem',
+};
+const grid2 = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '1rem',
+};
 
 /**
  * Reads a CSS color value from the DOM by creating a temporary probe element.
@@ -37,7 +45,12 @@ function rgbToHex(rgb) {
   if (!rgb) return null;
   const match = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
   if (!match) return null;
-  return '#' + [1, 2, 3].map(i => parseInt(match[i], 10).toString(16).padStart(2, '0')).join('');
+  return (
+    '#' +
+    [1, 2, 3]
+      .map(i => parseInt(match[i], 10).toString(16).padStart(2, '0'))
+      .join('')
+  );
 }
 
 function BrandIdentityPage({ themeName }) {
@@ -46,7 +59,7 @@ function BrandIdentityPage({ themeName }) {
   // so we need a second pass to probe the correct values.
   const [, rerender] = useState(0);
   useEffect(() => {
-    requestAnimationFrame(() => rerender((n) => n + 1));
+    requestAnimationFrame(() => rerender(n => n + 1));
   }, [themeName]);
 
   const theme = getTheme(themeName);
@@ -55,45 +68,65 @@ function BrandIdentityPage({ themeName }) {
   return (
     <div style={{ fontFamily: "'Roboto', sans-serif", maxWidth: 900 }}>
       {/* Hero */}
-      <div style={{
-        background: primaryColor,
-        color: 'white',
-        padding: '3rem 2.5rem',
-        borderRadius: '4px',
-        marginBottom: '2rem',
-      }}>
-        <h1 style={{
-          fontFamily: "'Roboto Condensed', sans-serif",
-          fontSize: '2.625rem',
-          fontWeight: 700,
-          margin: 0,
-          letterSpacing: '-0.5px',
-        }}>
+      <div
+        style={{
+          background: primaryColor,
+          color: 'white',
+          padding: '3rem 2.5rem',
+          borderRadius: '4px',
+          marginBottom: '2rem',
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: "'Roboto Condensed', sans-serif",
+            fontSize: '2.625rem',
+            fontWeight: 700,
+            margin: 0,
+            letterSpacing: '-0.5px',
+          }}
+        >
           {theme.name}
         </h1>
-        <p style={{ fontSize: '1.125rem', opacity: 0.9, margin: '0.5rem 0 0.25rem' }}>
+        <p
+          style={{
+            fontSize: '1.125rem',
+            opacity: 0.9,
+            margin: '0.5rem 0 0.25rem',
+          }}
+        >
           {theme.tagline}
         </p>
         <span style={{ fontSize: '0.875rem', opacity: 0.7 }}>{theme.url}</span>
       </div>
 
       <p style={{ color: '#666', marginBottom: '2rem' }}>
-        Use the <strong>theme selector</strong> in the toolbar above to switch between
-        UNDRR properties. The entire page updates to show that property's colors,
-        typography, and guidelines.
+        Use the <strong>theme selector</strong> in the toolbar above to switch
+        between UNDRR properties. The entire page updates to show that
+        property's colors, typography, and guidelines.
       </p>
 
       {/* Logo */}
       {theme.logo && (
         <>
           <h2>Logo</h2>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '2rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
-            <div style={{
-              background: '#f5f5f5',
-              padding: '2rem 3rem',
-              borderRadius: '4px',
-              border: '1px solid #e0e0e0',
-            }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '2rem',
+              marginBottom: '1rem',
+              flexWrap: 'wrap',
+            }}
+          >
+            <div
+              style={{
+                background: '#f5f5f5',
+                padding: '2rem 3rem',
+                borderRadius: '4px',
+                border: '1px solid #e0e0e0',
+              }}
+            >
               <img
                 src={theme.logo.src}
                 alt={theme.logo.alt}
@@ -101,11 +134,13 @@ function BrandIdentityPage({ themeName }) {
               />
             </div>
             {theme.logo.srcWhite && (
-              <div style={{
-                background: primaryColor,
-                padding: '2rem 3rem',
-                borderRadius: '4px',
-              }}>
+              <div
+                style={{
+                  background: primaryColor,
+                  padding: '2rem 3rem',
+                  borderRadius: '4px',
+                }}
+              >
                 <img
                   src={theme.logo.srcWhite}
                   alt={`${theme.logo.alt} (white variant)`}
@@ -117,25 +152,58 @@ function BrandIdentityPage({ themeName }) {
           <p style={{ fontSize: '0.875rem', marginBottom: '0.5rem' }}>
             Download a copy or hotlink directly to the CDN:
           </p>
-          <table style={{ width: '100%', fontSize: '0.8125rem', borderCollapse: 'collapse' }}>
+          <table
+            style={{
+              width: '100%',
+              fontSize: '0.8125rem',
+              borderCollapse: 'collapse',
+            }}
+          >
             <thead>
               <tr style={{ borderBottom: '1px solid #e0e0e0' }}>
-                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem 0.5rem 0', fontWeight: 600 }}>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.5rem 0.75rem 0.5rem 0',
+                    fontWeight: 600,
+                  }}
+                >
                   Variant
                 </th>
-                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', fontWeight: 600 }}>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.5rem 0.75rem',
+                    fontWeight: 600,
+                  }}
+                >
                   CDN URL (copy to hotlink)
                 </th>
-                <th style={{ textAlign: 'left', padding: '0.5rem 0', fontWeight: 600 }}>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.5rem 0',
+                    fontWeight: 600,
+                  }}
+                >
                   Download
                 </th>
               </tr>
             </thead>
             <tbody>
-              {theme.logo.variants.map((v) => (
+              {theme.logo.variants.map(v => (
                 <tr key={v.url} style={{ borderBottom: '1px solid #f0f0f0' }}>
-                  <td style={{ padding: '0.5rem 0.75rem 0.5rem 0' }}>{v.label}</td>
-                  <td style={{ padding: '0.5rem 0.75rem', fontFamily: 'monospace', fontSize: '0.75rem', wordBreak: 'break-all' }}>
+                  <td style={{ padding: '0.5rem 0.75rem 0.5rem 0' }}>
+                    {v.label}
+                  </td>
+                  <td
+                    style={{
+                      padding: '0.5rem 0.75rem',
+                      fontFamily: 'monospace',
+                      fontSize: '0.75rem',
+                      wordBreak: 'break-all',
+                    }}
+                  >
                     <code>{v.url}</code>
                   </td>
                   <td style={{ padding: '0.5rem 0' }}>
@@ -144,7 +212,11 @@ function BrandIdentityPage({ themeName }) {
                       download
                       target="_blank"
                       rel="noopener noreferrer"
-                      style={{ color: primaryColor, fontWeight: 500, whiteSpace: 'nowrap' }}
+                      style={{
+                        color: primaryColor,
+                        fontWeight: 500,
+                        whiteSpace: 'nowrap',
+                      }}
                     >
                       Download ↓
                     </a>
@@ -159,27 +231,44 @@ function BrandIdentityPage({ themeName }) {
 
       {/* Color palette — probed live from compiled theme CSS */}
       <h2>Color palette</h2>
-      <p>Colors used across {theme.url}. Click any swatch to copy its hex value.
-        These values are read directly from the active theme's compiled CSS.</p>
+      <p>
+        Colors used across {theme.url}. Click any swatch to copy its hex value.
+        These values are read directly from the active theme's compiled CSS.
+      </p>
 
       <h3>Brand and interactive colors</h3>
       <div style={grid4}>
         {colorProbes.brand.map((c, i) => (
-          <ColorSwatch key={`brand-${i}`} color={rgbToHex(probeColor(c.probe, c.property))} name={c.name} usage={c.usage} />
+          <ColorSwatch
+            key={`brand-${i}`}
+            color={rgbToHex(probeColor(c.probe, c.property))}
+            name={c.name}
+            usage={c.usage}
+          />
         ))}
       </div>
 
       <h3>Accent colors</h3>
       <div style={grid4}>
         {colorProbes.accent.map((c, i) => (
-          <ColorSwatch key={`accent-${i}`} color={rgbToHex(probeColor(c.probe, c.property))} name={c.name} usage={c.usage} />
+          <ColorSwatch
+            key={`accent-${i}`}
+            color={rgbToHex(probeColor(c.probe, c.property))}
+            name={c.name}
+            usage={c.usage}
+          />
         ))}
       </div>
 
       <h3>Neutral colors</h3>
       <div style={grid4}>
         {colorProbes.neutral.map((c, i) => (
-          <ColorSwatch key={`neutral-${i}`} color={c.color} name={c.name} usage={c.usage} />
+          <ColorSwatch
+            key={`neutral-${i}`}
+            color={c.color}
+            name={c.name}
+            usage={c.usage}
+          />
         ))}
       </div>
 
@@ -187,21 +276,56 @@ function BrandIdentityPage({ themeName }) {
 
       {/* Typography */}
       <h2>Typography</h2>
-      <p>{theme.name} uses Roboto for body text and Roboto Condensed for headings.</p>
+      <p>
+        {theme.name} uses Roboto for body text and Roboto Condensed for
+        headings.
+      </p>
 
-      <TypographySample fontFamily="Roboto Condensed" fontSize="2.625rem" fontWeight={700} label="Page title" lineHeight="1.1">
+      <TypographySample
+        fontFamily="Roboto Condensed"
+        fontSize="2.625rem"
+        fontWeight={700}
+        label="Page title"
+        lineHeight="1.1"
+      >
         <Heading type="1">Page title</Heading>
       </TypographySample>
-      <TypographySample fontFamily="Roboto Condensed" fontSize="1.75rem" fontWeight={700} label="Section heading" lineHeight="1.2">
+      <TypographySample
+        fontFamily="Roboto Condensed"
+        fontSize="1.75rem"
+        fontWeight={700}
+        label="Section heading"
+        lineHeight="1.2"
+      >
         <Heading type="2">Section heading</Heading>
       </TypographySample>
-      <TypographySample fontFamily="Roboto Condensed" fontSize="1.375rem" fontWeight={600} label="Subsection heading" lineHeight="1.3">
+      <TypographySample
+        fontFamily="Roboto Condensed"
+        fontSize="1.375rem"
+        fontWeight={600}
+        label="Subsection heading"
+        lineHeight="1.3"
+      >
         <Heading type="3">Subsection heading</Heading>
       </TypographySample>
-      <TypographySample fontFamily="Roboto" fontSize="1rem" fontWeight={400} label="Body text" lineHeight="1.5">
-        <P detail={`Body text looks like this. It's used for descriptions, paragraphs, and general content across ${theme.url}.`} />
+      <TypographySample
+        fontFamily="Roboto"
+        fontSize="1rem"
+        fontWeight={400}
+        label="Body text"
+        lineHeight="1.5"
+      >
+        <P
+          detail={`Body text looks like this. It's used for descriptions, paragraphs, and general content across ${theme.url}.`}
+        />
       </TypographySample>
-      <TypographySample fontFamily="Roboto" fontSize="0.8125rem" fontWeight={400} label="Small text" lineHeight="1.4">
+      <TypographySample
+        fontFamily="Roboto"
+        fontSize="0.8125rem"
+        fontWeight={400}
+        label="Small text"
+        lineHeight="1.4"
+      >
         <Small detail="Small text for metadata, dates, and captions" />
       </TypographySample>
 
@@ -209,8 +333,19 @@ function BrandIdentityPage({ themeName }) {
 
       {/* Buttons */}
       <h2>Buttons</h2>
-      <p>Primary buttons use the brand color. Secondary buttons use an outline style.</p>
-      <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+      <p>
+        Primary buttons use the brand color. Secondary buttons use an outline
+        style.
+      </p>
+      <div
+        style={{
+          display: 'flex',
+          gap: '1rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          marginBottom: '1rem',
+        }}
+      >
         <CtaButton label="Primary action" Type="Primary" />
         <CtaButton label="Secondary action" Type="Secondary" />
         <CtaButton label="Disabled" Type="Primary" State="Disabled" />
@@ -221,10 +356,18 @@ function BrandIdentityPage({ themeName }) {
       {/* Icons */}
       <h2>Icons</h2>
       <p>
-        Mangrove includes a custom icon set. Use <code>mg-icon mg-icon-name</code> classes
-        in HTML, or the <code>{'<Icon name="..." />'}</code> React component.
+        Mangrove includes a custom icon set. Use{' '}
+        <code>mg-icon mg-icon-name</code> classes in HTML, or the{' '}
+        <code>{'<Icon name="..." />'}</code> React component.
       </p>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '1rem', marginBottom: '1rem' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(6, 1fr)',
+          gap: '1rem',
+          marginBottom: '1rem',
+        }}
+      >
         {[
           { name: 'globe', label: 'Globe' },
           { name: 'search', label: 'Search' },
@@ -248,14 +391,26 @@ function BrandIdentityPage({ themeName }) {
           { name: 'drought', label: 'Drought' },
           { name: 'resilience', label: 'Resilience' },
         ].map(icon => (
-          <div key={icon.name} style={{ textAlign: 'center', padding: '0.75rem 0' }}>
+          <div
+            key={icon.name}
+            style={{ textAlign: 'center', padding: '0.75rem 0' }}
+          >
             <Icon name={icon.name} size="lg" />
-            <div style={{ fontSize: '0.6875rem', color: '#666', marginTop: '0.25rem' }}>{icon.label}</div>
+            <div
+              style={{
+                fontSize: '0.6875rem',
+                color: '#666',
+                marginTop: '0.25rem',
+              }}
+            >
+              {icon.label}
+            </div>
           </div>
         ))}
       </div>
       <p style={{ fontSize: '0.875rem', color: '#666' }}>
-        Showing 21 of 80+ icons, including OCHA humanitarian icons. See the full set in the{' '}
+        Showing 21 of 80+ icons, including OCHA humanitarian icons. See the full
+        set in the{' '}
         <a href="/?path=/docs/components-icons--docs">Icons documentation</a>.
       </p>
 
@@ -270,14 +425,15 @@ function BrandIdentityPage({ themeName }) {
         </HighlightBox>
         <HighlightBox variant="secondary">
           <span style={{ color: 'white' }}>
-            <strong>Don't:</strong> Mix brand colors from other UNDRR properties.
-            Each property has its own identity.
+            <strong>Don't:</strong> Mix brand colors from other UNDRR
+            properties. Each property has its own identity.
           </span>
         </HighlightBox>
       </div>
       <div style={{ ...grid2, marginTop: '1rem' }}>
         <HighlightBox>
-          <strong>Do:</strong> Use Roboto Condensed for headings and Roboto Regular for body text.
+          <strong>Do:</strong> Use Roboto Condensed for headings and Roboto
+          Regular for body text.
         </HighlightBox>
         <HighlightBox variant="secondary">
           <span style={{ color: 'white' }}>
@@ -307,5 +463,5 @@ export default {
 };
 
 export const Docs = {
-  render: (args) => <BrandIdentityPage themeName={args.themeName} />,
+  render: args => <BrandIdentityPage themeName={args.themeName} />,
 };

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -1,6 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
-import { DesignTokenDocBlock } from 'storybook-design-token';
 
 <Meta
   title="Brand/Common patterns"
@@ -14,21 +13,16 @@ import { DesignTokenDocBlock } from 'storybook-design-token';
 
 # Common patterns
 
-Shared foundations across all UNDRR web properties. These values don't change when
-you switch themes — they're the underlying structure that keeps all five properties
-feeling coherent.
+The structural foundations shared across every UNDRR web property. These don't
+change when you switch themes.
+
+For token tables (exact hex values, pixel sizes, etc.), see the
+<LinkTo kind="design-decisions-colors" story="docs">Design decisions</LinkTo>
+section. This page explains the concepts in plain language and points to where
+to find the details.
 
 For theme-specific colors, typography, and components, see
 <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo>.
-
----
-
-## Spacing scale
-
-Consistent spacing creates visual rhythm. Use these tokens instead of arbitrary
-pixel values. Based on a 5px baseline grid.
-
-<DesignTokenDocBlock categoryName="Spacing" viewType="card" />
 
 ---
 
@@ -46,22 +40,6 @@ automatically at each threshold.
 
 The `mg-grid` utility handles column reflow across these breakpoints automatically.
 A 4-column grid becomes 2 columns on tablet and 1 column on mobile.
-
----
-
-## Typography foundations
-
-Every property uses the same two font families:
-
-- **Roboto Condensed** for headings (h1-h6) — compact, authoritative
-- **Roboto** for body text — readable, widely supported
-- **Noto Kufi Arabic** + **Dubai** for Arabic content (automatic via `lang="ar"`)
-
-The full font-size scale:
-
-<DesignTokenDocBlock categoryName="Font sizes" viewType="table" />
-
-See: <LinkTo kind="design-decisions-typography" story="docs">Typography reference</LinkTo>
 
 ---
 
@@ -83,9 +61,35 @@ See: <LinkTo kind="design-decisions-grid" story="docs">Grid reference</LinkTo>
 
 ---
 
+## Typography system
+
+Every property uses the same two font families:
+
+- **Roboto Condensed** for headings (h1-h6) — compact, authoritative
+- **Roboto** for body text — readable, widely supported
+- **Noto Kufi Arabic** + **Dubai** for Arabic content (automatic via `lang="ar"`)
+
+See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo>
+·
+<LinkTo kind="design-decisions-fonts" story="docs">Fonts</LinkTo>
+
+---
+
+## Spacing, colors, and neutral shades
+
+Spacing uses a 5px baseline grid. Neutral colors (body text, secondary text,
+backgrounds) are shared across all themes — only brand and accent colors change
+per property.
+
+See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo>
+·
+<LinkTo kind="design-decisions-colors" story="docs">Colors</LinkTo>
+
+---
+
 ## Accessibility
 
-All Mangrove components follow these accessibility standards:
+All Mangrove components follow these standards:
 
 - **WCAG 2.1 AA** contrast ratios (4.5:1 for body text, 3:1 for large text)
 - **Keyboard navigation** — all interactive elements reachable via Tab
@@ -109,7 +113,7 @@ on a container and Mangrove applies the right font and text direction automatica
 </div>
 ```
 
-The theme switcher in the Storybook toolbar (top right) lets you preview locales.
+The locale switcher in the Storybook toolbar lets you preview different languages.
 
 ---
 
@@ -127,17 +131,11 @@ See: <LinkTo kind="components-icons" story="docs">Full icon set</LinkTo>
 
 ---
 
-## Shared neutral colors
-
-These neutral tones are the same across all themes:
-
-<DesignTokenDocBlock categoryName="Colors - neutral" viewType="card" />
-
----
-
 ## Z-index layers
 
-Mangrove uses named tokens for stacking contexts to avoid z-index chaos:
+Mangrove uses named tokens for stacking contexts to avoid z-index chaos. Use
+`$mg-z-index-*` tokens from `_variables.scss` for global stacking (fixed, sticky,
+portaled elements).
 
 See: <LinkTo kind="design-decisions-z-index-layers" story="docs">Z-index layers</LinkTo>
 

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -1,3 +1,8 @@
+{/* Future consideration: this page leans developer-oriented (breakpoints, grid
+  classes, lang="ar" selectors) and may be better placed under Design decisions
+  than Brand. The stated Brand-section audience is non-technical editors and
+  partners. Re-evaluate once we have usage signal. */}
+
 import { Meta } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
 

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -17,12 +17,19 @@ The structural foundations shared across every UNDRR web property. These don't
 change when you switch themes.
 
 For token tables (exact hex values, pixel sizes, etc.), see the
-<LinkTo kind="design-decisions-colors" story="docs">Design decisions</LinkTo>
+
+<LinkTo kind="design-decisions-colors" story="docs">
+  Design decisions
+</LinkTo>
 section. This page explains the concepts in plain language and points to where
 to find the details.
 
 For theme-specific colors, typography, and components, see
-<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo>.
+
+<LinkTo kind="brand-brand-identity" story="docs">
+  Brand identity
+</LinkTo>
+.
 
 ---
 
@@ -31,12 +38,12 @@ For theme-specific colors, typography, and components, see
 Mangrove uses a mobile-first approach with four breakpoints. Content reflows
 automatically at each threshold.
 
-| Breakpoint | Value | Use case |
-|------------|-------|----------|
-| Mobile | 480px | Phones in portrait |
-| Tablet | 900px | Tablets and small laptops |
-| Desktop | 1164px | Primary target for most content |
-| Wide desktop | 1440px | Large displays, dashboards |
+| Breakpoint   | Value  | Use case                        |
+| ------------ | ------ | ------------------------------- |
+| Mobile       | 480px  | Phones in portrait              |
+| Tablet       | 900px  | Tablets and small laptops       |
+| Desktop      | 1164px | Primary target for most content |
+| Wide desktop | 1440px | Large displays, dashboards      |
 
 The `mg-grid` utility handles column reflow across these breakpoints automatically.
 A 4-column grid becomes 2 columns on tablet and 1 column on mobile.
@@ -48,12 +55,12 @@ A 4-column grid becomes 2 columns on tablet and 1 column on mobile.
 The `mg-grid` utility provides responsive CSS Grid layouts with built-in breakpoint
 behavior. Apply `mg-grid` to a container and `mg-grid__col-{N}` to control column count.
 
-| Class | Desktop | Tablet | Mobile |
-|-------|---------|--------|--------|
-| `mg-grid__col-2` | 2 cols | 1 col | 1 col |
-| `mg-grid__col-3` | 3 cols | 2 cols | 1 col |
-| `mg-grid__col-4` | 4 cols | 2 cols | 1 col |
-| `mg-grid__col-6` | 6 cols | 3 cols | 1 col |
+| Class            | Desktop | Tablet | Mobile |
+| ---------------- | ------- | ------ | ------ |
+| `mg-grid__col-2` | 2 cols  | 1 col  | 1 col  |
+| `mg-grid__col-3` | 3 cols  | 2 cols | 1 col  |
+| `mg-grid__col-4` | 4 cols  | 2 cols | 1 col  |
+| `mg-grid__col-6` | 6 cols  | 3 cols | 1 col  |
 
 Span modifiers: `mg-grid__col--span-2`, `mg-grid__col--span-3`, `mg-grid__col--span-all`.
 
@@ -71,7 +78,10 @@ Every property uses the same two font families:
 
 See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo>
 ·
-<LinkTo kind="design-decisions-fonts" story="docs">Fonts</LinkTo>
+
+<LinkTo kind="design-decisions-fonts" story="docs">
+  Fonts
+</LinkTo>
 
 ---
 
@@ -83,7 +93,10 @@ per property.
 
 See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo>
 ·
-<LinkTo kind="design-decisions-colors" story="docs">Colors</LinkTo>
+
+<LinkTo kind="design-decisions-colors" story="docs">
+  Colors
+</LinkTo>
 
 ---
 

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -1,0 +1,146 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { DesignTokenDocBlock } from 'storybook-design-token';
+
+<Meta
+  title="Brand/Common patterns"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# Common patterns
+
+Shared foundations across all UNDRR web properties. These values don't change when
+you switch themes — they're the underlying structure that keeps all five properties
+feeling coherent.
+
+For theme-specific colors, typography, and components, see
+<LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo>.
+
+---
+
+## Spacing scale
+
+Consistent spacing creates visual rhythm. Use these tokens instead of arbitrary
+pixel values. Based on a 5px baseline grid.
+
+<DesignTokenDocBlock categoryName="Spacing" viewType="card" />
+
+---
+
+## Breakpoints
+
+Mangrove uses a mobile-first approach with four breakpoints. Content reflows
+automatically at each threshold.
+
+| Breakpoint | Value | Use case |
+|------------|-------|----------|
+| Mobile | 480px | Phones in portrait |
+| Tablet | 900px | Tablets and small laptops |
+| Desktop | 1164px | Primary target for most content |
+| Wide desktop | 1440px | Large displays, dashboards |
+
+The `mg-grid` utility handles column reflow across these breakpoints automatically.
+A 4-column grid becomes 2 columns on tablet and 1 column on mobile.
+
+---
+
+## Typography foundations
+
+Every property uses the same two font families:
+
+- **Roboto Condensed** for headings (h1-h6) — compact, authoritative
+- **Roboto** for body text — readable, widely supported
+- **Noto Kufi Arabic** + **Dubai** for Arabic content (automatic via `lang="ar"`)
+
+The full font-size scale:
+
+<DesignTokenDocBlock categoryName="Font sizes" viewType="table" />
+
+See: <LinkTo kind="design-decisions-typography" story="docs">Typography reference</LinkTo>
+
+---
+
+## Grid system
+
+The `mg-grid` utility provides responsive CSS Grid layouts with built-in breakpoint
+behavior. Apply `mg-grid` to a container and `mg-grid__col-{N}` to control column count.
+
+| Class | Desktop | Tablet | Mobile |
+|-------|---------|--------|--------|
+| `mg-grid__col-2` | 2 cols | 1 col | 1 col |
+| `mg-grid__col-3` | 3 cols | 2 cols | 1 col |
+| `mg-grid__col-4` | 4 cols | 2 cols | 1 col |
+| `mg-grid__col-6` | 6 cols | 3 cols | 1 col |
+
+Span modifiers: `mg-grid__col--span-2`, `mg-grid__col--span-3`, `mg-grid__col--span-all`.
+
+See: <LinkTo kind="design-decisions-grid" story="docs">Grid reference</LinkTo>
+
+---
+
+## Accessibility
+
+All Mangrove components follow these accessibility standards:
+
+- **WCAG 2.1 AA** contrast ratios (4.5:1 for body text, 3:1 for large text)
+- **Keyboard navigation** — all interactive elements reachable via Tab
+- **Focus indicators** — visible focus rings with 2px outline
+- **ARIA landmarks** — semantic HTML + ARIA for screen reader support
+- **Touch targets** — minimum 44x44 pixels for tap targets
+- **RTL support** — logical CSS properties for Arabic layouts
+
+See: <LinkTo kind="getting-started-accessibility" story="docs">Accessibility documentation</LinkTo>
+
+---
+
+## Language support
+
+Mangrove supports English, Arabic, Japanese, and Myanmar. Set the `lang` attribute
+on a container and Mangrove applies the right font and text direction automatically:
+
+```html
+<div lang="ar" dir="rtl">
+  <!-- Arabic fonts, right-to-left layout -->
+</div>
+```
+
+The theme switcher in the Storybook toolbar (top right) lets you preview locales.
+
+---
+
+## Icon system
+
+Mangrove includes 80+ icons from three sources:
+
+- **Lucide** — general UI icons (search, calendar, chart, user)
+- **OCHA** — humanitarian icons for hazards and disaster response (earthquake, tsunami, flood, resilience)
+- **Custom** — UNDRR-specific icons
+
+Use classes (`mg-icon mg-icon-{name}`) in HTML or the `<Icon name="..." />` React component.
+
+See: <LinkTo kind="components-icons" story="docs">Full icon set</LinkTo>
+
+---
+
+## Shared neutral colors
+
+These neutral tones are the same across all themes:
+
+<DesignTokenDocBlock categoryName="Colors - neutral" viewType="card" />
+
+---
+
+## Z-index layers
+
+Mangrove uses named tokens for stacking contexts to avoid z-index chaos:
+
+See: <LinkTo kind="design-decisions-z-index-layers" story="docs">Z-index layers</LinkTo>
+
+---
+
+Last updated: 12 April 2026

--- a/stories/Documentation/Brand/ComponentGallery.mdx
+++ b/stories/Documentation/Brand/ComponentGallery.mdx
@@ -25,13 +25,13 @@ to the selected theme automatically.
 
 Components that define the overall shape of a page.
 
-| Component        | What it does                                                            | View                                                               |
-| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Page header      | Sticky top navigation with UNDRR branding, language selector, and login | <LinkTo kind="components-pageheader" story="docs">View</LinkTo>    |
-| Mega menu        | Multi-column dropdown navigation for complex sites                      | <LinkTo kind="components-mega-menu" story="docs">View</LinkTo>     |
-| Breadcrumbs      | Hierarchical navigation trail                                           | <LinkTo kind="components-breadcrumbs" story="docs">View</LinkTo>   |
-| On-this-page nav | Sticky table of contents for long articles                              | <LinkTo kind="components-onthispagenav" story="docs">View</LinkTo> |
-| Footer           | Site-wide footer with navigation, social links, Sendai/SDG logos        | <LinkTo kind="components-footer" story="docs">View</LinkTo>        |
+| Component        | What it does                                                            | View                                                                     |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Page header      | Sticky top navigation with UNDRR branding, language selector, and login | <LinkTo kind="components-pageheader" story="docs">View</LinkTo>          |
+| Mega menu        | Multi-column dropdown navigation for complex sites                      | <LinkTo kind="components-megamenu" story="docs">View</LinkTo>            |
+| Breadcrumbs      | Hierarchical navigation trail                                           | <LinkTo kind="components-navigation-breadcrumbs" story="docs">View</LinkTo> |
+| On-this-page nav | Sticky table of contents for long articles                              | <LinkTo kind="components-on-this-page-nav" story="docs">View</LinkTo>    |
+| Footer           | Site-wide footer with navigation, social links, Sendai/SDG logos        | <LinkTo kind="components-footer" story="docs">View</LinkTo>              |
 
 ---
 
@@ -39,11 +39,10 @@ Components that define the overall shape of a page.
 
 High-visibility sections that establish context.
 
-| Component      | What it does                                                                | View                                                                |
-| -------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Hero           | Full-width banner with title, summary, call-to-action, and background image | <LinkTo kind="components-hero-hero" story="docs">View</LinkTo>      |
-| Child hero     | Compact hero for sub-pages                                                  | <LinkTo kind="components-hero-childhero" story="docs">View</LinkTo> |
-| Section header | Heading + description for page sections                                     | <LinkTo kind="molecules-sectionheader" story="docs">View</LinkTo>   |
+| Component  | What it does                                                                | View                                                                  |
+| ---------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Hero       | Full-width banner with title, summary, call-to-action, and background image | <LinkTo kind="components-hero-hero" story="docs">View</LinkTo>        |
+| Child hero | Compact hero for sub-pages                                                  | <LinkTo kind="components-hero-hero-child" story="docs">View</LinkTo>  |
 
 ---
 
@@ -51,15 +50,15 @@ High-visibility sections that establish context.
 
 For listings, teasers, and content summaries.
 
-| Component       | What it does                                    | View                                                                           |
-| --------------- | ----------------------------------------------- | ------------------------------------------------------------------------------ |
-| Vertical card   | Image-above-text card (news, articles, events)  | <LinkTo kind="components-cards-card-verticalcard" story="docs">View</LinkTo>   |
-| Horizontal card | Side-by-side image and text                     | <LinkTo kind="components-cards-card-horizontalcard" story="docs">View</LinkTo> |
-| Book card       | Publication cover + metadata                    | <LinkTo kind="components-cards-card-bookcard" story="docs">View</LinkTo>       |
-| Icon card       | Card with prominent icon (services, categories) | <LinkTo kind="components-cards-iconcard" story="docs">View</LinkTo>            |
-| Stats card      | Numeric highlights with label and context       | <LinkTo kind="components-cards-statscard" story="docs">View</LinkTo>           |
-| Quote highlight | Featured quote with attribution                 | <LinkTo kind="components-quotehighlight" story="docs">View</LinkTo>            |
-| Highlight box   | Emphasized content container with tone variants | <LinkTo kind="components-highlightbox" story="docs">View</LinkTo>              |
+| Component       | What it does                                    | View                                                                       |
+| --------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| Vertical card   | Image-above-text card (news, articles, events)  | <LinkTo kind="components-cards-vertical-card" story="docs">View</LinkTo>   |
+| Horizontal card | Side-by-side image and text                     | <LinkTo kind="components-cards-horizontal-card" story="docs">View</LinkTo> |
+| Book card       | Publication cover + metadata                    | <LinkTo kind="components-cards-book-card" story="docs">View</LinkTo>       |
+| Icon card       | Card with prominent icon (services, categories) | <LinkTo kind="components-cards-icon-card" story="docs">View</LinkTo>       |
+| Stats card      | Numeric highlights with label and context       | <LinkTo kind="components-cards-stats-card" story="docs">View</LinkTo>      |
+| Quote highlight | Featured quote with attribution                 | <LinkTo kind="components-quotehighlight" story="docs">View</LinkTo>        |
+| Highlight box   | Emphasized content container with tone variants | <LinkTo kind="components-highlightbox" story="docs">View</LinkTo>          |
 
 ---
 
@@ -67,15 +66,15 @@ For listings, teasers, and content summaries.
 
 Buttons, forms, and user input.
 
-| Component     | What it does                             | View                                                                      |
-| ------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| CTA button    | Primary and secondary action buttons     | <LinkTo kind="components-buttons-ctabutton" story="docs">View</LinkTo>    |
-| Chips         | Filter chips and tag selectors           | <LinkTo kind="components-buttons-chips" story="docs">View</LinkTo>        |
-| Share buttons | Social media share links with copy-URL   | <LinkTo kind="components-buttons-sharebuttons" story="docs">View</LinkTo> |
-| Forms         | Text inputs, checkboxes, radios, selects | <LinkTo kind="components-forms" story="docs">View</LinkTo>                |
-| Tabs          | Horizontal tab bar with active state     | <LinkTo kind="components-tab" story="docs">View</LinkTo>                  |
-| Pager         | Pagination for long result lists         | <LinkTo kind="components-pager" story="docs">View</LinkTo>                |
-| Pagination    | Classic page number navigation           | <LinkTo kind="components-pagination" story="docs">View</LinkTo>           |
+| Component     | What it does                             | View                                                                          |
+| ------------- | ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Buttons       | Primary and secondary action buttons     | <LinkTo kind="components-buttons-buttons" story="docs">View</LinkTo>          |
+| Chips         | Filter chips and tag selectors           | <LinkTo kind="components-buttons-chips" story="docs">View</LinkTo>            |
+| Share buttons | Social media share links with copy-URL   | <LinkTo kind="components-buttons-sharebuttons" story="docs">View</LinkTo>     |
+| Forms         | Text inputs, checkboxes, radios, selects | <LinkTo kind="components-forms-checkbox" story="docs">View</LinkTo>           |
+| Tabs          | Horizontal tab bar with active state     | <LinkTo kind="components-tabs" story="docs">View</LinkTo>                     |
+| Pager         | Pagination for long result lists         | <LinkTo kind="components-pager" story="docs">View</LinkTo>                    |
+| Pagination    | Classic page number navigation           | <LinkTo kind="components-navigation-pagination" story="docs">View</LinkTo>    |
 
 ---
 
@@ -83,25 +82,23 @@ Buttons, forms, and user input.
 
 For charts, maps, and media.
 
-| Component         | What it does                                | View                                                                 |
-| ----------------- | ------------------------------------------- | -------------------------------------------------------------------- |
-| Bar chart         | Horizontal and vertical bar charts          | <LinkTo kind="components-charts-barchart" story="docs">View</LinkTo> |
-| Map               | Interactive geographic maps (Leaflet-based) | <LinkTo kind="components-map" story="docs">View</LinkTo>             |
-| Gallery           | Image grid with lightbox                    | <LinkTo kind="components-gallery" story="docs">View</LinkTo>         |
-| Table of contents | Auto-generated content index                | <LinkTo kind="components-tableofcontents" story="docs">View</LinkTo> |
+| Component         | What it does                                | View                                                                       |
+| ----------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| Bar chart         | Horizontal and vertical bar charts          | <LinkTo kind="components-charts-barchart" story="docs">View</LinkTo>       |
+| Map               | Interactive geographic maps (Leaflet-based) | <LinkTo kind="components-maps-mapcomponent" story="docs">View</LinkTo>     |
+| Gallery           | Image grid with lightbox                    | <LinkTo kind="components-gallery" story="docs">View</LinkTo>               |
+| Table of contents | Auto-generated content index                | <LinkTo kind="components-table-of-contents" story="docs">View</LinkTo>     |
 
 ---
 
 ## Typography
 
-Headings, paragraphs, and text styling.
+Headings, paragraphs, and text styling. See all typography examples:
 
 | Component              | What it does                                | View                                                                                           |
 | ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Heading                | Semantic h1-h6 with Roboto Condensed        | <LinkTo kind="components-typography-heading" story="docs">View</LinkTo>                        |
-| Base typography        | Paragraphs, quotes, code, small text        | <LinkTo kind="components-typography" story="docs">View</LinkTo>                                |
+| Base typography        | Headings, paragraphs, quotes, code, lists   | <LinkTo kind="components-typography" story="docs">View</LinkTo>                                |
 | Links                  | Primary, secondary, and variant link styles | <LinkTo kind="components-typography-links" story="docs">View</LinkTo>                          |
-| Lists                  | Ordered, unordered, and description lists   | <LinkTo kind="components-typography-lists" story="docs">View</LinkTo>                          |
 | Typography integration | Complete typography example page            | <LinkTo kind="components-typography-typography-integration-example" story="docs">View</LinkTo> |
 
 ---
@@ -112,9 +109,8 @@ Utilities for structuring pages.
 
 | Component           | What it does                           | View                                                                     |
 | ------------------- | -------------------------------------- | ------------------------------------------------------------------------ |
-| Grid                | Responsive CSS Grid system             | <LinkTo kind="design-decisions-grid" story="docs">View</LinkTo>          |
+| Grid                | Responsive CSS Grid system             | <LinkTo kind="design-decisions-grid-layout" story="docs">View</LinkTo>   |
 | Scroll container    | Horizontal scrolling content carousels | <LinkTo kind="components-scrollcontainer" story="docs">View</LinkTo>     |
-| Body column         | Centered content column with max-width | <LinkTo kind="molecules-bodycolumn" story="docs">View</LinkTo>           |
 | Font size utilities | CSS classes for typography overrides   | <LinkTo kind="components-font-size-utilities" story="docs">View</LinkTo> |
 
 ---
@@ -129,8 +125,8 @@ Shared infrastructure across UNDRR sites.
 | Snackbar           | Temporary notifications and alerts | <LinkTo kind="components-snackbar" story="docs">View</LinkTo>                |
 | Syndication search | Cross-site content search widget   | <LinkTo kind="components-syndicationsearchwidget" story="docs">View</LinkTo> |
 | Fetcher            | Async content loading wrapper      | <LinkTo kind="components-fetcher" story="docs">View</LinkTo>                 |
-| Error pages        | 404, 500, and maintenance pages    | <LinkTo kind="components-errorpages" story="docs">View</LinkTo>              |
-| Page templates     | Complete page layout examples      | <LinkTo kind="components-pagetemplates" story="docs">View</LinkTo>           |
+| Error pages        | 404, 500, and maintenance pages    | <LinkTo kind="components-error-pages" story="docs">View</LinkTo>             |
+| Page template      | Complete page layout example       | <LinkTo kind="example-page-template-example" story="docs">View</LinkTo>      |
 
 ---
 
@@ -140,16 +136,6 @@ Shared infrastructure across UNDRR sites.
 hazard icons (earthquake, tsunami, flood, cyclone, drought).
 
 See: <LinkTo kind="components-icons" story="docs">Full icon set</LinkTo>
-
----
-
-## Utilities
-
-CSS-only helpers that don't need React.
-
-See: <LinkTo kind="utilities" story="docs">All utilities</LinkTo>
-
-Includes: font-size overrides, embed containers, show-more reveal, loaders.
 
 ---
 

--- a/stories/Documentation/Brand/ComponentGallery.mdx
+++ b/stories/Documentation/Brand/ComponentGallery.mdx
@@ -1,3 +1,9 @@
+{/* Maintenance note: the LinkTo `kind` values below are story IDs that change
+  when a component's Storybook title changes (e.g. renaming, re-categorising).
+  Validate against http://localhost:6006/index.json before shipping changes
+  that touch story titles. Consider adding an automated check to the
+  /document-release flow. */}
+
 import { Meta } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
 

--- a/stories/Documentation/Brand/ComponentGallery.mdx
+++ b/stories/Documentation/Brand/ComponentGallery.mdx
@@ -1,0 +1,164 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
+
+<Meta
+  title="Brand/Component gallery"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: {
+      canvas: { hidden: true },
+    },
+  }}
+/>
+
+# Component gallery
+
+A curated catalog of Mangrove components, organized by purpose. Click any component
+to see live examples, variants, and usage guidance.
+
+For theme-specific previews, switch themes in the toolbar. Every component adapts
+to the selected theme automatically.
+
+---
+
+## Page structure
+
+Components that define the overall shape of a page.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Page header | Sticky top navigation with UNDRR branding, language selector, and login | <LinkTo kind="components-pageheader" story="docs">View</LinkTo> |
+| Mega menu | Multi-column dropdown navigation for complex sites | <LinkTo kind="components-mega-menu" story="docs">View</LinkTo> |
+| Breadcrumbs | Hierarchical navigation trail | <LinkTo kind="components-breadcrumbs" story="docs">View</LinkTo> |
+| On-this-page nav | Sticky table of contents for long articles | <LinkTo kind="components-onthispagenav" story="docs">View</LinkTo> |
+| Footer | Site-wide footer with navigation, social links, Sendai/SDG logos | <LinkTo kind="components-footer" story="docs">View</LinkTo> |
+
+---
+
+## Hero and headers
+
+High-visibility sections that establish context.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Hero | Full-width banner with title, summary, call-to-action, and background image | <LinkTo kind="components-hero-hero" story="docs">View</LinkTo> |
+| Child hero | Compact hero for sub-pages | <LinkTo kind="components-hero-childhero" story="docs">View</LinkTo> |
+| Section header | Heading + description for page sections | <LinkTo kind="molecules-sectionheader" story="docs">View</LinkTo> |
+
+---
+
+## Content cards
+
+For listings, teasers, and content summaries.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Vertical card | Image-above-text card (news, articles, events) | <LinkTo kind="components-cards-card-verticalcard" story="docs">View</LinkTo> |
+| Horizontal card | Side-by-side image and text | <LinkTo kind="components-cards-card-horizontalcard" story="docs">View</LinkTo> |
+| Book card | Publication cover + metadata | <LinkTo kind="components-cards-card-bookcard" story="docs">View</LinkTo> |
+| Icon card | Card with prominent icon (services, categories) | <LinkTo kind="components-cards-iconcard" story="docs">View</LinkTo> |
+| Stats card | Numeric highlights with label and context | <LinkTo kind="components-cards-statscard" story="docs">View</LinkTo> |
+| Quote highlight | Featured quote with attribution | <LinkTo kind="components-quotehighlight" story="docs">View</LinkTo> |
+| Highlight box | Emphasized content container with tone variants | <LinkTo kind="components-highlightbox" story="docs">View</LinkTo> |
+
+---
+
+## Interactive elements
+
+Buttons, forms, and user input.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| CTA button | Primary and secondary action buttons | <LinkTo kind="components-buttons-ctabutton" story="docs">View</LinkTo> |
+| Chips | Filter chips and tag selectors | <LinkTo kind="components-buttons-chips" story="docs">View</LinkTo> |
+| Share buttons | Social media share links with copy-URL | <LinkTo kind="components-buttons-sharebuttons" story="docs">View</LinkTo> |
+| Forms | Text inputs, checkboxes, radios, selects | <LinkTo kind="components-forms" story="docs">View</LinkTo> |
+| Tabs | Horizontal tab bar with active state | <LinkTo kind="components-tab" story="docs">View</LinkTo> |
+| Pager | Pagination for long result lists | <LinkTo kind="components-pager" story="docs">View</LinkTo> |
+| Pagination | Classic page number navigation | <LinkTo kind="components-pagination" story="docs">View</LinkTo> |
+
+---
+
+## Data visualization
+
+For charts, maps, and media.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Bar chart | Horizontal and vertical bar charts | <LinkTo kind="components-charts-barchart" story="docs">View</LinkTo> |
+| Map | Interactive geographic maps (Leaflet-based) | <LinkTo kind="components-map" story="docs">View</LinkTo> |
+| Gallery | Image grid with lightbox | <LinkTo kind="components-gallery" story="docs">View</LinkTo> |
+| Table of contents | Auto-generated content index | <LinkTo kind="components-tableofcontents" story="docs">View</LinkTo> |
+
+---
+
+## Typography
+
+Headings, paragraphs, and text styling.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Heading | Semantic h1-h6 with Roboto Condensed | <LinkTo kind="components-typography-heading" story="docs">View</LinkTo> |
+| Base typography | Paragraphs, quotes, code, small text | <LinkTo kind="components-typography" story="docs">View</LinkTo> |
+| Links | Primary, secondary, and variant link styles | <LinkTo kind="components-typography-links" story="docs">View</LinkTo> |
+| Lists | Ordered, unordered, and description lists | <LinkTo kind="components-typography-lists" story="docs">View</LinkTo> |
+| Typography integration | Complete typography example page | <LinkTo kind="components-typography-typography-integration-example" story="docs">View</LinkTo> |
+
+---
+
+## Layout helpers
+
+Utilities for structuring pages.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Grid | Responsive CSS Grid system | <LinkTo kind="design-decisions-grid" story="docs">View</LinkTo> |
+| Scroll container | Horizontal scrolling content carousels | <LinkTo kind="components-scrollcontainer" story="docs">View</LinkTo> |
+| Body column | Centered content column with max-width | <LinkTo kind="molecules-bodycolumn" story="docs">View</LinkTo> |
+| Font size utilities | CSS classes for typography overrides | <LinkTo kind="components-font-size-utilities" story="docs">View</LinkTo> |
+
+---
+
+## Platform features
+
+Shared infrastructure across UNDRR sites.
+
+| Component | What it does | View |
+|-----------|-------------|------|
+| Cookie consent | GDPR-compliant cookie banner | <LinkTo kind="components-cookieconsentbanner" story="docs">View</LinkTo> |
+| Snackbar | Temporary notifications and alerts | <LinkTo kind="components-snackbar" story="docs">View</LinkTo> |
+| Syndication search | Cross-site content search widget | <LinkTo kind="components-syndicationsearchwidget" story="docs">View</LinkTo> |
+| Fetcher | Async content loading wrapper | <LinkTo kind="components-fetcher" story="docs">View</LinkTo> |
+| Error pages | 404, 500, and maintenance pages | <LinkTo kind="components-errorpages" story="docs">View</LinkTo> |
+| Page templates | Complete page layout examples | <LinkTo kind="components-pagetemplates" story="docs">View</LinkTo> |
+
+---
+
+## Icons
+
+80+ icons for UI and humanitarian content. Includes Lucide general icons and OCHA
+hazard icons (earthquake, tsunami, flood, cyclone, drought).
+
+See: <LinkTo kind="components-icons" story="docs">Full icon set</LinkTo>
+
+---
+
+## Utilities
+
+CSS-only helpers that don't need React.
+
+See: <LinkTo kind="utilities" story="docs">All utilities</LinkTo>
+
+Includes: font-size overrides, embed containers, show-more reveal, loaders.
+
+---
+
+## Need something that's not here?
+
+[Open a GitHub issue](https://github.com/unisdr/undrr-mangrove/issues) to request
+a new component or variant. For one-off patterns, check the existing components —
+most cases are covered by combining them.
+
+---
+
+Last updated: 12 April 2026

--- a/stories/Documentation/Brand/ComponentGallery.mdx
+++ b/stories/Documentation/Brand/ComponentGallery.mdx
@@ -25,13 +25,13 @@ to the selected theme automatically.
 
 Components that define the overall shape of a page.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Page header | Sticky top navigation with UNDRR branding, language selector, and login | <LinkTo kind="components-pageheader" story="docs">View</LinkTo> |
-| Mega menu | Multi-column dropdown navigation for complex sites | <LinkTo kind="components-mega-menu" story="docs">View</LinkTo> |
-| Breadcrumbs | Hierarchical navigation trail | <LinkTo kind="components-breadcrumbs" story="docs">View</LinkTo> |
-| On-this-page nav | Sticky table of contents for long articles | <LinkTo kind="components-onthispagenav" story="docs">View</LinkTo> |
-| Footer | Site-wide footer with navigation, social links, Sendai/SDG logos | <LinkTo kind="components-footer" story="docs">View</LinkTo> |
+| Component        | What it does                                                            | View                                                               |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Page header      | Sticky top navigation with UNDRR branding, language selector, and login | <LinkTo kind="components-pageheader" story="docs">View</LinkTo>    |
+| Mega menu        | Multi-column dropdown navigation for complex sites                      | <LinkTo kind="components-mega-menu" story="docs">View</LinkTo>     |
+| Breadcrumbs      | Hierarchical navigation trail                                           | <LinkTo kind="components-breadcrumbs" story="docs">View</LinkTo>   |
+| On-this-page nav | Sticky table of contents for long articles                              | <LinkTo kind="components-onthispagenav" story="docs">View</LinkTo> |
+| Footer           | Site-wide footer with navigation, social links, Sendai/SDG logos        | <LinkTo kind="components-footer" story="docs">View</LinkTo>        |
 
 ---
 
@@ -39,11 +39,11 @@ Components that define the overall shape of a page.
 
 High-visibility sections that establish context.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Hero | Full-width banner with title, summary, call-to-action, and background image | <LinkTo kind="components-hero-hero" story="docs">View</LinkTo> |
-| Child hero | Compact hero for sub-pages | <LinkTo kind="components-hero-childhero" story="docs">View</LinkTo> |
-| Section header | Heading + description for page sections | <LinkTo kind="molecules-sectionheader" story="docs">View</LinkTo> |
+| Component      | What it does                                                                | View                                                                |
+| -------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Hero           | Full-width banner with title, summary, call-to-action, and background image | <LinkTo kind="components-hero-hero" story="docs">View</LinkTo>      |
+| Child hero     | Compact hero for sub-pages                                                  | <LinkTo kind="components-hero-childhero" story="docs">View</LinkTo> |
+| Section header | Heading + description for page sections                                     | <LinkTo kind="molecules-sectionheader" story="docs">View</LinkTo>   |
 
 ---
 
@@ -51,15 +51,15 @@ High-visibility sections that establish context.
 
 For listings, teasers, and content summaries.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Vertical card | Image-above-text card (news, articles, events) | <LinkTo kind="components-cards-card-verticalcard" story="docs">View</LinkTo> |
-| Horizontal card | Side-by-side image and text | <LinkTo kind="components-cards-card-horizontalcard" story="docs">View</LinkTo> |
-| Book card | Publication cover + metadata | <LinkTo kind="components-cards-card-bookcard" story="docs">View</LinkTo> |
-| Icon card | Card with prominent icon (services, categories) | <LinkTo kind="components-cards-iconcard" story="docs">View</LinkTo> |
-| Stats card | Numeric highlights with label and context | <LinkTo kind="components-cards-statscard" story="docs">View</LinkTo> |
-| Quote highlight | Featured quote with attribution | <LinkTo kind="components-quotehighlight" story="docs">View</LinkTo> |
-| Highlight box | Emphasized content container with tone variants | <LinkTo kind="components-highlightbox" story="docs">View</LinkTo> |
+| Component       | What it does                                    | View                                                                           |
+| --------------- | ----------------------------------------------- | ------------------------------------------------------------------------------ |
+| Vertical card   | Image-above-text card (news, articles, events)  | <LinkTo kind="components-cards-card-verticalcard" story="docs">View</LinkTo>   |
+| Horizontal card | Side-by-side image and text                     | <LinkTo kind="components-cards-card-horizontalcard" story="docs">View</LinkTo> |
+| Book card       | Publication cover + metadata                    | <LinkTo kind="components-cards-card-bookcard" story="docs">View</LinkTo>       |
+| Icon card       | Card with prominent icon (services, categories) | <LinkTo kind="components-cards-iconcard" story="docs">View</LinkTo>            |
+| Stats card      | Numeric highlights with label and context       | <LinkTo kind="components-cards-statscard" story="docs">View</LinkTo>           |
+| Quote highlight | Featured quote with attribution                 | <LinkTo kind="components-quotehighlight" story="docs">View</LinkTo>            |
+| Highlight box   | Emphasized content container with tone variants | <LinkTo kind="components-highlightbox" story="docs">View</LinkTo>              |
 
 ---
 
@@ -67,15 +67,15 @@ For listings, teasers, and content summaries.
 
 Buttons, forms, and user input.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| CTA button | Primary and secondary action buttons | <LinkTo kind="components-buttons-ctabutton" story="docs">View</LinkTo> |
-| Chips | Filter chips and tag selectors | <LinkTo kind="components-buttons-chips" story="docs">View</LinkTo> |
-| Share buttons | Social media share links with copy-URL | <LinkTo kind="components-buttons-sharebuttons" story="docs">View</LinkTo> |
-| Forms | Text inputs, checkboxes, radios, selects | <LinkTo kind="components-forms" story="docs">View</LinkTo> |
-| Tabs | Horizontal tab bar with active state | <LinkTo kind="components-tab" story="docs">View</LinkTo> |
-| Pager | Pagination for long result lists | <LinkTo kind="components-pager" story="docs">View</LinkTo> |
-| Pagination | Classic page number navigation | <LinkTo kind="components-pagination" story="docs">View</LinkTo> |
+| Component     | What it does                             | View                                                                      |
+| ------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| CTA button    | Primary and secondary action buttons     | <LinkTo kind="components-buttons-ctabutton" story="docs">View</LinkTo>    |
+| Chips         | Filter chips and tag selectors           | <LinkTo kind="components-buttons-chips" story="docs">View</LinkTo>        |
+| Share buttons | Social media share links with copy-URL   | <LinkTo kind="components-buttons-sharebuttons" story="docs">View</LinkTo> |
+| Forms         | Text inputs, checkboxes, radios, selects | <LinkTo kind="components-forms" story="docs">View</LinkTo>                |
+| Tabs          | Horizontal tab bar with active state     | <LinkTo kind="components-tab" story="docs">View</LinkTo>                  |
+| Pager         | Pagination for long result lists         | <LinkTo kind="components-pager" story="docs">View</LinkTo>                |
+| Pagination    | Classic page number navigation           | <LinkTo kind="components-pagination" story="docs">View</LinkTo>           |
 
 ---
 
@@ -83,12 +83,12 @@ Buttons, forms, and user input.
 
 For charts, maps, and media.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Bar chart | Horizontal and vertical bar charts | <LinkTo kind="components-charts-barchart" story="docs">View</LinkTo> |
-| Map | Interactive geographic maps (Leaflet-based) | <LinkTo kind="components-map" story="docs">View</LinkTo> |
-| Gallery | Image grid with lightbox | <LinkTo kind="components-gallery" story="docs">View</LinkTo> |
-| Table of contents | Auto-generated content index | <LinkTo kind="components-tableofcontents" story="docs">View</LinkTo> |
+| Component         | What it does                                | View                                                                 |
+| ----------------- | ------------------------------------------- | -------------------------------------------------------------------- |
+| Bar chart         | Horizontal and vertical bar charts          | <LinkTo kind="components-charts-barchart" story="docs">View</LinkTo> |
+| Map               | Interactive geographic maps (Leaflet-based) | <LinkTo kind="components-map" story="docs">View</LinkTo>             |
+| Gallery           | Image grid with lightbox                    | <LinkTo kind="components-gallery" story="docs">View</LinkTo>         |
+| Table of contents | Auto-generated content index                | <LinkTo kind="components-tableofcontents" story="docs">View</LinkTo> |
 
 ---
 
@@ -96,13 +96,13 @@ For charts, maps, and media.
 
 Headings, paragraphs, and text styling.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Heading | Semantic h1-h6 with Roboto Condensed | <LinkTo kind="components-typography-heading" story="docs">View</LinkTo> |
-| Base typography | Paragraphs, quotes, code, small text | <LinkTo kind="components-typography" story="docs">View</LinkTo> |
-| Links | Primary, secondary, and variant link styles | <LinkTo kind="components-typography-links" story="docs">View</LinkTo> |
-| Lists | Ordered, unordered, and description lists | <LinkTo kind="components-typography-lists" story="docs">View</LinkTo> |
-| Typography integration | Complete typography example page | <LinkTo kind="components-typography-typography-integration-example" story="docs">View</LinkTo> |
+| Component              | What it does                                | View                                                                                           |
+| ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Heading                | Semantic h1-h6 with Roboto Condensed        | <LinkTo kind="components-typography-heading" story="docs">View</LinkTo>                        |
+| Base typography        | Paragraphs, quotes, code, small text        | <LinkTo kind="components-typography" story="docs">View</LinkTo>                                |
+| Links                  | Primary, secondary, and variant link styles | <LinkTo kind="components-typography-links" story="docs">View</LinkTo>                          |
+| Lists                  | Ordered, unordered, and description lists   | <LinkTo kind="components-typography-lists" story="docs">View</LinkTo>                          |
+| Typography integration | Complete typography example page            | <LinkTo kind="components-typography-typography-integration-example" story="docs">View</LinkTo> |
 
 ---
 
@@ -110,12 +110,12 @@ Headings, paragraphs, and text styling.
 
 Utilities for structuring pages.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Grid | Responsive CSS Grid system | <LinkTo kind="design-decisions-grid" story="docs">View</LinkTo> |
-| Scroll container | Horizontal scrolling content carousels | <LinkTo kind="components-scrollcontainer" story="docs">View</LinkTo> |
-| Body column | Centered content column with max-width | <LinkTo kind="molecules-bodycolumn" story="docs">View</LinkTo> |
-| Font size utilities | CSS classes for typography overrides | <LinkTo kind="components-font-size-utilities" story="docs">View</LinkTo> |
+| Component           | What it does                           | View                                                                     |
+| ------------------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Grid                | Responsive CSS Grid system             | <LinkTo kind="design-decisions-grid" story="docs">View</LinkTo>          |
+| Scroll container    | Horizontal scrolling content carousels | <LinkTo kind="components-scrollcontainer" story="docs">View</LinkTo>     |
+| Body column         | Centered content column with max-width | <LinkTo kind="molecules-bodycolumn" story="docs">View</LinkTo>           |
+| Font size utilities | CSS classes for typography overrides   | <LinkTo kind="components-font-size-utilities" story="docs">View</LinkTo> |
 
 ---
 
@@ -123,14 +123,14 @@ Utilities for structuring pages.
 
 Shared infrastructure across UNDRR sites.
 
-| Component | What it does | View |
-|-----------|-------------|------|
-| Cookie consent | GDPR-compliant cookie banner | <LinkTo kind="components-cookieconsentbanner" story="docs">View</LinkTo> |
-| Snackbar | Temporary notifications and alerts | <LinkTo kind="components-snackbar" story="docs">View</LinkTo> |
-| Syndication search | Cross-site content search widget | <LinkTo kind="components-syndicationsearchwidget" story="docs">View</LinkTo> |
-| Fetcher | Async content loading wrapper | <LinkTo kind="components-fetcher" story="docs">View</LinkTo> |
-| Error pages | 404, 500, and maintenance pages | <LinkTo kind="components-errorpages" story="docs">View</LinkTo> |
-| Page templates | Complete page layout examples | <LinkTo kind="components-pagetemplates" story="docs">View</LinkTo> |
+| Component          | What it does                       | View                                                                         |
+| ------------------ | ---------------------------------- | ---------------------------------------------------------------------------- |
+| Cookie consent     | GDPR-compliant cookie banner       | <LinkTo kind="components-cookieconsentbanner" story="docs">View</LinkTo>     |
+| Snackbar           | Temporary notifications and alerts | <LinkTo kind="components-snackbar" story="docs">View</LinkTo>                |
+| Syndication search | Cross-site content search widget   | <LinkTo kind="components-syndicationsearchwidget" story="docs">View</LinkTo> |
+| Fetcher            | Async content loading wrapper      | <LinkTo kind="components-fetcher" story="docs">View</LinkTo>                 |
+| Error pages        | 404, 500, and maintenance pages    | <LinkTo kind="components-errorpages" story="docs">View</LinkTo>              |
+| Page templates     | Complete page layout examples      | <LinkTo kind="components-pagetemplates" story="docs">View</LinkTo>           |
 
 ---
 

--- a/stories/Documentation/Brand/components/ColorSwatch.jsx
+++ b/stories/Documentation/Brand/components/ColorSwatch.jsx
@@ -1,0 +1,160 @@
+/**
+ * @file ColorSwatch.jsx
+ * @description Displays a color swatch with hex value, usage label, and click-to-copy.
+ * Reads resolved color values from the browser via getComputedStyle on a hidden probe element.
+ *
+ * @module ColorSwatch
+ */
+
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import './color-swatch.css';
+
+/**
+ * Returns white or dark text depending on background luminance.
+ * Uses the W3C relative luminance formula.
+ *
+ * @param {string} hex - Hex color string (e.g., '#004f91')
+ * @returns {'#fff'|'#1a1a1a'} Contrasting text color
+ */
+function contrastingText(hex) {
+  const c = hex.replace('#', '');
+  const r = parseInt(c.substring(0, 2), 16);
+  const g = parseInt(c.substring(2, 4), 16);
+  const b = parseInt(c.substring(4, 6), 16);
+  // Relative luminance (sRGB)
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#1a1a1a' : '#fff';
+}
+
+/**
+ * Converts an rgb/rgba string to a hex string.
+ *
+ * @param {string} rgb - e.g., 'rgb(0, 79, 145)' or 'rgba(0, 79, 145, 1)'
+ * @returns {string|null} Hex string (e.g., '#004f91') or null if unparseable
+ */
+function rgbToHex(rgb) {
+  if (!rgb) return null;
+  if (rgb.startsWith('#')) return rgb;
+  const match = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) return null;
+  const r = parseInt(match[1], 10);
+  const g = parseInt(match[2], 10);
+  const b = parseInt(match[3], 10);
+  return (
+    '#' +
+    [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')
+  );
+}
+
+/**
+ * Color swatch that reads its color from the browser's computed styles.
+ *
+ * Renders a hidden probe element with the given CSS class, reads the resolved
+ * color via getComputedStyle, and displays a visual swatch with hex value
+ * and copy-to-clipboard support.
+ *
+ * @param {Object} props
+ * @param {string} props.probe          CSS class to apply to the hidden probe element (e.g., 'mg-hero')
+ * @param {string} [props.property='background-color'] CSS property to read from the probe
+ * @param {string} [props.color]        Explicit hex color override (skips probing)
+ * @param {string} props.name           Human-readable color name
+ * @param {string} [props.usage]        Plain-language usage description
+ */
+export function ColorSwatch({
+  probe,
+  property = 'background-color',
+  color: explicitColor,
+  name,
+  usage,
+}) {
+  const probeRef = useRef(null);
+  const [hex, setHex] = useState(explicitColor || null);
+  const [copyState, setCopyState] = useState('idle'); // 'idle' | 'copied' | 'failed'
+
+  useEffect(() => {
+    if (explicitColor) {
+      setHex(explicitColor);
+      return;
+    }
+    if (!probeRef.current) return;
+    const computed = window.getComputedStyle(probeRef.current);
+    const raw = computed.getPropertyValue(property);
+    const resolved = rgbToHex(raw);
+    if (resolved && resolved !== '#000000') {
+      setHex(resolved);
+    }
+  }, [probe, property, explicitColor]);
+
+  const handleCopy = useCallback(async () => {
+    if (!hex) return;
+    try {
+      await navigator.clipboard.writeText(hex);
+      setCopyState('copied');
+      setTimeout(() => setCopyState('idle'), 1500);
+    } catch {
+      setCopyState('failed');
+      setTimeout(() => setCopyState('idle'), 2000);
+    }
+  }, [hex]);
+
+  const textColor = hex ? contrastingText(hex) : '#1a1a1a';
+  const displayHex = hex || '#000000';
+
+  return (
+    <div className="mg-color-swatch">
+      {/* Hidden probe element for CSS extraction */}
+      {!explicitColor && probe && (
+        <div
+          ref={probeRef}
+          className={probe}
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            width: 0,
+            height: 0,
+            overflow: 'hidden',
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+
+      <button
+        type="button"
+        className="mg-color-swatch__block"
+        style={{ backgroundColor: displayHex }}
+        onClick={handleCopy}
+        aria-label={`Copy hex value ${displayHex} for ${name}`}
+      >
+        <span
+          className="mg-color-swatch__hex"
+          style={{ color: textColor }}
+        >
+          {copyState === 'copied'
+            ? 'Copied!'
+            : copyState === 'failed'
+              ? 'Copy failed'
+              : displayHex}
+        </span>
+      </button>
+
+      <div className="mg-color-swatch__info">
+        <span className="mg-color-swatch__name">{name}</span>
+        {usage && <span className="mg-color-swatch__usage">{usage}</span>}
+      </div>
+    </div>
+  );
+}
+
+ColorSwatch.propTypes = {
+  /** CSS class to apply to the hidden probe element for color extraction. */
+  probe: PropTypes.string,
+  /** CSS property to read from the probe element. */
+  property: PropTypes.string,
+  /** Explicit hex color override (skips probing). */
+  color: PropTypes.string,
+  /** Human-readable color name. */
+  name: PropTypes.string.isRequired,
+  /** Plain-language usage description. */
+  usage: PropTypes.string,
+};

--- a/stories/Documentation/Brand/components/ColorSwatch.jsx
+++ b/stories/Documentation/Brand/components/ColorSwatch.jsx
@@ -40,10 +40,7 @@ function rgbToHex(rgb) {
   const r = parseInt(match[1], 10);
   const g = parseInt(match[2], 10);
   const b = parseInt(match[3], 10);
-  return (
-    '#' +
-    [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('')
-  );
+  return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
 }
 
 /**
@@ -136,10 +133,7 @@ export function ColorSwatch({
             : `${name} color unavailable`
         }
       >
-        <span
-          className="mg-color-swatch__hex"
-          style={{ color: textColor }}
-        >
+        <span className="mg-color-swatch__hex" style={{ color: textColor }}>
           {copyState === 'copied'
             ? 'Copied!'
             : copyState === 'failed'

--- a/stories/Documentation/Brand/components/ColorSwatch.jsx
+++ b/stories/Documentation/Brand/components/ColorSwatch.jsx
@@ -12,7 +12,7 @@ import './color-swatch.css';
 
 /**
  * Returns white or dark text depending on background luminance.
- * Uses the W3C relative luminance formula.
+ * Uses the ITU-R BT.601 perceived brightness formula.
  *
  * @param {string} hex - Hex color string (e.g., '#004f91')
  * @returns {'#fff'|'#1a1a1a'} Contrasting text color
@@ -69,32 +69,38 @@ export function ColorSwatch({
   usage,
 }) {
   const probeRef = useRef(null);
-  const [hex, setHex] = useState(explicitColor || null);
+  const copyTimerRef = useRef(null);
+  const [probedHex, setProbedHex] = useState(null);
   const [copyState, setCopyState] = useState('idle'); // 'idle' | 'copied' | 'failed'
 
+  // Probe CSS value for non-explicit colors
   useEffect(() => {
-    if (explicitColor) {
-      setHex(explicitColor);
-      return;
-    }
-    if (!probeRef.current) return;
+    if (explicitColor || !probeRef.current) return;
     const computed = window.getComputedStyle(probeRef.current);
     const raw = computed.getPropertyValue(property);
     const resolved = rgbToHex(raw);
     if (resolved && resolved !== '#000000') {
-      setHex(resolved);
+      setProbedHex(resolved);
     }
   }, [probe, property, explicitColor]);
 
+  // Use explicit color directly (not stored in state) so prop changes take effect
+  const hex = explicitColor || probedHex;
+
+  useEffect(() => {
+    return () => clearTimeout(copyTimerRef.current);
+  }, []);
+
   const handleCopy = useCallback(async () => {
     if (!hex) return;
+    clearTimeout(copyTimerRef.current);
     try {
       await navigator.clipboard.writeText(hex);
       setCopyState('copied');
-      setTimeout(() => setCopyState('idle'), 1500);
+      copyTimerRef.current = setTimeout(() => setCopyState('idle'), 1500);
     } catch {
       setCopyState('failed');
-      setTimeout(() => setCopyState('idle'), 2000);
+      copyTimerRef.current = setTimeout(() => setCopyState('idle'), 2000);
     }
   }, [hex]);
 

--- a/stories/Documentation/Brand/components/ColorSwatch.jsx
+++ b/stories/Documentation/Brand/components/ColorSwatch.jsx
@@ -129,7 +129,12 @@ export function ColorSwatch({
         className="mg-color-swatch__block"
         style={{ backgroundColor: displayHex }}
         onClick={handleCopy}
-        aria-label={`Copy hex value ${displayHex} for ${name}`}
+        disabled={!hex}
+        aria-label={
+          hex
+            ? `Copy hex value ${displayHex} for ${name}`
+            : `${name} color unavailable`
+        }
       >
         <span
           className="mg-color-swatch__hex"

--- a/stories/Documentation/Brand/components/ColorSwatch.jsx
+++ b/stories/Documentation/Brand/components/ColorSwatch.jsx
@@ -22,7 +22,6 @@ function contrastingText(hex) {
   const r = parseInt(c.substring(0, 2), 16);
   const g = parseInt(c.substring(2, 4), 16);
   const b = parseInt(c.substring(4, 6), 16);
-  // Relative luminance (sRGB)
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
   return luminance > 0.5 ? '#1a1a1a' : '#fff';
 }

--- a/stories/Documentation/Brand/components/TypographySample.jsx
+++ b/stories/Documentation/Brand/components/TypographySample.jsx
@@ -26,7 +26,8 @@ const WEIGHT_NAMES = {
 
 function weightName(weight) {
   if (weight == null) return '';
-  const key = typeof weight === 'number' ? weight : String(weight).toLowerCase();
+  const key =
+    typeof weight === 'number' ? weight : String(weight).toLowerCase();
   return WEIGHT_NAMES[key] || String(weight);
 }
 
@@ -85,7 +86,8 @@ TypographySample.propTypes = {
   /** CSS font-size value. */
   fontSize: PropTypes.string.isRequired,
   /** Font weight (number or string). */
-  fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
   /** Display label for this typography level. */
   label: PropTypes.string.isRequired,
   /** Custom sample text (defaults to label). */

--- a/stories/Documentation/Brand/components/TypographySample.jsx
+++ b/stories/Documentation/Brand/components/TypographySample.jsx
@@ -10,6 +10,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import './typography-sample.css';
 
+const WEIGHT_NAMES = {
+  100: 'Thin',
+  200: 'ExtraLight',
+  300: 'Light',
+  400: 'Regular',
+  500: 'Medium',
+  600: 'SemiBold',
+  700: 'Bold',
+  800: 'ExtraBold',
+  900: 'Black',
+  normal: 'Regular',
+  bold: 'Bold',
+};
+
+function weightName(weight) {
+  if (weight == null) return '';
+  const key = typeof weight === 'number' ? weight : String(weight).toLowerCase();
+  return WEIGHT_NAMES[key] || String(weight);
+}
+
 /**
  * Typography sample with visual rendering and font metadata.
  *
@@ -49,7 +69,7 @@ export function TypographySample({
       </div>
       <div className="mg-typography-sample__meta">
         <span className="mg-typography-sample__font-name">
-          {fontFamily} {typeof fontWeight === 'number' && fontWeight >= 600 ? 'Bold' : 'Regular'}
+          {fontFamily} {weightName(fontWeight)}
         </span>
         <span className="mg-typography-sample__font-spec">
           {fontSize} / {fontWeight}

--- a/stories/Documentation/Brand/components/TypographySample.jsx
+++ b/stories/Documentation/Brand/components/TypographySample.jsx
@@ -1,0 +1,77 @@
+/**
+ * @file TypographySample.jsx
+ * @description Renders a text sample at a specified font, size, and weight
+ * with metadata annotations. Used in brand pages to show the typography hierarchy.
+ *
+ * @module TypographySample
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import './typography-sample.css';
+
+/**
+ * Typography sample with visual rendering and font metadata.
+ *
+ * @param {Object} props
+ * @param {string} props.fontFamily      Font family name (e.g., 'Roboto Condensed')
+ * @param {string} props.fontSize        CSS font-size (e.g., '42px', '2.625rem')
+ * @param {string|number} props.fontWeight Font weight (e.g., 700, 'bold')
+ * @param {string} props.label           Display label (e.g., 'Page title')
+ * @param {string} [props.sampleText]    Custom sample text (defaults to label)
+ * @param {React.ReactNode} [props.children] Mangrove component to render (overrides sampleText)
+ * @param {string} [props.lineHeight='1.2'] CSS line-height
+ */
+export function TypographySample({
+  fontFamily,
+  fontSize,
+  fontWeight,
+  label,
+  sampleText,
+  children,
+  lineHeight = '1.2',
+}) {
+  return (
+    <div className="mg-typography-sample">
+      <div className="mg-typography-sample__rendered">
+        {children || (
+          <span
+            style={{
+              fontFamily: `'${fontFamily}', sans-serif`,
+              fontSize,
+              fontWeight,
+              lineHeight,
+            }}
+          >
+            {sampleText || label}
+          </span>
+        )}
+      </div>
+      <div className="mg-typography-sample__meta">
+        <span className="mg-typography-sample__font-name">
+          {fontFamily} {typeof fontWeight === 'number' && fontWeight >= 600 ? 'Bold' : 'Regular'}
+        </span>
+        <span className="mg-typography-sample__font-spec">
+          {fontSize} / {fontWeight}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+TypographySample.propTypes = {
+  /** Font family name. */
+  fontFamily: PropTypes.string.isRequired,
+  /** CSS font-size value. */
+  fontSize: PropTypes.string.isRequired,
+  /** Font weight (number or string). */
+  fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  /** Display label for this typography level. */
+  label: PropTypes.string.isRequired,
+  /** Custom sample text (defaults to label). */
+  sampleText: PropTypes.string,
+  /** Mangrove component to render instead of styled text. */
+  children: PropTypes.node,
+  /** CSS line-height value. */
+  lineHeight: PropTypes.string,
+};

--- a/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
@@ -4,6 +4,16 @@ import { axe } from 'jest-axe';
 import { ColorSwatch } from '../ColorSwatch';
 
 describe('ColorSwatch', () => {
+  const originalClipboard = navigator.clipboard;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
+  });
+
   // --------------------------------------------------
   // Rendering with explicit color
   // --------------------------------------------------

--- a/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
@@ -27,10 +27,12 @@ describe('ColorSwatch', () => {
   });
 
   it('renders without a usage description', () => {
-    render(<ColorSwatch color="#004f91" name="Primary blue" />);
+    const { container } = render(
+      <ColorSwatch color="#004f91" name="Primary blue" />,
+    );
 
     expect(screen.getByText('Primary blue')).toBeInTheDocument();
-    expect(screen.queryByClassName?.('mg-color-swatch__usage')).toBeFalsy();
+    expect(container.querySelector('.mg-color-swatch__usage')).toBeNull();
   });
 
   // --------------------------------------------------
@@ -92,8 +94,12 @@ describe('ColorSwatch', () => {
   it('falls back to #000000 when probe resolves nothing', () => {
     render(<ColorSwatch probe="mg-nonexistent-class" name="Unknown" />);
 
-    // Should still render without crashing
     expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByText('#000000')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Copy hex value #000000 for Unknown',
+    );
   });
 
   // --------------------------------------------------

--- a/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { ColorSwatch } from '../ColorSwatch';
+
+describe('ColorSwatch', () => {
+  // --------------------------------------------------
+  // Rendering with explicit color
+  // --------------------------------------------------
+
+  it('renders the swatch with an explicit color', () => {
+    render(<ColorSwatch color="#004f91" name="Primary blue" usage="Headers and navigation" />);
+
+    expect(screen.getByText('Primary blue')).toBeInTheDocument();
+    expect(screen.getByText('Headers and navigation')).toBeInTheDocument();
+    expect(screen.getByText('#004f91')).toBeInTheDocument();
+  });
+
+  it('renders without a usage description', () => {
+    render(<ColorSwatch color="#004f91" name="Primary blue" />);
+
+    expect(screen.getByText('Primary blue')).toBeInTheDocument();
+    expect(screen.queryByClassName?.('mg-color-swatch__usage')).toBeFalsy();
+  });
+
+  // --------------------------------------------------
+  // Contrast detection
+  // --------------------------------------------------
+
+  it('uses white text on dark backgrounds', () => {
+    render(<ColorSwatch color="#004f91" name="Dark blue" />);
+
+    const hex = screen.getByText('#004f91');
+    expect(hex).toHaveStyle({ color: '#fff' });
+  });
+
+  it('uses dark text on light backgrounds', () => {
+    render(<ColorSwatch color="#fbc412" name="Yellow" />);
+
+    const hex = screen.getByText('#fbc412');
+    expect(hex).toHaveStyle({ color: '#1a1a1a' });
+  });
+
+  // --------------------------------------------------
+  // Copy to clipboard
+  // --------------------------------------------------
+
+  it('copies hex value on click and shows feedback', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<ColorSwatch color="#004f91" name="Primary blue" />);
+
+    const button = screen.getByRole('button');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(writeText).toHaveBeenCalledWith('#004f91');
+    expect(screen.getByText('Copied!')).toBeInTheDocument();
+  });
+
+  it('shows error feedback when clipboard fails', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('denied')) },
+    });
+
+    render(<ColorSwatch color="#004f91" name="Primary blue" />);
+
+    const button = screen.getByRole('button');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(screen.getByText('Copy failed')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------
+  // Probe fallback
+  // --------------------------------------------------
+
+  it('falls back to #000000 when probe resolves nothing', () => {
+    render(<ColorSwatch probe="mg-nonexistent-class" name="Unknown" />);
+
+    // Should still render without crashing
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------
+  // Accessibility
+  // --------------------------------------------------
+
+  it('has an accessible copy button with aria-label', () => {
+    render(<ColorSwatch color="#004f91" name="Primary blue" />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute(
+      'aria-label',
+      'Copy hex value #004f91 for Primary blue',
+    );
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <ColorSwatch color="#004f91" name="Primary blue" usage="Headers" />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
@@ -91,15 +91,15 @@ describe('ColorSwatch', () => {
   // Probe fallback
   // --------------------------------------------------
 
-  it('falls back to #000000 when probe resolves nothing', () => {
+  it('falls back to #000000 and disables copy when probe resolves nothing', () => {
     render(<ColorSwatch probe="mg-nonexistent-class" name="Unknown" />);
 
     expect(screen.getByText('Unknown')).toBeInTheDocument();
     expect(screen.getByText('#000000')).toBeInTheDocument();
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-label',
-      'Copy hex value #000000 for Unknown',
-    );
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-label', 'Unknown color unavailable');
   });
 
   // --------------------------------------------------

--- a/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/ColorSwatch.test.jsx
@@ -19,7 +19,13 @@ describe('ColorSwatch', () => {
   // --------------------------------------------------
 
   it('renders the swatch with an explicit color', () => {
-    render(<ColorSwatch color="#004f91" name="Primary blue" usage="Headers and navigation" />);
+    render(
+      <ColorSwatch
+        color="#004f91"
+        name="Primary blue"
+        usage="Headers and navigation"
+      />
+    );
 
     expect(screen.getByText('Primary blue')).toBeInTheDocument();
     expect(screen.getByText('Headers and navigation')).toBeInTheDocument();
@@ -28,7 +34,7 @@ describe('ColorSwatch', () => {
 
   it('renders without a usage description', () => {
     const { container } = render(
-      <ColorSwatch color="#004f91" name="Primary blue" />,
+      <ColorSwatch color="#004f91" name="Primary blue" />
     );
 
     expect(screen.getByText('Primary blue')).toBeInTheDocument();
@@ -74,7 +80,9 @@ describe('ColorSwatch', () => {
 
   it('shows error feedback when clipboard fails', async () => {
     Object.assign(navigator, {
-      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('denied')) },
+      clipboard: {
+        writeText: jest.fn().mockRejectedValue(new Error('denied')),
+      },
     });
 
     render(<ColorSwatch color="#004f91" name="Primary blue" />);
@@ -112,13 +120,13 @@ describe('ColorSwatch', () => {
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute(
       'aria-label',
-      'Copy hex value #004f91 for Primary blue',
+      'Copy hex value #004f91 for Primary blue'
     );
   });
 
   it('has no accessibility violations', async () => {
     const { container } = render(
-      <ColorSwatch color="#004f91" name="Primary blue" usage="Headers" />,
+      <ColorSwatch color="#004f91" name="Primary blue" usage="Headers" />
     );
 
     const results = await axe(container);

--- a/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
@@ -27,9 +27,7 @@ describe('TypographySample', () => {
   });
 
   it('uses custom sample text when provided', () => {
-    render(
-      <TypographySample {...defaultProps} sampleText="Custom sample" />,
-    );
+    render(<TypographySample {...defaultProps} sampleText="Custom sample" />);
 
     expect(screen.getByText('Custom sample')).toBeInTheDocument();
     expect(screen.queryByText('Page title')).not.toBeInTheDocument();
@@ -44,7 +42,7 @@ describe('TypographySample', () => {
 
   it('labels numeric weights with correct OpenType names', () => {
     const { rerender } = render(
-      <TypographySample {...defaultProps} fontWeight={400} />,
+      <TypographySample {...defaultProps} fontWeight={400} />
     );
     expect(screen.getByText('Roboto Condensed Regular')).toBeInTheDocument();
 
@@ -60,7 +58,7 @@ describe('TypographySample', () => {
 
   it('labels string weights (normal, bold)', () => {
     const { rerender } = render(
-      <TypographySample {...defaultProps} fontWeight="bold" />,
+      <TypographySample {...defaultProps} fontWeight="bold" />
     );
     expect(screen.getByText('Roboto Condensed Bold')).toBeInTheDocument();
 

--- a/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
@@ -42,11 +42,29 @@ describe('TypographySample', () => {
     expect(screen.getByText('42px / 700')).toBeInTheDocument();
   });
 
-  it('labels regular weight for values below 600', () => {
-    render(
+  it('labels numeric weights with correct OpenType names', () => {
+    const { rerender } = render(
       <TypographySample {...defaultProps} fontWeight={400} />,
     );
+    expect(screen.getByText('Roboto Condensed Regular')).toBeInTheDocument();
 
+    rerender(<TypographySample {...defaultProps} fontWeight={500} />);
+    expect(screen.getByText('Roboto Condensed Medium')).toBeInTheDocument();
+
+    rerender(<TypographySample {...defaultProps} fontWeight={600} />);
+    expect(screen.getByText('Roboto Condensed SemiBold')).toBeInTheDocument();
+
+    rerender(<TypographySample {...defaultProps} fontWeight={900} />);
+    expect(screen.getByText('Roboto Condensed Black')).toBeInTheDocument();
+  });
+
+  it('labels string weights (normal, bold)', () => {
+    const { rerender } = render(
+      <TypographySample {...defaultProps} fontWeight="bold" />,
+    );
+    expect(screen.getByText('Roboto Condensed Bold')).toBeInTheDocument();
+
+    rerender(<TypographySample {...defaultProps} fontWeight="normal" />);
     expect(screen.getByText('Roboto Condensed Regular')).toBeInTheDocument();
   });
 

--- a/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
+++ b/stories/Documentation/Brand/components/__tests__/TypographySample.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { TypographySample } from '../TypographySample';
+
+describe('TypographySample', () => {
+  const defaultProps = {
+    fontFamily: 'Roboto Condensed',
+    fontSize: '42px',
+    fontWeight: 700,
+    label: 'Page title',
+  };
+
+  // --------------------------------------------------
+  // Rendering
+  // --------------------------------------------------
+
+  it('renders the sample text at the specified style', () => {
+    render(<TypographySample {...defaultProps} />);
+
+    const rendered = screen.getByText('Page title');
+    expect(rendered).toHaveStyle({
+      fontFamily: "'Roboto Condensed', sans-serif",
+      fontSize: '42px',
+      fontWeight: 700,
+    });
+  });
+
+  it('uses custom sample text when provided', () => {
+    render(
+      <TypographySample {...defaultProps} sampleText="Custom sample" />,
+    );
+
+    expect(screen.getByText('Custom sample')).toBeInTheDocument();
+    expect(screen.queryByText('Page title')).not.toBeInTheDocument();
+  });
+
+  it('shows font metadata', () => {
+    render(<TypographySample {...defaultProps} />);
+
+    expect(screen.getByText('Roboto Condensed Bold')).toBeInTheDocument();
+    expect(screen.getByText('42px / 700')).toBeInTheDocument();
+  });
+
+  it('labels regular weight for values below 600', () => {
+    render(
+      <TypographySample {...defaultProps} fontWeight={400} />,
+    );
+
+    expect(screen.getByText('Roboto Condensed Regular')).toBeInTheDocument();
+  });
+
+  // --------------------------------------------------
+  // Accessibility
+  // --------------------------------------------------
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<TypographySample {...defaultProps} />);
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/stories/Documentation/Brand/components/color-swatch.css
+++ b/stories/Documentation/Brand/components/color-swatch.css
@@ -1,0 +1,59 @@
+.mg-color-swatch {
+  border: 1px solid #b3b3b3;
+  border-radius: 4px;
+  overflow: hidden;
+  transition: box-shadow 0.15s ease;
+}
+
+.mg-color-swatch:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.mg-color-swatch__block {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+  height: 80px;
+  padding: 4px 8px;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.mg-color-swatch__block:hover {
+  opacity: 0.9;
+}
+
+.mg-color-swatch__block:active {
+  opacity: 0.8;
+}
+
+.mg-color-swatch__block:focus-visible {
+  outline: 2px solid #004f91;
+  outline-offset: -2px;
+}
+
+.mg-color-swatch__hex {
+  font-family: monospace;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mg-color-swatch__info {
+  padding: 8px;
+  background: #fff;
+}
+
+.mg-color-swatch__name {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.mg-color-swatch__usage {
+  display: block;
+  font-size: 12px;
+  color: #666;
+  margin-top: 2px;
+}

--- a/stories/Documentation/Brand/components/typography-sample.css
+++ b/stories/Documentation/Brand/components/typography-sample.css
@@ -26,6 +26,6 @@
 .mg-typography-sample__font-spec {
   display: block;
   font-size: 11px;
-  color: #808080;
+  color: #666;
   font-family: monospace;
 }

--- a/stories/Documentation/Brand/components/typography-sample.css
+++ b/stories/Documentation/Brand/components/typography-sample.css
@@ -1,0 +1,31 @@
+.mg-typography-sample {
+  display: flex;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid #ccc;
+  gap: 16px;
+}
+
+.mg-typography-sample__rendered {
+  flex: 1;
+  color: #1a1a1a;
+}
+
+.mg-typography-sample__meta {
+  width: 200px;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.mg-typography-sample__font-name {
+  display: block;
+  font-size: 12px;
+  color: #666;
+}
+
+.mg-typography-sample__font-spec {
+  display: block;
+  font-size: 11px;
+  color: #808080;
+  font-family: monospace;
+}

--- a/stories/Documentation/Brand/data/themes.js
+++ b/stories/Documentation/Brand/data/themes.js
@@ -14,19 +14,56 @@ const CDN = 'https://assets.undrr.org/static/logos';
  */
 export const colorProbes = {
   brand: [
-    { probe: 'mg-hero__overlay', property: 'background-color', name: 'Hero / primary', usage: 'Hero banners, branded sections' },
-    { probe: 'mg-button mg-button-primary', property: 'background-color', name: 'Button primary', usage: 'Primary action buttons' },
-    { probe: 'mg-tag', property: 'background-color', name: 'Tag', usage: 'Content tags and labels' },
-    { probe: 'mg-tag mg-tag--secondary', property: 'background-color', name: 'Tag secondary', usage: 'Secondary tags' },
+    {
+      probe: 'mg-hero__overlay',
+      property: 'background-color',
+      name: 'Hero / primary',
+      usage: 'Hero banners, branded sections',
+    },
+    {
+      probe: 'mg-button mg-button-primary',
+      property: 'background-color',
+      name: 'Button primary',
+      usage: 'Primary action buttons',
+    },
+    {
+      probe: 'mg-tag',
+      property: 'background-color',
+      name: 'Tag',
+      usage: 'Content tags and labels',
+    },
+    {
+      probe: 'mg-tag mg-tag--secondary',
+      property: 'background-color',
+      name: 'Tag secondary',
+      usage: 'Secondary tags',
+    },
   ],
   accent: [
-    { probe: 'mg-tag mg-tag--accent', property: 'background-color', name: 'Accent', usage: 'Accent highlights and callouts' },
+    {
+      probe: 'mg-tag mg-tag--accent',
+      property: 'background-color',
+      name: 'Accent',
+      usage: 'Accent highlights and callouts',
+    },
   ],
   neutral: [
     { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-    { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-    { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-    { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+    {
+      color: '#666666',
+      name: 'Secondary text',
+      usage: 'Descriptions, metadata, captions',
+    },
+    {
+      color: '#f2f2f2',
+      name: 'Background light',
+      usage: 'Section backgrounds, cards',
+    },
+    {
+      color: '#ffffff',
+      name: 'White',
+      usage: 'Page background, card surfaces',
+    },
   ],
 };
 
@@ -43,7 +80,10 @@ export const themes = {
       variants: [
         { label: 'Blue (SVG)', url: `${CDN}/undrr/undrr-logo-blue.svg` },
         { label: 'White (SVG)', url: `${CDN}/undrr/undrr-logo-white.svg` },
-        { label: 'Square (SVG)', url: `${CDN}/undrr/undrr-logo-square-blue.svg` },
+        {
+          label: 'Square (SVG)',
+          url: `${CDN}/undrr/undrr-logo-square-blue.svg`,
+        },
       ],
     },
   },
@@ -56,9 +96,7 @@ export const themes = {
       src: `${CDN}/pw/pw-logo.svg`,
       // srcWhite: `${CDN}/pw/pw-logo-white.svg`,  // No dedicated white variant on CDN yet — dark-background preview hidden
       alt: 'PreventionWeb logo',
-      variants: [
-        { label: 'Logo (SVG)', url: `${CDN}/pw/pw-logo.svg` },
-      ],
+      variants: [{ label: 'Logo (SVG)', url: `${CDN}/pw/pw-logo.svg` }],
     },
   },
   'MCR2030 Theme': {
@@ -88,9 +126,7 @@ export const themes = {
       src: `${CDN}/irp/irp-logo.svg`,
       // srcWhite: `${CDN}/irp/irp-logo-white.svg`,  // No dedicated white variant on CDN yet — dark-background preview hidden
       alt: 'IRP logo',
-      variants: [
-        { label: 'Logo (SVG)', url: `${CDN}/irp/irp-logo.svg` },
-      ],
+      variants: [{ label: 'Logo (SVG)', url: `${CDN}/irp/irp-logo.svg` }],
     },
   },
   'DELTA Resilience Theme': {

--- a/stories/Documentation/Brand/data/themes.js
+++ b/stories/Documentation/Brand/data/themes.js
@@ -54,7 +54,7 @@ export const themes = {
     tagline: 'Knowledge platform for disaster risk reduction',
     logo: {
       src: `${CDN}/pw/pw-logo.svg`,
-      srcWhite: `${CDN}/pw/pw-logo.svg`,
+      // srcWhite: `${CDN}/pw/pw-logo-white.svg`,  // No dedicated white variant on CDN yet — dark-background preview hidden
       alt: 'PreventionWeb logo',
       variants: [
         { label: 'Logo (SVG)', url: `${CDN}/pw/pw-logo.svg` },
@@ -86,7 +86,7 @@ export const themes = {
     tagline: 'International Recovery Platform',
     logo: {
       src: `${CDN}/irp/irp-logo.svg`,
-      srcWhite: `${CDN}/irp/irp-logo.svg`,
+      // srcWhite: `${CDN}/irp/irp-logo-white.svg`,  // No dedicated white variant on CDN yet — dark-background preview hidden
       alt: 'IRP logo',
       variants: [
         { label: 'Logo (SVG)', url: `${CDN}/irp/irp-logo.svg` },

--- a/stories/Documentation/Brand/data/themes.js
+++ b/stories/Documentation/Brand/data/themes.js
@@ -1,0 +1,202 @@
+/**
+ * @file themes.js
+ * @description Theme color palettes for brand pages. Values sourced from
+ * _variables.scss and _variables-{theme}.scss.
+ *
+ * Update these when theme tokens change (brand refreshes).
+ */
+
+const CDN = 'https://assets.undrr.org/static/logos';
+
+export const themes = {
+  'Global UNDRR Theme': {
+    id: 'undrr',
+    name: 'UNDRR',
+    url: 'undrr.org',
+    tagline: 'Global hub for disaster risk reduction',
+    logo: {
+      src: `${CDN}/undrr/undrr-logo-blue.svg`,
+      srcWhite: `${CDN}/undrr/undrr-logo-white.svg`,
+      alt: 'UNDRR logo',
+      variants: [
+        { label: 'Blue (SVG)', url: `${CDN}/undrr/undrr-logo-blue.svg` },
+        { label: 'White (SVG)', url: `${CDN}/undrr/undrr-logo-white.svg` },
+        { label: 'Square (SVG)', url: `${CDN}/undrr/undrr-logo-square-blue.svg` },
+      ],
+    },
+    colors: {
+      brand: [
+        { color: '#004f91', name: 'Primary blue', usage: 'Headers, navigation, brand identity' },
+        { color: '#004f91', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
+        { color: '#3372a7', name: 'Interactive hover', usage: 'Hovered links and buttons' },
+        { color: '#004f91', name: 'Hero background', usage: 'Hero banners and branded sections' },
+      ],
+      accent: [
+        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis, Sendai markers' },
+        { color: '#eb752a', name: 'Orange', usage: 'Secondary accents, highlights' },
+        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights, warnings' },
+        { color: '#0a6969', name: 'Teal', usage: 'Secondary palette, accent blocks' },
+      ],
+      neutral: [
+        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+      ],
+    },
+  },
+  'PreventionWeb Theme': {
+    id: 'preventionweb',
+    name: 'PreventionWeb',
+    url: 'preventionweb.net',
+    tagline: 'Knowledge platform for disaster risk reduction',
+    logo: {
+      src: `${CDN}/pw/pw-logo.svg`,
+      srcWhite: `${CDN}/pw/pw-logo.svg`,
+      alt: 'PreventionWeb logo',
+      variants: [
+        { label: 'Logo (SVG)', url: `${CDN}/pw/pw-logo.svg` },
+      ],
+    },
+    colors: {
+      brand: [
+        { color: '#0a6969', name: 'Primary teal', usage: 'Headers, navigation, brand identity' },
+        { color: '#0a6969', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
+        { color: '#0a6969', name: 'Interactive hover', usage: 'Hovered links and buttons' },
+        { color: '#0a6969', name: 'Hero background', usage: 'Hero banners and branded sections' },
+      ],
+      accent: [
+        { color: '#eb752a', name: 'Orange', usage: 'Button hover, secondary actions' },
+        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
+        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
+        { color: '#004f91', name: 'Blue', usage: 'Accent blocks, secondary palette' },
+      ],
+      neutral: [
+        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+      ],
+    },
+  },
+  'MCR2030 Theme': {
+    id: 'mcr2030',
+    name: 'MCR2030',
+    url: 'mcr2030.undrr.org',
+    tagline: 'Making Cities Resilient 2030',
+    // To add the MCR2030 logo:
+    // 1. Upload the SVG to the CDN at: logos/mcr2030/mcr2030-logo.svg
+    // 2. Replace `null` below with:
+    //    {
+    //      src: `${CDN}/mcr2030/mcr2030-logo.svg`,
+    //      srcWhite: `${CDN}/mcr2030/mcr2030-logo-white.svg`,  // if a white variant exists
+    //      alt: 'MCR2030 logo',
+    //      variants: [
+    //        { label: 'Logo (SVG)', url: `${CDN}/mcr2030/mcr2030-logo.svg` },
+    //      ],
+    //    }
+    logo: null,
+    colors: {
+      brand: [
+        { color: '#591a61', name: 'Primary purple', usage: 'Headers, navigation, brand identity' },
+        { color: '#591a61', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
+        { color: '#591a61', name: 'Interactive hover', usage: 'Hovered links and buttons' },
+        { color: '#591a61', name: 'Hero background', usage: 'Hero banners and branded sections' },
+      ],
+      accent: [
+        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions, highlights' },
+        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
+        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
+        { color: '#004f91', name: 'Blue', usage: 'Accent blocks' },
+      ],
+      neutral: [
+        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+      ],
+    },
+  },
+  'IRP Theme': {
+    id: 'irp',
+    name: 'IRP',
+    url: 'recovery.preventionweb.net',
+    tagline: 'International Recovery Platform',
+    logo: {
+      src: `${CDN}/irp/irp-logo.svg`,
+      srcWhite: `${CDN}/irp/irp-logo.svg`,
+      alt: 'IRP logo',
+      variants: [
+        { label: 'Logo (SVG)', url: `${CDN}/irp/irp-logo.svg` },
+      ],
+    },
+    colors: {
+      brand: [
+        { color: '#0f78bf', name: 'Primary blue', usage: 'Headers, navigation, brand identity' },
+        { color: '#0f78bf', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
+        { color: '#0f78bf', name: 'Interactive hover', usage: 'Hovered links and buttons' },
+        { color: '#0f78bf', name: 'Hero background', usage: 'Hero banners and branded sections' },
+      ],
+      accent: [
+        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions, highlights' },
+        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
+        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
+        { color: '#0a6969', name: 'Teal', usage: 'Accent blocks' },
+      ],
+      neutral: [
+        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+      ],
+    },
+  },
+  'DELTA Resilience Theme': {
+    id: 'delta',
+    name: 'DELTA Resilience',
+    url: 'deltaresilience.org',
+    tagline: 'Data-driven resilience assessment',
+    logo: {
+      src: require('../../../assets/images/delta-logo-placeholder.svg'),
+      alt: 'DELTA Resilience logo (placeholder)',
+      variants: [],
+    },
+    colors: {
+      brand: [
+        { color: '#132e48', name: 'Primary navy', usage: 'Headers, navigation, brand identity' },
+        { color: '#132e48', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
+        { color: '#132e48', name: 'Interactive hover', usage: 'Hovered links and buttons' },
+        { color: '#132e48', name: 'Hero background', usage: 'Hero banners and branded sections' },
+      ],
+      accent: [
+        { color: '#2196f3', name: 'Bright blue', usage: 'Accents, highlights, data viz' },
+        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions' },
+        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
+        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
+      ],
+      neutral: [
+        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+      ],
+    },
+  },
+};
+
+/** Map legacy theme names to their standard counterpart */
+const legacyMap = {
+  'Global UNDRR Theme (legacy 10px)': 'Global UNDRR Theme',
+  'PreventionWeb Theme (legacy 10px)': 'PreventionWeb Theme',
+  'IRP Theme (legacy 10px)': 'IRP Theme',
+  'MCR2030 Theme (legacy 10px)': 'MCR2030 Theme',
+};
+
+/**
+ * Get theme data for the given theme name.
+ * Falls back to UNDRR if theme is unknown or legacy.
+ */
+export function getTheme(themeName) {
+  const resolved = legacyMap[themeName] || themeName;
+  return themes[resolved] || themes['Global UNDRR Theme'];
+}

--- a/stories/Documentation/Brand/data/themes.js
+++ b/stories/Documentation/Brand/data/themes.js
@@ -1,12 +1,34 @@
 /**
  * @file themes.js
- * @description Theme color palettes for brand pages. Values sourced from
- * _variables.scss and _variables-{theme}.scss.
- *
- * Update these when theme tokens change (brand refreshes).
+ * @description Theme metadata and logo URLs for brand pages.
+ * Color values are read live from the compiled CSS via getComputedStyle
+ * probes in ColorSwatch — no hardcoded hex values to maintain.
  */
 
 const CDN = 'https://assets.undrr.org/static/logos';
+
+/**
+ * CSS class → property mappings for probing theme colors from the DOM.
+ * Each entry becomes a ColorSwatch on the brand identity page.
+ * The resolved color comes from the active Storybook theme's compiled CSS.
+ */
+export const colorProbes = {
+  brand: [
+    { probe: 'mg-hero__overlay', property: 'background-color', name: 'Hero / primary', usage: 'Hero banners, branded sections' },
+    { probe: 'mg-button mg-button-primary', property: 'background-color', name: 'Button primary', usage: 'Primary action buttons' },
+    { probe: 'mg-tag', property: 'background-color', name: 'Tag', usage: 'Content tags and labels' },
+    { probe: 'mg-tag mg-tag--secondary', property: 'background-color', name: 'Tag secondary', usage: 'Secondary tags' },
+  ],
+  accent: [
+    { probe: 'mg-tag mg-tag--accent', property: 'background-color', name: 'Accent', usage: 'Accent highlights and callouts' },
+  ],
+  neutral: [
+    { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
+    { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
+    { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
+    { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
+  ],
+};
 
 export const themes = {
   'Global UNDRR Theme': {
@@ -24,26 +46,6 @@ export const themes = {
         { label: 'Square (SVG)', url: `${CDN}/undrr/undrr-logo-square-blue.svg` },
       ],
     },
-    colors: {
-      brand: [
-        { color: '#004f91', name: 'Primary blue', usage: 'Headers, navigation, brand identity' },
-        { color: '#004f91', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
-        { color: '#3372a7', name: 'Interactive hover', usage: 'Hovered links and buttons' },
-        { color: '#004f91', name: 'Hero background', usage: 'Hero banners and branded sections' },
-      ],
-      accent: [
-        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis, Sendai markers' },
-        { color: '#eb752a', name: 'Orange', usage: 'Secondary accents, highlights' },
-        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights, warnings' },
-        { color: '#0a6969', name: 'Teal', usage: 'Secondary palette, accent blocks' },
-      ],
-      neutral: [
-        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
-      ],
-    },
   },
   'PreventionWeb Theme': {
     id: 'preventionweb',
@@ -58,26 +60,6 @@ export const themes = {
         { label: 'Logo (SVG)', url: `${CDN}/pw/pw-logo.svg` },
       ],
     },
-    colors: {
-      brand: [
-        { color: '#0a6969', name: 'Primary teal', usage: 'Headers, navigation, brand identity' },
-        { color: '#0a6969', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
-        { color: '#0a6969', name: 'Interactive hover', usage: 'Hovered links and buttons' },
-        { color: '#0a6969', name: 'Hero background', usage: 'Hero banners and branded sections' },
-      ],
-      accent: [
-        { color: '#eb752a', name: 'Orange', usage: 'Button hover, secondary actions' },
-        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
-        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
-        { color: '#004f91', name: 'Blue', usage: 'Accent blocks, secondary palette' },
-      ],
-      neutral: [
-        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
-      ],
-    },
   },
   'MCR2030 Theme': {
     id: 'mcr2030',
@@ -89,33 +71,13 @@ export const themes = {
     // 2. Replace `null` below with:
     //    {
     //      src: `${CDN}/mcr2030/mcr2030-logo.svg`,
-    //      srcWhite: `${CDN}/mcr2030/mcr2030-logo-white.svg`,  // if a white variant exists
+    //      srcWhite: `${CDN}/mcr2030/mcr2030-logo-white.svg`,
     //      alt: 'MCR2030 logo',
     //      variants: [
     //        { label: 'Logo (SVG)', url: `${CDN}/mcr2030/mcr2030-logo.svg` },
     //      ],
     //    }
     logo: null,
-    colors: {
-      brand: [
-        { color: '#591a61', name: 'Primary purple', usage: 'Headers, navigation, brand identity' },
-        { color: '#591a61', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
-        { color: '#591a61', name: 'Interactive hover', usage: 'Hovered links and buttons' },
-        { color: '#591a61', name: 'Hero background', usage: 'Hero banners and branded sections' },
-      ],
-      accent: [
-        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions, highlights' },
-        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
-        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
-        { color: '#004f91', name: 'Blue', usage: 'Accent blocks' },
-      ],
-      neutral: [
-        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
-      ],
-    },
   },
   'IRP Theme': {
     id: 'irp',
@@ -130,26 +92,6 @@ export const themes = {
         { label: 'Logo (SVG)', url: `${CDN}/irp/irp-logo.svg` },
       ],
     },
-    colors: {
-      brand: [
-        { color: '#0f78bf', name: 'Primary blue', usage: 'Headers, navigation, brand identity' },
-        { color: '#0f78bf', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
-        { color: '#0f78bf', name: 'Interactive hover', usage: 'Hovered links and buttons' },
-        { color: '#0f78bf', name: 'Hero background', usage: 'Hero banners and branded sections' },
-      ],
-      accent: [
-        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions, highlights' },
-        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
-        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
-        { color: '#0a6969', name: 'Teal', usage: 'Accent blocks' },
-      ],
-      neutral: [
-        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
-      ],
-    },
   },
   'DELTA Resilience Theme': {
     id: 'delta',
@@ -160,26 +102,6 @@ export const themes = {
       src: require('../../../assets/images/delta-logo-placeholder.svg'),
       alt: 'DELTA Resilience logo (placeholder)',
       variants: [],
-    },
-    colors: {
-      brand: [
-        { color: '#132e48', name: 'Primary navy', usage: 'Headers, navigation, brand identity' },
-        { color: '#132e48', name: 'Interactive', usage: 'Links, buttons, clickable elements' },
-        { color: '#132e48', name: 'Interactive hover', usage: 'Hovered links and buttons' },
-        { color: '#132e48', name: 'Hero background', usage: 'Hero banners and branded sections' },
-      ],
-      accent: [
-        { color: '#2196f3', name: 'Bright blue', usage: 'Accents, highlights, data viz' },
-        { color: '#eb752a', name: 'Orange', usage: 'Secondary actions' },
-        { color: '#c10920', name: 'Red', usage: 'Alerts, emphasis' },
-        { color: '#f4e496', name: 'Yellow', usage: 'Tags, soft highlights' },
-      ],
-      neutral: [
-        { color: '#1a1a1a', name: 'Body text', usage: 'Primary text, headings' },
-        { color: '#666666', name: 'Secondary text', usage: 'Descriptions, metadata, captions' },
-        { color: '#f2f2f2', name: 'Background light', usage: 'Section backgrounds, cards' },
-        { color: '#ffffff', name: 'White', usage: 'Page background, card surfaces' },
-      ],
     },
   },
 };

--- a/stories/assets/scss/_foundational.scss
+++ b/stories/assets/scss/_foundational.scss
@@ -37,6 +37,14 @@ h6,
 caption {
   margin: $mg-spacing-100 $mg-spacing-0;
   padding: $mg-spacing-0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: $mg-font-family-headings;
 }
 

--- a/stories/assets/scss/_foundational.scss
+++ b/stories/assets/scss/_foundational.scss
@@ -37,10 +37,10 @@ h6,
 caption {
   margin: $mg-spacing-100 $mg-spacing-0;
   padding: $mg-spacing-0;
+  font-family: $mg-font-family-headings;
 }
 
 h1 {
-  font-family: $mg-font-family;
   font-size: $mg-font-size-600;
   letter-spacing: 0.02em;
   line-height: 1.08;

--- a/stories/assets/scss/_variables.scss
+++ b/stories/assets/scss/_variables.scss
@@ -254,6 +254,7 @@ $mg-font-line-height-700: 1.5em;
 
 $mg-font-family: "Roboto", sans-serif;
 $mg-font-family-condensed: "Roboto Condensed", sans-serif;
+$mg-font-family-headings: $mg-font-family-condensed !default;
 $mg-font-family-icons: "fontawesome";
 
 // Arabic fonts

--- a/stories/assets/scss/_variables.scss
+++ b/stories/assets/scss/_variables.scss
@@ -353,7 +353,10 @@ $mg-color-hero-title: $mg-color-neutral-0 !default;
 $mg-spacing-hero-overlay: 0 !default;
 $mg-hero-overlay-max-width: $mg-width-400 !default;
 $mg-hero-overlay-padding: $mg-spacing-200 !default;
-$mg-color-hero-button-secondary-background: rgba($mg-color-neutral-0, 0.9) !default;
+$mg-color-hero-button-secondary-background: rgba(
+  $mg-color-neutral-0,
+  0.9
+) !default;
 $mg-color-hero-button-secondary-color: $mg-color-hero !default;
 $mg-border-color-hero-button-secondary: $mg-color-neutral-0 !default;
 
@@ -399,21 +402,21 @@ $author-image-radius: 50%;
  */
 
 // Background utility — pseudo-element placed behind all sibling content
-$mg-z-index-behind: -1;      // ::before backgrounds (e.g. mg-container-full-width)
+$mg-z-index-behind: -1; // ::before backgrounds (e.g. mg-container-full-width)
 
 // Navigation zone — ⚠ FROZEN: Drupal themes depend on these exact values
-$mg-z-index-nav: 10;         // MegaMenu (mobile sidebar/overlay uses nav - 1 = 9)
-$mg-z-index-sticky: 11;      // Secondary sticky bars, e.g. OnThisPageNav
-$mg-z-index-nav-toggle: 14;  // Mobile nav hamburger toggle (above all nav layers)
-$mg-z-index-header: 22;      // PageHeader (above nav and sticky bar)
+$mg-z-index-nav: 10; // MegaMenu (mobile sidebar/overlay uses nav - 1 = 9)
+$mg-z-index-sticky: 11; // Secondary sticky bars, e.g. OnThisPageNav
+$mg-z-index-nav-toggle: 14; // Mobile nav hamburger toggle (above all nav layers)
+$mg-z-index-header: 22; // PageHeader (above nav and sticky bar)
 
 // Overlay zone — floats above page content
-$mg-z-index-drawer: 2000;    // Drawer / side panel (backdrop uses drawer - 1 = 1999)
-$mg-z-index-dropdown: 2500;  // Dropdowns and inline menus (above drawers)
+$mg-z-index-drawer: 2000; // Drawer / side panel (backdrop uses drawer - 1 = 1999)
+$mg-z-index-dropdown: 2500; // Dropdowns and inline menus (above drawers)
 
 // Modal zone — portaled to <body>, must clear all page chrome
-$mg-z-index-modal: 5000;     // Modal and dialog (backdrop uses modal - 1 = 4999)
-$mg-z-index-toast: 5500;     // Toast notifications (Snackbar), above modals
+$mg-z-index-modal: 5000; // Modal and dialog (backdrop uses modal - 1 = 4999)
+$mg-z-index-toast: 5500; // Toast notifications (Snackbar), above modals
 
 /**
   * @tokens-end


### PR DESCRIPTION
Closes #925.

## What this PR does

Adds a **Brand section** to Storybook aimed at non-technical UNDRR colleagues (content editors, brand managers, external partners). Replaces the outdated Google Sites and SharePoint web style guides with a single public URL per property that stays in sync with the component library.

After this ships, someone like Louise or Fanny can send a link to a partner and they'll see the right colors, fonts, logos, and component examples for their property, without needing to understand SCSS or React.

## Five new pages

| Page | What it is |
|---|---|
| **About this guide** | Welcome page. 5 clickable theme cards, one per UNDRR property, each linking to the Brand identity page pre-filtered to that theme. |
| **Brand identity** | Theme-aware page. Switch themes in the toolbar and the whole page updates (hero, colors, typography, logos, buttons, icons, usage guidelines). |
| **Brand guidelines** | Editorial content migrated from SharePoint: positioning, communication rules (inverted pyramid, avoid jargon), logo usage (safety zones, backgrounds), photography (sizes, credit rules), web elements. Source URLs preserved as comments. |
| **Common patterns** | Plain-language reference for shared foundations: breakpoints, grid classes, a11y, language support (`lang="ar"` mechanism), icon sources, z-index. Links out to Design decisions for token tables (no duplication). |
| **Component gallery** | Curated catalog of ~40 Mangrove components organized into 8 categories with links to full docs. |

## Key technical decisions

- **Colors probed live from compiled CSS** (`getComputedStyle`) instead of hardcoded hex. Zero duplicated hex values, zero sync drift when tokens change. Required a deliberate re-render after the theme decorator's useEffect loads CSS — see `BrandIdentity.stories.jsx`.
- **One dynamic page replaces five per-theme pages.** Initial design doc called for 5 separate pages. Collapsing to 1 page + theme picker cut 80% of the page count with no loss of information.
- **Helper components follow Mangrove conventions** (`mg-` BEM prefix, PropTypes, JSDoc, tests with jest-axe) so they can be promoted to the library later without a rewrite.
- **Dog-foods Mangrove wherever possible.** Typography section uses real `<Heading>`, `<P>`, `<Small>`. Buttons section uses `<CtaButton>`. Icons uses `<Icon>`. Usage guidelines use `<HighlightBox>`. VerticalCard on the About page.

## Heading font fix (affects every site)

Added `$mg-font-family-headings` token defaulting to Roboto Condensed, applied to h1–h6 globally. Previously headings rendered in Roboto Regular despite the design spec calling for Condensed. **This was a dog-fooding find while building the brand page** — the typography section showed wrong font-family labels because the actual rendered headings didn't match the design tokens.

Every UNDRR site will see slightly more compact, more authoritative headings after this ships. Documented in the new [RELEASE-1.5.md 1.5.1 addendum](https://github.com/unisdr/undrr-mangrove/blob/feat/brand-guide/docs/RELEASE-1.5.md#151-addendum) with a note for site managers.

## Follow-ups

- **#926** — HighlightBox `primary`/`secondary` variants don't apply text color correctly in docs mode (found while dog-fooding). Worked around with inline styles; clean fix is a ~5-line component change.
- **MCR2030 logo not on CDN yet.** Logo section hidden for MCR until a white-on-transparent variant is uploaded. Revival instructions in `themes.js` comment.
- **Editorial review** by Content and Channels team (post-merge activity, not a blocker).

## Future considerations (surface-area gut check)

Honest self-critique before it ships, so we have it on record:

- **Common patterns page leans developer-oriented.** Breakpoints, grid classes, `lang="ar"` selectors. The stated Brand audience is non-technical editors and partners. May belong under Design decisions instead. Re-evaluate once we have usage signal. Noted in an MDX comment at the top of the file.
- **Component gallery has a link-rot trap.** 37 `LinkTo` IDs must match Storybook story titles. 22 of 41 broke during initial build; fixed by validating against `index.json`. No automated check. Consider adding link validation to the `/document-release` flow. Noted in an MDX comment.
- **No downloadable asset bundle.** A partner wanting every logo has to click each CDN link. A zip would be more useful.
- **No per-theme vanity URL.** `?globals=theme:PreventionWeb Theme` is ugly to share. `/brand/preventionweb` would be much better but Storybook doesn't make this trivial.
- **No offline/PDF version.** External agencies without live-site access can't use this.

These are known gaps, not blockers. The core 3 pages (About, Brand identity, Brand guidelines) serve the stated workflow.

## Tests

All 696 Jest tests pass (15 new, covering ColorSwatch rendering, contrast detection, click-to-copy success + failure, probe fallback, disabled state, accessibility; TypographySample rendering, weight labels for all OpenType weights including string values, accessibility).

Coverage audit: 15/17 paths tested (88%). Story-only helpers skip unit tests by design (visual QA via Storybook).

## QA

Ran `/qa` across all 5 themes. **0 issues, 0 console errors, health score 100.** Screenshots captured locally in `.gstack/qa-reports/screenshots/`. Full report: `.gstack/qa-reports/qa-report-brand-guide-2026-04-12.md`.

Also ran:
- `/plan-eng-review` — architecture cleared
- `/plan-design-review` — UX cleared
- Adversarial subagent — 3 findings auto-fixed (caption font regression, weight label bug, null-hex clickable button)
- Pre-landing review — 4 findings auto-fixed (broken test assertion, missing test assertion, WCAG AA contrast, contradictory comment)

## AI manifest

`scripts/ai-manifest/generate-ai-manifest.js` now emits a Brand guide section in `llms.txt` with key facts (characteristics, communication rules, typography, property color palettes, photo sizes, logo rules, icon sources) so AI agents consuming Mangrove docs can discover the brand system.