### PR TITLE
feat(hero): add split layout variant

### DIFF
--- a/scripts/ai-manifest/component-data.js
+++ b/scripts/ai-manifest/component-data.js
@@ -435,7 +435,9 @@ export default {
   },
 
   'components-hero-hero-child': {
-    description: 'Smaller hero banner for child/section pages. Single CTA button, linked label.',
+    description: 'DEPRECATED — planned for removal by end of 2026. Never adopted in production across UNDRR sites; do not use in new work. Migrate to the main Hero component (`headingLevel="h2"`/`"h3"` or `layout="split"`), which covers the same use cases. Kept available for reference only. Smaller hero banner for child/section pages. Single CTA button, linked label.',
+    deprecated: true,
+    deprecationNotice: 'Planned for removal by end of 2026. Migrate to `components-hero-hero`.',
     cssClasses: [
       'mg-hero', 'mg-hero--child', 'mg-hero__overlay', 'mg-hero__content',
       'mg-hero__meta', 'mg-hero__label', 'mg-hero__title', 'mg-hero__summaryText', 'mg-hero__buttons',

--- a/scripts/ai-manifest/component-data.js
+++ b/scripts/ai-manifest/component-data.js
@@ -422,7 +422,16 @@ export default {
   'components-quotehighlight': { description: 'Testimonial or pull quote with attribution, portrait, and optional large image. Background: light, dark, bright. Variants: line separator or image. Alignment: full, left, right.' },
 
   // --- Hero ---
-  'components-hero-hero': { description: 'Full-width hero banner with background image, overlay, title, summary, and CTA buttons. Four color variants.' },
+  'components-hero-hero': {
+    description: 'Full-width hero banner with title, summary, and CTA buttons. Four color variants. Two layouts: `background` (full-bleed image with overlay, default) and `split` (solid theme-colour background with a content column plus a media image column). Split layout supports 2/3, 1/2, and 1/3 content-to-media ratios and a configurable heading level (h1–h3).',
+    cssClasses: [
+      'mg-hero', 'mg-hero--secondary', 'mg-hero--tertiary', 'mg-hero--quaternary',
+      'mg-hero--split', 'mg-hero--split-2-3', 'mg-hero--split-1-2', 'mg-hero--split-1-3',
+      'mg-hero__overlay', 'mg-hero__split-grid', 'mg-hero__content',
+      'mg-hero__meta', 'mg-hero__label', 'mg-hero__title', 'mg-hero__summaryText', 'mg-hero__buttons',
+      'mg-hero__media', 'mg-hero__media-img',
+    ],
+  },
 
   'components-hero-hero-child': {
     description: 'Smaller hero banner for child/section pages. Single CTA button, linked label.',

--- a/scripts/ai-manifest/component-data.js
+++ b/scripts/ai-manifest/component-data.js
@@ -423,13 +423,14 @@ export default {
 
   // --- Hero ---
   'components-hero-hero': {
-    description: 'Full-width hero banner with title, summary, and CTA buttons. Four color variants. Two layouts: `background` (full-bleed image with overlay, default) and `split` (solid theme-colour background with a content column plus a media image column). Split layout supports 2/3, 1/2, and 1/3 content-to-media ratios and a configurable heading level (h1–h3).',
+    description: 'Full-width hero banner with title, summary, and CTA buttons. Four color variants. Two layouts: `background` (full-bleed image with overlay, default) and `split` (solid theme-colour background with a content column plus a media column). Split layout supports 2/3, 1/2, and 1/3 content-to-media ratios, a configurable heading level (h1–h3), and three media types: `image` (default), `video` (iframe embed — provide the provider embed URL and a `title` for accessibility), or `html` (pre-sanitized HTML string for custom embeds; consumer must sanitize).',
     cssClasses: [
       'mg-hero', 'mg-hero--secondary', 'mg-hero--tertiary', 'mg-hero--quaternary',
       'mg-hero--split', 'mg-hero--split-2-3', 'mg-hero--split-1-2', 'mg-hero--split-1-3',
       'mg-hero__overlay', 'mg-hero__split-grid', 'mg-hero__content',
       'mg-hero__meta', 'mg-hero__label', 'mg-hero__title', 'mg-hero__summaryText', 'mg-hero__buttons',
-      'mg-hero__media', 'mg-hero__media-img',
+      'mg-hero__media', 'mg-hero__media--video', 'mg-hero__media--html',
+      'mg-hero__media-img', 'mg-hero__media-iframe',
     ],
   },
 

--- a/stories/Components/Hero/ChildHero.jsx
+++ b/stories/Components/Hero/ChildHero.jsx
@@ -14,6 +14,10 @@ export const variantOptions = {
 };
 
 /**
+ * @deprecated Planned for removal by end of 2026. Never adopted in production
+ * across UNDRR sites; the main Hero component covers the same use cases via
+ * `headingLevel="h2"`/`"h3"` and `layout="split"`. Do not adopt in new work.
+ *
  * Smaller hero banner for child/section pages with linked label, title, and single CTA button.
  * Renders one section per item in the data array (typically one).
  */

--- a/stories/Components/Hero/ChildHero.mdx
+++ b/stories/Components/Hero/ChildHero.mdx
@@ -77,6 +77,8 @@ export const getCaptionForLocale = locale => {
 
 <Meta of={ChildHeroStories} />
 
+> **⚠️ Deprecated — planned for removal by the end of 2026.** ChildHero was never adopted in production across UNDRR sites, and the main [Hero](?path=/docs/components-hero-hero--docs) component now covers the same use cases via `headingLevel="h2"` / `"h3"` and the `layout="split"` variant. Do not adopt ChildHero in new work; migrate existing usage to Hero. This documentation is retained for reference while the component is still available.
+
 > If you are creating or modifying this component, see [docs/REVIEW-CHECKLIST.md](../../../docs/REVIEW-CHECKLIST.md) for Mangrove's component standards.
 
 # Mangrove hero (sub)
@@ -113,5 +115,6 @@ There are two types of Mangrove Hero components: Mangrove Hero Parent and Mangro
 
 ## Changelog
 
+- **1.2** — 2026-04-15 ([#942](https://github.com/unisdr/undrr-mangrove/issues/942)): Marked as deprecated. Planned for removal by end of 2026. Migrate to the main Hero component (`headingLevel="h2"`/`"h3"` or `layout="split"`).
 - **1.1** — 2026-04-13: Inherits the `.mg-hero__title` heading-font and Arabic-override change from Hero (same SCSS file).
 - **1.0** — 2022-12-12: Released component

--- a/stories/Components/Hero/Hero.jsx
+++ b/stories/Components/Hero/Hero.jsx
@@ -12,13 +12,99 @@ export const variantOptions = {
   quaternary: 'quaternary',
 };
 
-/**
- * Full-width hero banner with background image, title, summary, and call-to-action buttons.
- * Renders one section per item in the data array (typically one).
- */
-export function Hero({ data, variant = 'primary' }) {
-  let variantActive = variantOptions[`${variant}`];
+const splitSuffixMap = {
+  '2/3': '2-3',
+  '1/2': '1-2',
+  '1/3': '1-3',
+};
 
+/**
+ * Full-width hero banner. Supports two layouts:
+ * - `background` (default): full-bleed background image with coloured overlay.
+ * - `split`: solid theme-colour background with a content column and a media column side by side.
+ */
+export function Hero({
+  data,
+  variant = 'primary',
+  layout = 'background',
+  headingLevel = 'h1',
+  split = '2/3',
+}) {
+  const variantActive = variantOptions[variant];
+  const HeadingTag = headingLevel;
+
+  const renderTitle = (item) => (
+    <header className="mg-hero__title">
+      <HeadingTag className="text-xxl">
+        {item.link ? (
+          <a href={item.link}>
+            <span dangerouslySetInnerHTML={{ __html: item.title }} />
+          </a>
+        ) : (
+          <span dangerouslySetInnerHTML={{ __html: item.title }} />
+        )}
+      </HeadingTag>
+    </header>
+  );
+
+  const renderContent = (item) => (
+    <article className="mg-hero__content">
+      <div className="mg-hero__meta">
+        {item.label && <span className="mg-hero__label">{item.label}</span>}
+      </div>
+      {renderTitle(item)}
+      <div className="mg-hero__summaryText">
+        <span dangerouslySetInnerHTML={{ __html: item.summaryText }} />
+      </div>
+      <div className="mg-hero__meta meta-detail">
+        {item.detail && (
+          <span className="mg-hero__label detail">{item.detail}</span>
+        )}
+      </div>
+      <div className="mg-hero__buttons">
+        {item.primary_button && (
+          <CtaButton Type="Primary" label={item.primary_button} />
+        )}
+        {item.secondary_button && (
+          <CtaButton Type="Secondary" label={item.secondary_button} />
+        )}
+      </div>
+    </article>
+  );
+
+  if (layout === 'split') {
+    const splitSuffix = splitSuffixMap[split] || '2-3';
+    return (
+      <>
+        {data.map((item, index) => (
+          <section
+            key={index}
+            className={cls(
+              'mg-hero',
+              'mg-hero--split',
+              `mg-hero--split-${splitSuffix}`,
+              variantActive && `mg-hero--${variantActive}`
+            )}
+          >
+            <div className="mg-hero__split-grid">
+              {renderContent(item)}
+              {item.media && (
+                <div className="mg-hero__media">
+                  <img
+                    src={item.media.src}
+                    alt={item.media.alt || ''}
+                    className="mg-hero__media-img"
+                  />
+                </div>
+              )}
+            </div>
+          </section>
+        ))}
+      </>
+    );
+  }
+
+  // layout === 'background' (default)
   return (
     <>
       {data.map((item, index) => (
@@ -28,40 +114,7 @@ export function Hero({ data, variant = 'primary' }) {
           style={{ backgroundImage: `url(${item.imgback})` }}
         >
           <div className="mg-hero__overlay">
-            <article className="mg-hero__content">
-              <div className="mg-hero__meta">
-                {item.label && (
-                  <span className="mg-hero__label">{item.label}</span>
-                )}
-              </div>
-              <header className="mg-hero__title">
-                {item.link ? (
-                  <a href={item.link} className="text-xxl">
-                    <span dangerouslySetInnerHTML={{ __html: item.title }} />
-                  </a>
-                ) : (
-                  <h1 className="text-xxl">
-                    <span dangerouslySetInnerHTML={{ __html: item.title }} />
-                  </h1>
-                )}
-              </header>
-              <div className="mg-hero__summaryText">
-                <span dangerouslySetInnerHTML={{ __html: item.summaryText }} />
-              </div>
-              <div className="mg-hero__meta meta-detail">
-                {item.detail && (
-                  <span className="mg-hero__label detail">{item.detail}</span>
-                )}
-              </div>
-              <div className="mg-hero__buttons">
-                {item.primary_button && (
-                  <CtaButton Type="Primary" label={item.primary_button} />
-                )}
-                {item.secondary_button && (
-                  <CtaButton Type="Secondary" label={item.secondary_button} />
-                )}
-              </div>
-            </article>
+            {renderContent(item)}
           </div>
         </section>
       ))}
@@ -81,8 +134,20 @@ Hero.propTypes = {
       detail: PropTypes.string,
       primary_button: PropTypes.string,
       secondary_button: PropTypes.string,
+      /** Media for split layout. Only `type: 'image'` is supported in v1. */
+      media: PropTypes.shape({
+        type: PropTypes.oneOf(['image']),
+        src: PropTypes.string,
+        alt: PropTypes.string,
+      }),
     })
   ).isRequired,
   /** Color variant: primary (default blue), secondary, tertiary, or quaternary. */
   variant: PropTypes.oneOf(['primary', 'secondary', 'tertiary', 'quaternary']),
+  /** Layout mode. `background` uses a full-bleed image; `split` uses a solid background with a media column. */
+  layout: PropTypes.oneOf(['background', 'split']),
+  /** Heading element level for the title. Defaults to `h1`; use `h2` or `h3` for mid-page placement. */
+  headingLevel: PropTypes.oneOf(['h1', 'h2', 'h3']),
+  /** Column split for `layout="split"`. Content column is always first. Defaults to `2/3`. */
+  split: PropTypes.oneOf(['2/3', '1/2', '1/3']),
 };

--- a/stories/Components/Hero/Hero.jsx
+++ b/stories/Components/Hero/Hero.jsx
@@ -47,6 +47,44 @@ export function Hero({
     </header>
   );
 
+  const renderMedia = (media) => {
+    if (!media) return null;
+    const type = media.type || 'image';
+
+    if (type === 'video') {
+      return (
+        <div className="mg-hero__media mg-hero__media--video">
+          <iframe
+            src={media.src}
+            title={media.title || 'Embedded video'}
+            className="mg-hero__media-iframe"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        </div>
+      );
+    }
+
+    if (type === 'html') {
+      return (
+        <div
+          className="mg-hero__media mg-hero__media--html"
+          dangerouslySetInnerHTML={{ __html: media.html || '' }}
+        />
+      );
+    }
+
+    return (
+      <div className="mg-hero__media">
+        <img
+          src={media.src}
+          alt={media.alt || ''}
+          className="mg-hero__media-img"
+        />
+      </div>
+    );
+  };
+
   const renderContent = (item) => (
     <article className="mg-hero__content">
       <div className="mg-hero__meta">
@@ -88,15 +126,7 @@ export function Hero({
           >
             <div className="mg-hero__split-grid">
               {renderContent(item)}
-              {item.media && (
-                <div className="mg-hero__media">
-                  <img
-                    src={item.media.src}
-                    alt={item.media.alt || ''}
-                    className="mg-hero__media-img"
-                  />
-                </div>
-              )}
+              {renderMedia(item.media)}
             </div>
           </section>
         ))}
@@ -134,11 +164,18 @@ Hero.propTypes = {
       detail: PropTypes.string,
       primary_button: PropTypes.string,
       secondary_button: PropTypes.string,
-      /** Media for split layout. Only `type: 'image'` is supported in v1. */
+      /**
+       * Media for split layout. Discriminated by `type`:
+       * - `image` (default): `src` (required), `alt` (optional; empty string for decorative).
+       * - `video`: `src` is an iframe-embeddable URL (e.g. `https://www.youtube.com/embed/…`), `title` is required for a11y.
+       * - `html`: `html` is a pre-sanitized HTML string rendered via `dangerouslySetInnerHTML`. The consumer (e.g. Drupal) must sanitize.
+       */
       media: PropTypes.shape({
-        type: PropTypes.oneOf(['image']),
+        type: PropTypes.oneOf(['image', 'video', 'html']),
         src: PropTypes.string,
         alt: PropTypes.string,
+        title: PropTypes.string,
+        html: PropTypes.string,
       }),
     })
   ).isRequired,

--- a/stories/Components/Hero/Hero.mdx
+++ b/stories/Components/Hero/Hero.mdx
@@ -30,7 +30,7 @@ The media column accepts three shapes, discriminated by `media.type`:
 |---|---|---|
 | `"image"` (default) | `src`, `alt` (empty string for decorative) | Rendered as a cover-fit `<img>`. |
 | `"video"` | `src` (iframe-embeddable URL), `title` | Rendered as a 16:9 `<iframe>`. Use the provider's embed URL (e.g. `https://www.youtube.com/embed/…`). `title` is required for screen reader users. |
-| `"html"` | `html` (pre-sanitized HTML string) | Rendered via `dangerouslySetInnerHTML`. The **consumer must sanitize** — Mangrove does not escape this string. Use for custom embeds, figures with attribution overlays, or any markup that doesn't fit image/video. A `<figure>` with an `<img>` and `<figcaption>` is styled by Mangrove as an attribution strip overlaid on the image. |
+| `"html"` | `html` (pre-sanitized HTML string) | Rendered via `dangerouslySetInnerHTML`. The **consumer must sanitize** — Mangrove does not escape this string. Use for custom embeds, figures with attribution overlays, or any markup that doesn't fit image/video. A `<figure>` dropped directly into the slot is styled by Mangrove as a full-bleed image with an attribution strip overlay. Wrap content in your own container (as in the example below) to add padding, decoration, or composition on top of the hero's coloured background. |
 
 Omitting `media.type` falls back to `image` for backwards compatibility with existing content.
 

--- a/stories/Components/Hero/Hero.mdx
+++ b/stories/Components/Hero/Hero.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 import { Hero } from './Hero';
 import * as HeroStories from './Hero.stories';
 
@@ -8,28 +8,50 @@ import * as HeroStories from './Hero.stories';
 
 # Mangrove hero (main)
 
-The Mangrove Hero components are page sections with images and overlay colors for primary, secondary, tertiary, and quaternary variants.
+The Hero component is a full-width page section with a title, summary text, and optional CTA buttons. It supports two layout modes and four colour variants.
 
 ## Overview
 
-The Mangrove Hero component defines a section with an image, some text, and optional CTA buttons. It is highly customizable and can be styled in four different variants: primary, secondary, tertiary, and quaternary.
+### Layouts
 
-### When to use:
+**`layout="background"` (default):** A full-bleed background image with a semi-transparent coloured overlay. Use at the top of campaign or homepage-style pages.
 
-Use this component when you want to display a prominent section with an image background, title, text, and optional action buttons.
+**`layout="split"`:** A solid theme-coloured background with a content column on the left and a media image on the right. Use for topic pages, section introductions, or any page where rich body copy and a representative image are equally important. The content column always comes first in the DOM (and visually in LTR/RTL both).
 
-## Example
+### Heading level
 
-This story shows the default Hero component with a link in the title.
+The `headingLevel` prop controls the HTML heading element used for the title (`h1`, `h2`, or `h3`; default `h1`). Set it to `h1` when the Hero is the page's primary heading, or `h2`/`h3` when it appears mid-page below another heading.
+
+### Column split (split layout only)
+
+The `split` prop controls the content/media column ratio, aligned to the MG 12-column grid:
+
+| `split` | Content | Media | Use case |
+|---|---|---|---|
+| `"2/3"` (default) | 8 cols | 4 cols | Text-heavy topic pages |
+| `"1/2"` | 6 cols | 6 cols | Balanced content and image |
+| `"1/3"` | 4 cols | 8 cols | Media-led, image dominates |
+
+### When to use
+
+- Use `layout="background"` for visually-led pages where the image is central to the brand moment.
+- Use `layout="split"` when you need dense body copy alongside a representative image (e.g., topic pages, campaign sections).
+
+## Example — background (default)
 
 <Canvas of={HeroStories.Default} meta={HeroStories} />
 
+## Example — split layout
+
+<Canvas of={HeroStories.SplitDefault} meta={HeroStories} />
+
 ## Interactions
 
-- Clicking on the title (if it has a link) or CTA buttons triggers the associated action (navigating to the link or executing a JavaScript function).
+- Clicking the title (if a `link` is provided) or CTA buttons navigates to the linked destination.
 
 ## Changelog
 
+- **1.5** — 2026-04-15 ([#942](https://github.com/unisdr/undrr-mangrove/issues/942)): Added `layout="split"` — solid-background two-column layout with `headingLevel` and `split` props. Title now always rendered inside a heading element (`headingLevel`, default `h1`); links are placed inside the heading rather than replacing it.
 - **1.4** — 2026-04-13: `.mg-hero__title` and `.mg-hero__label` now use `$mg-font-family-headings` (Roboto Condensed). Added a `:lang(ar)` block routing both to `$mg-font-family-arabic-headings`.
 - **1.3** — 2026-03-14 ([web-backlog#2630](https://gitlab.com/undrr/web-backlog/-/work_items/2630)): Hero title color is now a theme token (`$mg-color-hero-title`, default white). Overlay width increased from `$mg-width-400` (40rem) to `$mg-width-600` (60rem) and padding from `$mg-spacing-200` to `$mg-spacing-400` for better content readability across all themes.
 - **1.2** — 2024-09-20: Conditional rendering of headline (anchor tag when link is present, header tag otherwise); added HTML support in title and summaryText fields

--- a/stories/Components/Hero/Hero.mdx
+++ b/stories/Components/Hero/Hero.mdx
@@ -22,6 +22,18 @@ The Hero component is a full-width page section with a title, summary text, and 
 
 The `headingLevel` prop controls the HTML heading element used for the title (`h1`, `h2`, or `h3`; default `h1`). Set it to `h1` when the Hero is the page's primary heading, or `h2`/`h3` when it appears mid-page below another heading.
 
+### Media slot (split layout only)
+
+The media column accepts three shapes, discriminated by `media.type`:
+
+| `media.type` | Required fields | Notes |
+|---|---|---|
+| `"image"` (default) | `src`, `alt` (empty string for decorative) | Rendered as a cover-fit `<img>`. |
+| `"video"` | `src` (iframe-embeddable URL), `title` | Rendered as a 16:9 `<iframe>`. Use the provider's embed URL (e.g. `https://www.youtube.com/embed/…`). `title` is required for screen reader users. |
+| `"html"` | `html` (pre-sanitized HTML string) | Rendered via `dangerouslySetInnerHTML`. The **consumer must sanitize** — Mangrove does not escape this string. Use for custom embeds, stat callouts, or any markup that doesn't fit image/video. |
+
+Omitting `media.type` falls back to `image` for backwards compatibility with existing content.
+
 ### Column split (split layout only)
 
 The `split` prop controls the content/media column ratio, aligned to the MG 12-column grid:
@@ -45,13 +57,21 @@ The `split` prop controls the content/media column ratio, aligned to the MG 12-c
 
 <Canvas of={HeroStories.SplitDefault} meta={HeroStories} />
 
+## Example — split with video
+
+<Canvas of={HeroStories.SplitWithVideo} meta={HeroStories} />
+
+## Example — split with custom HTML
+
+<Canvas of={HeroStories.SplitWithHtml} meta={HeroStories} />
+
 ## Interactions
 
 - Clicking the title (if a `link` is provided) or CTA buttons navigates to the linked destination.
 
 ## Changelog
 
-- **1.5** — 2026-04-15 ([#942](https://github.com/unisdr/undrr-mangrove/issues/942)): Added `layout="split"` — solid-background two-column layout with `headingLevel` and `split` props. Title now always rendered inside a heading element (`headingLevel`, default `h1`); links are placed inside the heading rather than replacing it.
+- **1.5** — 2026-04-15 ([#942](https://github.com/unisdr/undrr-mangrove/issues/942)): Added `layout="split"` — solid-background two-column layout with `headingLevel` and `split` props. Title now always rendered inside a heading element (`headingLevel`, default `h1`); links are placed inside the heading rather than replacing it. Split layout media column accepts `type: 'image'` (default), `type: 'video'` (iframe embed), or `type: 'html'` (pre-sanitized HTML string).
 - **1.4** — 2026-04-13: `.mg-hero__title` and `.mg-hero__label` now use `$mg-font-family-headings` (Roboto Condensed). Added a `:lang(ar)` block routing both to `$mg-font-family-arabic-headings`.
 - **1.3** — 2026-03-14 ([web-backlog#2630](https://gitlab.com/undrr/web-backlog/-/work_items/2630)): Hero title color is now a theme token (`$mg-color-hero-title`, default white). Overlay width increased from `$mg-width-400` (40rem) to `$mg-width-600` (60rem) and padding from `$mg-spacing-200` to `$mg-spacing-400` for better content readability across all themes.
 - **1.2** — 2024-09-20: Conditional rendering of headline (anchor tag when link is present, header tag otherwise); added HTML support in title and summaryText fields

--- a/stories/Components/Hero/Hero.mdx
+++ b/stories/Components/Hero/Hero.mdx
@@ -30,7 +30,7 @@ The media column accepts three shapes, discriminated by `media.type`:
 |---|---|---|
 | `"image"` (default) | `src`, `alt` (empty string for decorative) | Rendered as a cover-fit `<img>`. |
 | `"video"` | `src` (iframe-embeddable URL), `title` | Rendered as a 16:9 `<iframe>`. Use the provider's embed URL (e.g. `https://www.youtube.com/embed/…`). `title` is required for screen reader users. |
-| `"html"` | `html` (pre-sanitized HTML string) | Rendered via `dangerouslySetInnerHTML`. The **consumer must sanitize** — Mangrove does not escape this string. Use for custom embeds, stat callouts, or any markup that doesn't fit image/video. |
+| `"html"` | `html` (pre-sanitized HTML string) | Rendered via `dangerouslySetInnerHTML`. The **consumer must sanitize** — Mangrove does not escape this string. Use for custom embeds, figures with attribution overlays, or any markup that doesn't fit image/video. A `<figure>` with an `<img>` and `<figcaption>` is styled by Mangrove as an attribution strip overlaid on the image. |
 
 Omitting `media.type` falls back to `image` for backwards compatibility with existing content.
 

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -183,7 +183,7 @@ const splitMediaData = [
 ];
 
 export const SplitDefault = {
-  name: 'Split, 2/3 content (default)',
+  name: 'Split (2/3 content, default)',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -194,7 +194,7 @@ export const SplitDefault = {
 };
 
 export const SplitBalanced = {
-  name: 'Split, 1/2 balanced',
+  name: 'Split (1/2 balanced)',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -205,7 +205,7 @@ export const SplitBalanced = {
 };
 
 export const SplitMediaLed = {
-  name: 'Split, 1/3 media-led',
+  name: 'Split (1/3 media-led)',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -216,7 +216,7 @@ export const SplitMediaLed = {
 };
 
 export const SplitWithVideo = {
-  name: 'Split, video embed',
+  name: 'Split (video embed)',
   args: {
     data: [
       {
@@ -240,7 +240,7 @@ export const SplitWithVideo = {
 };
 
 export const SplitWithHtml = {
-  name: 'Split, custom HTML slot',
+  name: 'Split (custom HTML slot)',
   args: {
     data: [
       {

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -183,7 +183,7 @@ const splitMediaData = [
 ];
 
 export const SplitDefault = {
-  name: 'Split — 2/3 content (default)',
+  name: 'Split, 2/3 content (default)',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -194,7 +194,7 @@ export const SplitDefault = {
 };
 
 export const SplitBalanced = {
-  name: 'Split — 1/2 balanced',
+  name: 'Split, 1/2 balanced',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -205,7 +205,7 @@ export const SplitBalanced = {
 };
 
 export const SplitMediaLed = {
-  name: 'Split — 1/3 media-led',
+  name: 'Split, 1/3 media-led',
   args: {
     data: splitMediaData,
     layout: 'split',
@@ -216,7 +216,7 @@ export const SplitMediaLed = {
 };
 
 export const SplitWithVideo = {
-  name: 'Split — video embed',
+  name: 'Split, video embed',
   args: {
     data: [
       {
@@ -240,7 +240,7 @@ export const SplitWithVideo = {
 };
 
 export const SplitWithHtml = {
-  name: 'Split — custom HTML slot',
+  name: 'Split, custom HTML slot',
   args: {
     data: [
       {
@@ -251,11 +251,17 @@ export const SplitWithHtml = {
         primary_button: 'Read the full report',
         media: {
           type: 'html',
-          html:
-            '<div style="background:#f2f4f7;color:#0b2545;padding:2rem;display:grid;place-items:center;text-align:center;font-family:Roboto,sans-serif;">' +
-            '<div><div style="font-size:3rem;font-weight:700;">$202B</div>' +
-            '<div style="font-size:1rem;">annual losses from disasters, 2020–2024</div></div>' +
-            '</div>',
+          html: `
+<section class="mg-stats-card mg-stats-card--highlighted" aria-label="Disaster losses">
+  <div class="mg-grid mg-grid__col-1">
+    <article class="mg-card mg-stats-card-item">
+      <span class="mg-stats-card-item__label">Annual average, 2020–2024</span>
+      <data class="mg-stats-card-item__value" value="202000000000">$202B</data>
+      <strong class="mg-stats-card-item__bottom-label">in disaster losses</strong>
+      <p class="mg-stats-card-item__summary">Source: UNDRR Global Assessment Report.</p>
+    </article>
+  </div>
+</section>`,
         },
       },
     ],

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -244,24 +244,21 @@ export const SplitWithHtml = {
   args: {
     data: [
       {
-        title: 'Disaster risk by the numbers',
+        title: 'Global Assessment Report 2026',
         summaryText:
-          '<p>Key indicators from the 2026 Global Assessment Report, visualised alongside the narrative.</p>',
-        label: 'Report',
-        primary_button: 'Read the full report',
+          "<p>UNDRR's flagship biennial review of global progress on disaster risk reduction.</p>",
+        label: 'Flagship report',
+        primary_button: 'Read the report',
         media: {
           type: 'html',
           html: `
-<section class="mg-stats-card mg-stats-card--highlighted" aria-label="Disaster losses">
-  <div class="mg-grid mg-grid__col-1">
-    <article class="mg-card mg-stats-card-item">
-      <span class="mg-stats-card-item__label">Annual average, 2020–2024</span>
-      <data class="mg-stats-card-item__value" value="202000000000">$202B</data>
-      <strong class="mg-stats-card-item__bottom-label">in disaster losses</strong>
-      <p class="mg-stats-card-item__summary">Source: UNDRR Global Assessment Report.</p>
-    </article>
-  </div>
-</section>`,
+<figure>
+  <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="Aerial view of a road through a green forest" />
+  <figcaption>
+    <strong>From the cover essay</strong>
+    <span>Photo: UNDRR</span>
+  </figcaption>
+</figure>`,
         },
       },
     ],

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -252,13 +252,16 @@ export const SplitWithHtml = {
         media: {
           type: 'html',
           html: `
-<figure>
-  <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="Aerial view of a road through a green forest" />
-  <figcaption>
-    <strong>From the cover essay</strong>
-    <span>Photo: UNDRR</span>
-  </figcaption>
-</figure>`,
+<div style="padding: 1.5rem; box-sizing: border-box; height: 100%; display: flex; flex-direction: column; gap: 0.75rem;">
+  <span style="align-self: flex-start; background: rgba(255, 255, 255, 0.18); color: #fff; font-size: 0.75rem; letter-spacing: 0.05em; text-transform: uppercase; padding: 0.25rem 0.75rem; border-radius: 999px;">Custom composition</span>
+  <figure style="margin: 0; flex: 1; position: relative; overflow: hidden; border-radius: 4px;">
+    <img src="https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg" alt="Aerial view of a road through a green forest" style="width: 100%; height: 100%; object-fit: cover; display: block;" />
+    <figcaption style="position: absolute; inset-inline: 0; inset-block-end: 0; background: rgba(0, 0, 0, 0.7); color: #fff; padding: 0.5rem 0.75rem; display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; font-size: 0.875rem;">
+      <strong>From the cover essay</strong>
+      <span>Photo: UNDRR</span>
+    </figcaption>
+  </figure>
+</div>`,
         },
       },
     ],

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -85,6 +85,27 @@ export default {
       description: 'Variant of the Hero component',
       defaultValue: 'primary',
     },
+    layout: {
+      options: ['background', 'split'],
+      control: { type: 'inline-radio' },
+      description:
+        'Layout mode: full-bleed background image, or solid background with media column.',
+      defaultValue: 'background',
+    },
+    headingLevel: {
+      options: ['h1', 'h2', 'h3'],
+      control: { type: 'inline-radio' },
+      description:
+        "Heading element for the title. Use h1 for the page's primary heading, h2/h3 for mid-page.",
+      defaultValue: 'h1',
+    },
+    split: {
+      options: ['2/3', '1/2', '1/3'],
+      control: { type: 'inline-radio' },
+      description:
+        'Column split for layout="split". Content column is always first.',
+      defaultValue: '2/3',
+    },
   },
 };
 
@@ -142,5 +163,54 @@ export const WithHtmlInTitle = {
   render: (args, { globals: { locale } }) => {
     const caption = getCaptionForLocale(locale);
     return <Hero data={caption.contentdata} {...args} />;
+  },
+};
+
+const splitMediaData = [
+  {
+    title: 'Comprehensive disaster and climate risk management',
+    summaryText:
+      '<p>CRM is a holistic approach to managing the risks associated with both climatic and non-climatic hazards across varied time scales and levels.</p><p>It seeks to build long-term resilience among countries and communities in vulnerable conditions.</p>',
+    label: 'Topic',
+    primary_button: 'Download a flyer on CRM',
+    secondary_button: 'Learn more',
+    media: {
+      type: 'image',
+      src: 'https://www.undrr.org/sites/default/files/2020-01/Home---about-us_0.jpg',
+      alt: 'Aerial view of a road through a green forest',
+    },
+  },
+];
+
+export const SplitDefault = {
+  name: 'Split — 2/3 content (default)',
+  args: {
+    data: splitMediaData,
+    layout: 'split',
+    variant: 'primary',
+    headingLevel: 'h1',
+    split: '2/3',
+  },
+};
+
+export const SplitBalanced = {
+  name: 'Split — 1/2 balanced',
+  args: {
+    data: splitMediaData,
+    layout: 'split',
+    variant: 'secondary',
+    headingLevel: 'h2',
+    split: '1/2',
+  },
+};
+
+export const SplitMediaLed = {
+  name: 'Split — 1/3 media-led',
+  args: {
+    data: splitMediaData,
+    layout: 'split',
+    variant: 'tertiary',
+    headingLevel: 'h2',
+    split: '1/3',
   },
 };

--- a/stories/Components/Hero/Hero.stories.jsx
+++ b/stories/Components/Hero/Hero.stories.jsx
@@ -214,3 +214,54 @@ export const SplitMediaLed = {
     split: '1/3',
   },
 };
+
+export const SplitWithVideo = {
+  name: 'Split — video embed',
+  args: {
+    data: [
+      {
+        title: 'Watch: early warning for all',
+        summaryText:
+          '<p>A short film on how multi-hazard early warning systems save lives in every region.</p>',
+        label: 'Video',
+        primary_button: 'More stories',
+        media: {
+          type: 'video',
+          src: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+          title: 'Early warning for all — UNDRR',
+        },
+      },
+    ],
+    layout: 'split',
+    variant: 'primary',
+    headingLevel: 'h2',
+    split: '1/2',
+  },
+};
+
+export const SplitWithHtml = {
+  name: 'Split — custom HTML slot',
+  args: {
+    data: [
+      {
+        title: 'Disaster risk by the numbers',
+        summaryText:
+          '<p>Key indicators from the 2026 Global Assessment Report, visualised alongside the narrative.</p>',
+        label: 'Report',
+        primary_button: 'Read the full report',
+        media: {
+          type: 'html',
+          html:
+            '<div style="background:#f2f4f7;color:#0b2545;padding:2rem;display:grid;place-items:center;text-align:center;font-family:Roboto,sans-serif;">' +
+            '<div><div style="font-size:3rem;font-weight:700;">$202B</div>' +
+            '<div style="font-size:1rem;">annual losses from disasters, 2020–2024</div></div>' +
+            '</div>',
+        },
+      },
+    ],
+    layout: 'split',
+    variant: 'quaternary',
+    headingLevel: 'h2',
+    split: '1/2',
+  },
+};

--- a/stories/Components/Hero/__tests__/Hero.test.jsx
+++ b/stories/Components/Hero/__tests__/Hero.test.jsx
@@ -162,6 +162,59 @@ describe('Hero — split layout', () => {
   });
 });
 
+describe('Hero — split layout media types', () => {
+  it('renders a video iframe with title when media.type="video"', () => {
+    const videoItem = {
+      ...baseItem,
+      media: {
+        type: 'video',
+        src: 'https://www.youtube.com/embed/abc123',
+        title: 'UNDRR video',
+      },
+    };
+    const { container } = render(<Hero data={[videoItem]} layout="split" />);
+    const iframe = container.querySelector('.mg-hero__media-iframe');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/abc123');
+    expect(iframe).toHaveAttribute('title', 'UNDRR video');
+    expect(container.querySelector('.mg-hero__media--video')).toBeInTheDocument();
+  });
+
+  it('falls back to a default iframe title when media.title is omitted', () => {
+    const videoItem = {
+      ...baseItem,
+      media: { type: 'video', src: 'https://www.youtube.com/embed/abc123' },
+    };
+    const { container } = render(<Hero data={[videoItem]} layout="split" />);
+    expect(container.querySelector('.mg-hero__media-iframe')).toHaveAttribute(
+      'title',
+      'Embedded video'
+    );
+  });
+
+  it('renders raw HTML when media.type="html"', () => {
+    const htmlItem = {
+      ...baseItem,
+      media: { type: 'html', html: '<p class="custom-embed">Custom widget</p>' },
+    };
+    const { container } = render(<Hero data={[htmlItem]} layout="split" />);
+    const slot = container.querySelector('.mg-hero__media--html');
+    expect(slot).toBeInTheDocument();
+    expect(slot.querySelector('.custom-embed')).toHaveTextContent('Custom widget');
+  });
+
+  it('renders an image when media.type is omitted (backwards compatible)', () => {
+    const legacyItem = {
+      ...baseItem,
+      media: { src: 'https://example.com/photo.jpg', alt: 'A test photo' },
+    };
+    render(<Hero data={[legacyItem]} layout="split" />);
+    expect(
+      screen.getByRole('img', { name: 'A test photo' })
+    ).toBeInTheDocument();
+  });
+});
+
 describe('Hero — accessibility', () => {
   it('has no axe violations in background layout', async () => {
     const { container } = render(<Hero data={[baseItem]} />);
@@ -171,6 +224,21 @@ describe('Hero — accessibility', () => {
   it('has no axe violations in split layout', async () => {
     const { container } = render(
       <Hero data={[splitItem]} layout="split" headingLevel="h2" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations with a video media slot', async () => {
+    const videoItem = {
+      ...baseItem,
+      media: {
+        type: 'video',
+        src: 'https://www.youtube.com/embed/abc123',
+        title: 'UNDRR video',
+      },
+    };
+    const { container } = render(
+      <Hero data={[videoItem]} layout="split" headingLevel="h2" />
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/stories/Components/Hero/__tests__/Hero.test.jsx
+++ b/stories/Components/Hero/__tests__/Hero.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { Hero } from '../Hero';
 
 const baseItem = {
@@ -158,5 +159,19 @@ describe('Hero — split layout', () => {
     render(<Hero data={[itemWithLink]} layout="split" headingLevel="h2" />);
     const heading = screen.getByRole('heading', { level: 2 });
     expect(heading.querySelector('a[href="/topic"]')).toBeInTheDocument();
+  });
+});
+
+describe('Hero — accessibility', () => {
+  it('has no axe violations in background layout', async () => {
+    const { container } = render(<Hero data={[baseItem]} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('has no axe violations in split layout', async () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" headingLevel="h2" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/stories/Components/Hero/__tests__/Hero.test.jsx
+++ b/stories/Components/Hero/__tests__/Hero.test.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Hero } from '../Hero';
+
+const baseItem = {
+  title: 'Test Hero Title',
+  summaryText: 'Test summary text.',
+  label: 'Test Label',
+  primary_button: 'Primary action',
+  imgback: 'https://example.com/image.jpg',
+};
+
+const splitItem = {
+  ...baseItem,
+  media: {
+    type: 'image',
+    src: 'https://example.com/photo.jpg',
+    alt: 'A test photo',
+  },
+};
+
+describe('Hero — background layout (default)', () => {
+  it('renders the section with mg-hero class', () => {
+    const { container } = render(<Hero data={[baseItem]} />);
+    expect(container.querySelector('.mg-hero')).toBeInTheDocument();
+  });
+
+  it('applies background image via inline style', () => {
+    const { container } = render(<Hero data={[baseItem]} />);
+    const section = container.querySelector('.mg-hero');
+    expect(section).toHaveStyle(
+      `background-image: url(${baseItem.imgback})`
+    );
+  });
+
+  it('renders a variant class', () => {
+    const { container } = render(<Hero data={[baseItem]} variant="secondary" />);
+    expect(container.querySelector('.mg-hero--secondary')).toBeInTheDocument();
+  });
+
+  it('renders title text', () => {
+    render(<Hero data={[baseItem]} />);
+    expect(screen.getByText('Test Hero Title')).toBeInTheDocument();
+  });
+
+  it('does not render mg-hero--split class', () => {
+    const { container } = render(<Hero data={[baseItem]} />);
+    expect(container.querySelector('.mg-hero--split')).not.toBeInTheDocument();
+  });
+});
+
+describe('Hero — headingLevel', () => {
+  it('renders h1 by default', () => {
+    render(<Hero data={[baseItem]} />);
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('renders h2 when headingLevel="h2"', () => {
+    render(<Hero data={[baseItem]} headingLevel="h2" />);
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+
+  it('renders h3 when headingLevel="h3"', () => {
+    render(<Hero data={[baseItem]} headingLevel="h3" />);
+    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+  });
+
+  it('wraps a link inside the heading element', () => {
+    const itemWithLink = { ...baseItem, link: '/some-page' };
+    render(<Hero data={[itemWithLink]} headingLevel="h2" />);
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.querySelector('a[href="/some-page"]')).toBeInTheDocument();
+  });
+});
+
+describe('Hero — split layout', () => {
+  it('renders mg-hero--split class', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" />
+    );
+    expect(container.querySelector('.mg-hero--split')).toBeInTheDocument();
+  });
+
+  it('does not apply background-image inline style', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" />
+    );
+    const section = container.querySelector('.mg-hero--split');
+    expect(section).not.toHaveStyle('background-image: url(https://example.com/image.jpg)');
+  });
+
+  it('renders __split-grid container', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" />
+    );
+    expect(container.querySelector('.mg-hero__split-grid')).toBeInTheDocument();
+  });
+
+  it('applies default split class mg-hero--split-2-3', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" />
+    );
+    expect(container.querySelector('.mg-hero--split-2-3')).toBeInTheDocument();
+  });
+
+  it('applies mg-hero--split-1-2 for split="1/2"', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" split="1/2" />
+    );
+    expect(container.querySelector('.mg-hero--split-1-2')).toBeInTheDocument();
+  });
+
+  it('applies mg-hero--split-1-3 for split="1/3"', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" split="1/3" />
+    );
+    expect(container.querySelector('.mg-hero--split-1-3')).toBeInTheDocument();
+  });
+
+  it('applies variant class alongside split', () => {
+    const { container } = render(
+      <Hero data={[splitItem]} layout="split" variant="secondary" />
+    );
+    expect(container.querySelector('.mg-hero--split.mg-hero--secondary')).toBeInTheDocument();
+  });
+
+  it('renders media image', () => {
+    render(<Hero data={[splitItem]} layout="split" />);
+    const img = screen.getByRole('img', { name: 'A test photo' });
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+  });
+
+  it('renders img with empty alt when alt is omitted', () => {
+    const itemNoAlt = {
+      ...baseItem,
+      media: { type: 'image', src: 'https://example.com/photo.jpg' },
+    };
+    const { container } = render(<Hero data={[itemNoAlt]} layout="split" />);
+    const img = container.querySelector('.mg-hero__media-img');
+    expect(img).toHaveAttribute('alt', '');
+  });
+
+  it('renders gracefully without media (no __media element)', () => {
+    const { container } = render(
+      <Hero data={[baseItem]} layout="split" />
+    );
+    expect(container.querySelector('.mg-hero__media')).not.toBeInTheDocument();
+  });
+
+  it('renders headingLevel inside split layout', () => {
+    render(<Hero data={[splitItem]} layout="split" headingLevel="h2" />);
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+  });
+
+  it('wraps link inside heading in split layout', () => {
+    const itemWithLink = { ...splitItem, link: '/topic' };
+    render(<Hero data={[itemWithLink]} layout="split" headingLevel="h2" />);
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading.querySelector('a[href="/topic"]')).toBeInTheDocument();
+  });
+});

--- a/stories/Components/Hero/hero.scss
+++ b/stories/Components/Hero/hero.scss
@@ -298,10 +298,31 @@ $variant-colours: (
     }
   }
 
+  // Video embeds force a 16:9 ratio so iframes never collapse.
+  .mg-hero__media--video {
+    aspect-ratio: 16 / 9;
+  }
+
+  // HTML slot: let consumer content define its own layout; ensure it fills the column.
+  .mg-hero__media--html {
+    display: flex;
+
+    > * {
+      width: 100%;
+    }
+  }
+
   .mg-hero__media-img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    display: block;
+  }
+
+  .mg-hero__media-iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
     display: block;
   }
 }

--- a/stories/Components/Hero/hero.scss
+++ b/stories/Components/Hero/hero.scss
@@ -206,8 +206,8 @@ $variant-colours: (
   }
 }
 
-// RTL tweaks
-[dir="rtl"] .mg-hero {
+// RTL tweaks (background layout only)
+[dir="rtl"] .mg-hero:not(.mg-hero--split) {
   margin-right: calc(50% - (50vw)); // to expand out of the parent container
   padding-right: $mg-spacing-100;
 
@@ -217,6 +217,115 @@ $variant-colours: (
 
   @media (min-width: $mg-breakpoint-desktop-wide) {
     padding-right: calc(50vw - calc($mg-breakpoint-desktop-wide / 2)); // to keep the overlay fixed
+  }
+}
+
+// Split layout variant
+.mg-hero--split {
+  background-image: none;
+  aspect-ratio: unset;
+
+  // Reset background-layout padding offsets
+  padding-left: 0;
+  background-color: $mg-color-hero;
+
+  // Button/CTA overrides (mirrors background layout, but scoped to split section
+  // since there is no __overlay to target)
+  a.mg-button,
+  a.mg-button:hover,
+  a.mg-button:visited {
+    color: $mg-color-hero;
+  }
+
+  a.mg-button-primary {
+    background-color: $mg-color-neutral-0;
+  }
+
+  a.mg-button-secondary,
+  a.mg-button-secondary:hover,
+  a.mg-button-secondary:visited {
+    background-color: $mg-color-hero-button-secondary-background;
+    color: $mg-color-hero-button-secondary-color;
+    border-color: $mg-border-color-hero-button-secondary;
+  }
+
+  a.mg-button:focus-visible {
+    box-shadow: 0 0 0 2px $mg-color-neutral-0;
+    outline: 2px solid $mg-color-neutral-0;
+    outline-offset: 2px;
+  }
+
+  .mg-hero__split-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr; // default 2/3
+    align-items: stretch;
+    max-width: $mg-breakpoint-desktop;
+    margin: 0 auto;
+
+    @media (max-width: $mg-breakpoint-tablet) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &.mg-hero--split-1-2 .mg-hero__split-grid {
+    grid-template-columns: 1fr 1fr;
+
+    @media (max-width: $mg-breakpoint-tablet) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &.mg-hero--split-1-3 .mg-hero__split-grid {
+    grid-template-columns: 1fr 2fr;
+
+    @media (max-width: $mg-breakpoint-tablet) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .mg-hero__content {
+    display: grid;
+    row-gap: mg-rem(10);
+    padding: $mg-spacing-200 $mg-spacing-100;
+    align-content: center;
+  }
+
+  .mg-hero__media {
+    overflow: hidden;
+
+    @media (max-width: $mg-breakpoint-tablet) {
+      aspect-ratio: 16 / 9;
+    }
+  }
+
+  .mg-hero__media-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+// Variant colours at full opacity for split (no rgba wrapper needed — no photo underneath)
+@each $name, $color in $variant-colours {
+  .mg-hero--split.mg-hero--#{$name} {
+    background-color: $color;
+
+    a.mg-button,
+    a.mg-button:hover,
+    a.mg-button:visited {
+      color: #{$color};
+    }
+  }
+}
+
+// RTL for split: reset outer offsets and reverse column order via grid direction
+[dir="rtl"] .mg-hero--split {
+  margin-right: 0;
+  padding-right: 0;
+
+  .mg-hero__split-grid {
+    direction: rtl; // reverses grid item order (content stays first semantically)
   }
 }
 

--- a/stories/Components/Hero/hero.scss
+++ b/stories/Components/Hero/hero.scss
@@ -310,6 +310,37 @@ $variant-colours: (
     > * {
       width: 100%;
     }
+
+    // First-class rendering for a <figure> + <figcaption> composition inside
+    // the slot (image with an attribution overlay). Consumers get this for free
+    // by dropping in semantic markup.
+    > figure {
+      position: relative;
+      margin: 0;
+      width: 100%;
+      height: 100%;
+
+      > img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+        padding: 0;
+      }
+
+      > figcaption {
+        position: absolute;
+        inset-inline: 0;
+        inset-block-end: 0;
+        background: rgba($mg-color-neutral-900, 0.75);
+        color: $mg-color-neutral-0;
+        padding: $mg-spacing-50 $mg-spacing-100;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: $mg-spacing-100;
+      }
+    }
   }
 
   .mg-hero__media-img {


### PR DESCRIPTION
Closes #942

## What changed

Adds `layout="split"` to the Hero component — a solid-background two-column layout (content + media) as an alternative to the existing background-image overlay. The media column supports three content types (image, video, arbitrary HTML) so consumers can use the slot for promotional visuals beyond a single photo.

**Also marks `ChildHero` as deprecated** (see below) — it was never adopted in production and the main Hero now covers the same use cases.

### New props

| Prop | Type | Default | Notes |
|---|---|---|---|
| `layout` | `'background' \| 'split'` | `'background'` | No change to existing behaviour |
| `headingLevel` | `'h1' \| 'h2' \| 'h3'` | `'h1'` | Applies to both layouts |
| `split` | `'2/3' \| '1/2' \| '1/3'` | `'2/3'` | Split layout only |
| `data[].media` | `{ type, src, alt, title, html }` | — | Split layout only; absent = single content column |

### Media types

| `media.type` | Fields | Notes |
|---|---|---|
| `image` (default) | `src`, `alt` | Cover-fit `<img>`. Omitting `type` falls back here for backwards compat. |
| `video` | `src`, `title` | Provider embed URL (e.g. `youtube.com/embed/…`), rendered as a 16:9 iframe. `title` required for screen reader users. |
| `html` | `html` | Pre-sanitized HTML string via `dangerouslySetInnerHTML`. Consumer must sanitize. A `<figure>` dropped directly into the slot gets a first-class attribution overlay for free; consumers can also wrap content in a custom container for extra composition. |

### Behaviour notes

- **Heading+link**: the link is now wrapped *inside* the heading element (`<h2><a href=...>`) rather than replacing it. Subtle fix for both layouts — `headingLevel` is always respected regardless of whether a link is present.
- **Variant colours**: split layout applies variant colour at full opacity (no `rgba(0.85)` wrapper — no photo underneath).
- **CTA button overrides**: duplicated at `.mg-hero--split` scope since there is no `__overlay` to target.
- **RTL**: outer background-layout positioning offsets are reset for split; column order reverses via `direction: rtl` on the grid container.
- **Missing media**: gracefully collapses to a single content column.

## ChildHero deprecation

`ChildHero` is marked deprecated and planned for removal by the **end of 2026**. It was never picked up in production across UNDRR sites, and the main Hero now covers the same use cases via `headingLevel="h2"`/`"h3"` and `layout="split"`. The MDX docs carry a top-of-page deprecation callout and a changelog entry (1.2), the component has a `@deprecated` JSDoc tag, and the AI manifest entry flags `deprecated: true`. The component is still available during the transition window.

## Tests

28 Jest tests in `__tests__/Hero.test.jsx` covering background layout, split layout at all three ratios, `headingLevel` (with and without links), variant classes, all three media types (image, video, html), video `title` fallback, legacy media shape without `type`, missing-media edge case, and jest-axe assertions for background, split, and split-with-video.

## Storybook

Five split-layout stories, named with the house parens convention:

- `Split (2/3 content, default)`
- `Split (1/2 balanced)`
- `Split (1/3 media-led)`
- `Split (video embed)`
- `Split (custom HTML slot)` — demonstrates a consumer-wrapped figure with attribution overlay

## AI manifest

`components-hero-hero` entry updated with the new description and CSS class list (`mg-hero--split`, `mg-hero--split-2-3`/`1-2`/`1-3`, `mg-hero__split-grid`, `mg-hero__media--video`, `mg-hero__media--html`, `mg-hero__media-iframe`). `components-hero-hero-child` entry flagged as deprecated. `yarn validate-manifest` passes.

## Checklist

- [x] Existing `layout="background"` stories and behaviour unchanged
- [x] 5 new Storybook stories
- [x] 28 Jest tests, all passing (including jest-axe)
- [x] Lint clean
- [x] MDX updated with changelog entry
- [x] AI manifest updated
- [x] ChildHero deprecation documented
- [ ] ⚠️ `quaternary` variant WCAG AA contrast audit across themes (tracked in #942 — not blocking this PR but should be followed up)