### PR TITLE
fix: collapse multi-line LinkTo blocks in Brand pages

### DIFF
--- a/stories/Documentation/Brand/AboutThisGuide.mdx
+++ b/stories/Documentation/Brand/AboutThisGuide.mdx
@@ -20,26 +20,15 @@ Colors, fonts, and components used across UNDRR websites.
 
 ## Who this is for
 
-For content editors, designers, and partners who work with UNDRR web properties.
-This guide shows the visual identity of each property so you can stay on-brand
-without needing to read code or install anything. For developers, see
-
-<LinkTo kind="getting-started-getting-started-guide" story="docs">
-  Getting started
-</LinkTo>
-.
+{/* prettier-ignore */}
+For content editors, designers, and partners who work with UNDRR web properties. This guide shows the visual identity of each property so you can stay on-brand without needing to read code or install anything. For developers, see <LinkTo kind="getting-started-getting-started-guide" story="docs">Getting started</LinkTo>.
 
 ---
 
 ## Choose your property
 
-Each UNDRR web property has its own visual identity. Click a card to see that
-property's colors, fonts, and component styles on the
-
-<LinkTo kind="brand-brand-identity" story="docs">
-  Brand identity
-</LinkTo>
-page.
+{/* prettier-ignore */}
+Each UNDRR web property has its own visual identity. Click a card to see that property's colors, fonts, and component styles on the <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
 
 <div
   style={{

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -193,7 +193,7 @@ The page header displays the Sendai color stripe, UNDRR logo, and global navigat
 on every page. It includes the language selector, login icon, and links to core
 resources and tools.
 
-See: <LinkTo kind="components-pageheader" story="docs">Page header component</LinkTo> | <LinkTo kind="components-mega-menu" story="docs">Mega menu component</LinkTo>
+See: <LinkTo kind="components-pageheader" story="docs">Page header component</LinkTo>, <LinkTo kind="components-mega-menu" story="docs">Mega menu component</LinkTo>
 
 ### Footer
 

--- a/stories/Documentation/Brand/BrandGuidelines.mdx
+++ b/stories/Documentation/Brand/BrandGuidelines.mdx
@@ -22,13 +22,8 @@ import { HighlightBox } from '../../Components/HighlightBox/HighlightBox';
 
 # Brand guidelines
 
-Editorial and visual identity guidelines for all UNDRR communications. For
-theme-specific colors, typography, and component previews, see the
-
-<LinkTo kind="brand-brand-identity" story="docs">
-  Brand identity
-</LinkTo>
-page and use the theme picker in the toolbar.
+{/* prettier-ignore */}
+Editorial and visual identity guidelines for all UNDRR communications. For theme-specific colors, typography, and component previews, see the <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page and use the theme picker in the toolbar.
 
 ---
 
@@ -114,12 +109,8 @@ UNDRR's brand is defined by three core characteristics:
 
 {/* Source: https://unitednations.sharepoint.com/sites/UNDRR-DRR-COMMS/SitePages/Logos.aspx */}
 
-For logo files and downloads, switch to your property's theme on the
-
-<LinkTo kind="brand-brand-identity" story="docs">
-  Brand identity
-</LinkTo>
-page.
+{/* prettier-ignore */}
+For logo files and downloads, switch to your property's theme on the <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo> page.
 
 ### UNDRR logo rules
 

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -73,7 +73,7 @@ Every property uses the same two font families:
 - **Noto Kufi Arabic** + **Dubai** for Arabic content (automatic via `lang="ar"`)
 
 {/* prettier-ignore */}
-See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo> · <LinkTo kind="design-decisions-fonts" story="docs">Fonts</LinkTo>
+See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo>, <LinkTo kind="design-decisions-fonts" story="docs">Fonts</LinkTo>
 
 ---
 
@@ -84,7 +84,7 @@ backgrounds) are shared across all themes — only brand and accent colors chang
 per property.
 
 {/* prettier-ignore */}
-See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo> · <LinkTo kind="design-decisions-colors" story="docs">Colors</LinkTo>
+See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo>, <LinkTo kind="design-decisions-colors" story="docs">Colors</LinkTo>
 
 ---
 

--- a/stories/Documentation/Brand/CommonPatterns.mdx
+++ b/stories/Documentation/Brand/CommonPatterns.mdx
@@ -21,20 +21,11 @@ import LinkTo from '@storybook/addon-links/react';
 The structural foundations shared across every UNDRR web property. These don't
 change when you switch themes.
 
-For token tables (exact hex values, pixel sizes, etc.), see the
+{/* prettier-ignore */}
+For token tables (exact hex values, pixel sizes, etc.), see the <LinkTo kind="design-decisions-colors" story="docs">Design decisions</LinkTo> section. This page explains the concepts in plain language and points to where to find the details.
 
-<LinkTo kind="design-decisions-colors" story="docs">
-  Design decisions
-</LinkTo>
-section. This page explains the concepts in plain language and points to where
-to find the details.
-
-For theme-specific colors, typography, and components, see
-
-<LinkTo kind="brand-brand-identity" story="docs">
-  Brand identity
-</LinkTo>
-.
+{/* prettier-ignore */}
+For theme-specific colors, typography, and components, see <LinkTo kind="brand-brand-identity" story="docs">Brand identity</LinkTo>.
 
 ---
 
@@ -81,12 +72,8 @@ Every property uses the same two font families:
 - **Roboto** for body text — readable, widely supported
 - **Noto Kufi Arabic** + **Dubai** for Arabic content (automatic via `lang="ar"`)
 
-See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo>
-·
-
-<LinkTo kind="design-decisions-fonts" story="docs">
-  Fonts
-</LinkTo>
+{/* prettier-ignore */}
+See: <LinkTo kind="design-decisions-typography" story="docs">Typography</LinkTo> · <LinkTo kind="design-decisions-fonts" story="docs">Fonts</LinkTo>
 
 ---
 
@@ -96,12 +83,8 @@ Spacing uses a 5px baseline grid. Neutral colors (body text, secondary text,
 backgrounds) are shared across all themes — only brand and accent colors change
 per property.
 
-See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo>
-·
-
-<LinkTo kind="design-decisions-colors" story="docs">
-  Colors
-</LinkTo>
+{/* prettier-ignore */}
+See: <LinkTo kind="design-decisions-spacing" story="docs">Spacing</LinkTo> · <LinkTo kind="design-decisions-colors" story="docs">Colors</LinkTo>
 
 ---
 


### PR DESCRIPTION
Follow-up to #927.

## Problem

Several `<LinkTo>` elements in the Brand MDX pages were wrapped across multiple lines (by Prettier or authored that way). MDX's markdown parser treats multi-line JSX inside prose as block-level, which:

- Broke surrounding paragraphs into visible fragments with large gaps
- In the Common patterns "See: X · Y" sections, split the middle-dot separator and second link onto their own paragraphs (see [earlier screenshot shared during review])

## Fix

Collapsed each instance onto a single line and added `{/* prettier-ignore */}` directives so `yarn format` doesn't re-wrap them.

## Files

- `AboutThisGuide.mdx` — Who-this-is-for and Choose-your-property paragraphs
- `BrandGuidelines.mdx` — intro paragraph and Logo usage section
- `CommonPatterns.mdx` — intro paragraphs, Typography and Spacing See-links

## Test plan

- [x] `yarn lint:check` passes
- [ ] Verify rendering on http://localhost:6006 for:
  - Brand → About this guide (Who-this-is-for paragraph reads as one flow)
  - Brand → Brand guidelines (intro paragraph + Logo usage paragraph)
  - Brand → Common patterns (intro paragraphs + "See: Typography · Fonts" + "See: Spacing · Colors" render inline)