### PR TITLE
fix(mega-menu): declare title and icon on section PropTypes shape

### DIFF
--- a/stories/Components/MegaMenu/MegaMenu.jsx
+++ b/stories/Components/MegaMenu/MegaMenu.jsx
@@ -10,6 +10,8 @@
  * `logoHref`, e.g. `data-mg-mega-menu-logo-href="/ar/"` on Arabic pages.
  *
  * @param {Object[]} sections - Array of section objects containing menu structure
+ * @param {string} sections[].title - Top-level menu item label (required)
+ * @param {string} sections[].icon - Optional icon class name shown before the title on desktop topbar (e.g. "mg-icon mg-icon-chart-bar")
  * @param {string} sections[].bannerHeading - Heading text for the section banner
  * @param {string} sections[].bannerDescription - Description text for the section banner
  * @param {Object} sections[].bannerButton - Optional button object for the banner
@@ -162,6 +164,8 @@ MegaMenu.propTypes = {
   /** Array of section objects containing the menu structure. */
   sections: PropTypes.arrayOf(
     PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      icon: PropTypes.string,
       bannerHeading: PropTypes.string,
       bannerDescription: PropTypes.string,
       bannerButton: PropTypes.shape({

--- a/stories/Components/MegaMenu/MegaMenu.mdx
+++ b/stories/Components/MegaMenu/MegaMenu.mdx
@@ -165,6 +165,7 @@ See the [hydration guide](https://github.com/unisdr/undrr-mangrove/blob/main/doc
 
 ## Changelog
 
+- **1.2.2** — 2026-04-23: Declared `title` (required) and `icon` (optional) on the section-object `PropTypes` shape. Both props were already used by `TopBar` and `Sidebar` and documented in the section object properties table, but were absent from runtime `PropTypes` validation, so consumers got no warning when passing sections without a `title`.
 - **1.2.1** — 2026-04-14 ([https://github.com/unisdr/undrr-mangrove/issues/939](https://github.com/unisdr/undrr-mangrove/issues/939)): Scoped submenu CSS multicolumn layout to tablet+ viewports. Primarily a Safari mobile fix: third-level menu items rendered invisibly (space reserved, content unpainted) due to a long-standing interaction between multicolumn containers and descendant `opacity < 1`. Other browsers were unaffected.
 - **1.2** — 2026-04-13: `.mg-mega-topbar__item-link` migrated from raw `$mg-font-family-condensed` to the semantic `$mg-font-family-headings` alias. Same rendered font; future-proof if a theme overrides the heading token independently of the condensed token.
 - **1.1.1** — 2026-04-06 ([#916](https://github.com/unisdr/undrr-mangrove/pull/916)): Fixed mobile links non-clickable when using Mangrove nav CSS without the React component, or when JS hydration fails.

--- a/stories/Components/MegaMenu/__tests__/MegaMenu.test.jsx
+++ b/stories/Components/MegaMenu/__tests__/MegaMenu.test.jsx
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import MegaMenu from '../MegaMenu';
+
+// React 19 no longer invokes PropTypes validation at runtime, but the
+// declarations on MegaMenu.propTypes still drive react-docgen output,
+// Storybook autodocs, and the AI manifest — so the contract needs to
+// stay accurate. These tests invoke checkPropTypes directly to verify
+// the declared shape matches the documented section-object contract.
+describe('MegaMenu propTypes', () => {
+  let consoleSpy;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    PropTypes.resetWarningCache();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('flags a section missing the required title', () => {
+    PropTypes.checkPropTypes(
+      MegaMenu.propTypes,
+      { sections: [{ bannerHeading: 'x' }] },
+      'prop',
+      'MegaMenu',
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+    const message = consoleSpy.mock.calls[0][0];
+    expect(message).toMatch(/title/);
+    expect(message).toMatch(/required|marked as required/i);
+  });
+
+  it('flags a non-string icon on a section', () => {
+    PropTypes.checkPropTypes(
+      MegaMenu.propTypes,
+      { sections: [{ title: 'Section', icon: 42 }] },
+      'prop',
+      'MegaMenu',
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+    const message = consoleSpy.mock.calls[0][0];
+    expect(message).toMatch(/icon/);
+  });
+
+  it('accepts a well-formed section with title and optional icon', () => {
+    PropTypes.checkPropTypes(
+      MegaMenu.propTypes,
+      {
+        sections: [
+          { title: 'Section A', icon: 'mg-icon mg-icon-globe' },
+          { title: 'Section B' },
+        ],
+      },
+      'prop',
+      'MegaMenu',
+    );
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`MegaMenu`'s `propTypes.sections` shape was missing `title` and `icon`, even though:

- [`MegaMenu.mdx`](stories/Components/MegaMenu/MegaMenu.mdx) documents both under **Section object properties** (title required, icon optional).
- [`TopBar.jsx:43-44`](stories/Components/MegaMenu/TopBar/TopBar.jsx#L43-L44) renders `section.title` and `section.icon`.
- [`Sidebar.jsx:34,47`](stories/Components/MegaMenu/TopBar/Sidebar.jsx#L34) renders `section.title`.
- Every section in [`MegaMenu.stories.jsx`](stories/Components/MegaMenu/MegaMenu.stories.jsx) supplies a `title`.

Under React 19, PropTypes is no longer auto-invoked at runtime — but the declaration still drives react-docgen output, Storybook autodocs, and the AI manifest. Keeping the declared shape accurate is what makes those downstream views correct.

## What's in

- Add `title: PropTypes.string.isRequired` and `icon: PropTypes.string` to the `sections` shape.
- Update the top-of-file JSDoc block to list both props alongside the existing `sections[].banner*` entries.
- New test file `stories/Components/MegaMenu/__tests__/MegaMenu.test.jsx` that invokes `checkPropTypes` directly to verify the contract: missing title flagged, wrong-type icon flagged, well-formed sections pass clean.
- Component changelog entry bumping to 1.2.2.

## Out of scope

- No runtime behavior change. React 19 doesn't call PropTypes; the declaration is metadata.
- Drupal-side wrapper (`MegaMenu-wrapper.js`) already passes `title` on every section, so no consumer change.

## How this was surfaced

Found while auditing canonical field names in the content-schemas branch (#885) against real component prop surfaces. The `navigation` schema there already documented `title` and `icon` on section objects; this PR brings the runtime PropTypes declaration into agreement so react-docgen, Storybook, and the AI manifest all reflect the same contract.

## Test plan

- [x] `yarn lint:check` passes
- [x] `yarn test MegaMenu` passes (10/10 — 7 existing + 3 new PropTypes contract tests)
- [x] `yarn validate-manifest` passes (no regression in PropTypes coverage)