### PR TITLE
fix: Safari mobile third-level megamenu items invisible (#939)

### DIFF
--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -165,6 +165,7 @@ See the [hydration guide](https://github.com/unisdr/undrr-mangrove/blob/main/doc
 
 ## Changelog
 
+- **1.2.1** — 2026-04-14 ([https://github.com/unisdr/undrr-mangrove/issues/939](https://github.com/unisdr/undrr-mangrove/issues/939)): Scoped submenu CSS multicolumn layout to tablet+ viewports. Primarily a Safari mobile fix: third-level menu items rendered invisibly (space reserved, content unpainted) due to a long-standing interaction between multicolumn containers and descendant `opacity < 1`. Other browsers were unaffected.
 - **1.2** — 2026-04-13: `.mg-mega-topbar__item-link` migrated from raw `$mg-font-family-condensed` to the semantic `$mg-font-family-headings` alias. Same rendered font; future-proof if a theme overrides the heading token independently of the condensed token.
 - **1.1.1** — 2026-04-06 ([#916](https://github.com/unisdr/undrr-mangrove/pull/916)): Fixed mobile links non-clickable when using Mangrove nav CSS without the React component, or when JS hydration fails.
 - **1.1.0** — 2026-03-13 ([web-backlog#2630](https://gitlab.com/undrr/web-backlog/-/work_items/2630)): Optional `icon` property on sections for top-level menu item icons (desktop topbar only; decorative, `aria-hidden`). Added section object properties documentation.

--- a/stories/Components/MegaMenu/mega-menu.scss
+++ b/stories/Components/MegaMenu/mega-menu.scss
@@ -431,10 +431,19 @@
     flex: 1;
     padding: $mg-spacing-150;
     list-style: none;
-    column-count: auto;
-    column-width: 300px;
-    column-gap: $mg-spacing-200;
-    column-fill: balance;
+
+    // Multicolumn layout only on desktop. This is primarily a Safari fix:
+    // on mobile Safari, descendants with opacity < 1 inside a multicolumn
+    // container are not painted (space reserved, text invisible). Other
+    // browsers render fine either way, and at mobile widths the columns
+    // collapse to 1 anyway, so scoping to tablet+ loses nothing.
+    // See https://github.com/unisdr/undrr-mangrove/issues/939.
+    @media screen and (min-width: $mg-breakpoint-tablet) {
+      column-count: auto;
+      column-width: 300px;
+      column-gap: $mg-spacing-200;
+      column-fill: balance;
+    }
 
     // nested menus - RTL-friendly
     ul {


### PR DESCRIPTION
Closes [#939](https://github.com/unisdr/undrr-mangrove/issues/939).

## Summary

On mobile Safari, the third level of the MegaMenu rendered with layout space reserved but the items themselves were invisible. Other browsers were unaffected.

Root cause: `.mg-mega-content__right ul` applied CSS multicolumn layout (`column-width: 300px`, etc.) to *both* the mobile and desktop submenus. A nested `ul { opacity: 0.8 }` rule then hit a long-standing WebKit bug where descendants with `opacity < 1` inside a multicolumn container fail to paint. The reporter's clue — "manually disabling opacity makes the content appear" — matches exactly.

Fix: Scope the multicolumn properties to `min-width: $mg-breakpoint-tablet`. Columns are meaningless at mobile widths (320px → 1 column regardless), so mobile loses nothing and Safari no longer engages its multicolumn paint path for those lists.

## What's in

- `stories/Components/MegaMenu/mega-menu.scss` — moved `column-count` / `column-width` / `column-gap` / `column-fill` inside a tablet+ media query, with a comment explaining the Safari rationale.
- `stories/Components/MegaMenu/MegaMenu.mdx` — added `1.2.1` changelog entry.

## Out of scope

- No change to the `opacity: 0.8` styling on nested lists — that's intentional de-emphasis on desktop and now renders correctly on Safari mobile too.
- No JS changes.

## Hotfix for existing integrations

Sites consuming Mangrove CSS can apply this one-rule override in their own stylesheet until they pick up the next Mangrove release — no rebuild required:

~~~css
/* Safari iOS megamenu third-level visibility hotfix — undrr/undrr-mangrove#939 */
@media screen and (max-width: 768px) {
  .mg-mega-content__right ul {
    column-count: unset !important;
    column-width: auto !important;
  }
}
~~~

Why `unset` and not `1`: explicitly setting `column-count: 1` still declares a multicolumn formatting context, so WebKit keeps the buggy paint path active. `unset` reverts to the initial value (`auto`), letting Safari skip constructing a multicolumn context at all — the paint bug never fires. Confirmed working on Safari mobile.

Drop into any theme CSS loaded after `mangrove.css` (e.g. `undrr_common/css/mangrove/mangrove.css` or a site-specific override file). Remove once the site consumes a Mangrove release that includes this PR.

## Test plan

- [x] SCSS compiles cleanly (`yarn scss`).
- [x] `yarn lint` — no new errors introduced.
- [x] User manually confirmed the fix resolves the Safari mobile issue.
- [x] Hotfix CSS confirmed working on an integrated site.
- [ ] Spot-check MegaMenu Default story on desktop — confirm multicolumn layout still applies at tablet+.
- [ ] Spot-check on a non-Safari mobile browser — confirm no regression in third-level rendering.