### PR TITLE
feat: add preview-access soft-gate component

### DIFF
--- a/scripts/ai-manifest/component-data.js
+++ b/scripts/ai-manifest/component-data.js
@@ -382,7 +382,7 @@ export default {
 
   // --- Preview access ---
   'components-preview-access': {
-    description: 'Soft "wet paint" preview gate. Drop <div data-mg-preview-access> into a page and a PIN-prompt modal covers the content until the right code is entered. Unlock persists in sessionStorage for the browser session. CSS-first via :has() (no flash). Vanilla JS — requires preview-access.js. Not a security mechanism: the PIN sits in the DOM.',
+    description: 'Page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Drop <div data-mg-preview-access> into a page and load js/preview-access.js. Unlock persists in sessionStorage for the browser session. CSS-first anti-flash via :has(). Editorial signalling only — not a security mechanism, since the PIN sits in the DOM.',
     cssClasses: [
       'mg-preview-access--unlocked',
       'mg-preview-access__overlay',

--- a/scripts/ai-manifest/component-data.js
+++ b/scripts/ai-manifest/component-data.js
@@ -380,6 +380,41 @@ export default {
     ],
   },
 
+  // --- Preview access ---
+  'components-preview-access': {
+    description: 'Soft "wet paint" preview gate. Drop <div data-mg-preview-access> into a page and a PIN-prompt modal covers the content until the right code is entered. Unlock persists in sessionStorage for the browser session. CSS-first via :has() (no flash). Vanilla JS — requires preview-access.js. Not a security mechanism: the PIN sits in the DOM.',
+    cssClasses: [
+      'mg-preview-access--unlocked',
+      'mg-preview-access__overlay',
+      'mg-preview-access__modal',
+      'mg-preview-access__eyebrow',
+      'mg-preview-access__title',
+      'mg-preview-access__body',
+      'mg-preview-access__form',
+      'mg-preview-access__label',
+      'mg-preview-access__field',
+      'mg-preview-access__input',
+      'mg-preview-access__submit',
+      'mg-preview-access__error',
+      'mg-preview-access__contact',
+    ],
+    examples: [
+      {
+        name: 'Default gate (PIN 5498)',
+        html: `<div data-mg-preview-access></div>`,
+      },
+      {
+        name: 'Branded gate with shared id',
+        html: `<div data-mg-preview-access
+     data-mg-preview-pin="5498"
+     data-mg-preview-id="delta-2026-preview"
+     data-mg-preview-eyebrow="DELTA Resilience · Preview"
+     data-mg-preview-title="This page is a preview"
+     data-mg-preview-message="The DELTA Resilience country dashboard is in active development and is not yet ready for public review. Enter the preview PIN to continue, or contact UNDRR if you need access."></div>`,
+      },
+    ],
+  },
+
   // --- On this page nav ---
   'components-on-this-page-nav': {
     description: 'Sticky horizontal "On this page" navigation bar with IntersectionObserver scroll-spy. Two modes: auto-detect (scans h2/h3/h4 headings) or explicit (author-provided links). Optional CTA button. Vanilla JS — requires on-this-page-nav.js.',

--- a/stories/Components/PreviewAccess/PreviewAccess.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.jsx
@@ -12,21 +12,21 @@ const DEFAULT_MESSAGE =
 /**
  * Storybook / docs preview of the preview-access modal panel.
  *
- * Renders a static visual preview of the modal markup — useful for previewing
- * copy, RTL layout, and theme application without actually gating Storybook.
- * To activate the real body-level gate behaviour, pass `live`. The live mode
- * renders the trigger div and calls the vanilla mgPreviewAccess() runtime; on
+ * Renders a static visual preview of the modal markup, useful for previewing
+ * copy, theme, and RTL without actually gating Storybook. To activate the
+ * real body-level gate behaviour, pass `live`. In `live` mode the runtime
+ * appends the overlay to `document.body` (not into the React tree). On
  * unmount it removes the overlay and restores body siblings.
  *
- * For production pages, prefer dropping `<div data-mg-preview-access>` directly
- * into the HTML and loading js/preview-access.js — the gate is fundamentally a
- * page-level concern, not a subtree component.
+ * For production pages, prefer dropping `<div data-mg-preview-access>` into
+ * the HTML directly and loading js/preview-access.js. The gate is
+ * fundamentally a page-level concern, not a subtree component.
  *
  * @param {Object}  props
  * @param {boolean} [props.live]            When true, mounts the real gate.
  * @param {string}  [props.pin]             Unlock PIN.
  * @param {string}  [props.id]              sessionStorage scope key.
- * @param {string}  [props.eyebrow]         Small uppercase label above the title.
+ * @param {string}  [props.eyebrow]         Small label above the title.
  * @param {string}  [props.title]           Modal heading.
  * @param {string}  [props.message]         Modal body copy.
  * @param {string}  [props.contactUrl]      Help link URL.
@@ -50,6 +50,10 @@ export default function PreviewAccess({
 }) {
   const gateRef = useRef(null);
 
+  // Only mount/unmount on `live` toggles; copy-prop edits update the data
+  // attributes in place via React's normal render path. The runtime reads
+  // attributes once at init, so changing copy after mount is intentionally
+  // a no-op — keeping the gate stable avoids overlay flicker and lost focus.
   useEffect(() => {
     if (!live) return undefined;
     const gate = gateRef.current;
@@ -59,19 +63,7 @@ export default function PreviewAccess({
     return () => {
       if (gate) mgPreviewAccessDestroy(gate);
     };
-  }, [
-    live,
-    pin,
-    id,
-    eyebrow,
-    title,
-    message,
-    contactUrl,
-    contactLabel,
-    pinLabel,
-    submitLabel,
-    errorMessage,
-  ]);
+  }, [live]);
 
   if (live) {
     return (
@@ -92,11 +84,24 @@ export default function PreviewAccess({
     );
   }
 
+  // Static preview: mirrors the runtime's modal panel structure so reviewers
+  // see the same markup that ships in production. Form is wired to no-op so
+  // the user can still tab through, but the gate behaviour is not active.
   return (
-    <div className="mg-preview-access__modal">
+    <div
+      className="mg-preview-access__modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mg-preview-access-title-preview"
+      aria-describedby="mg-preview-access-body-preview"
+    >
       <p className="mg-preview-access__eyebrow">{eyebrow}</p>
-      <h2 className="mg-preview-access__title">{title}</h2>
-      <p className="mg-preview-access__body">{message}</p>
+      <h2 className="mg-preview-access__title" id="mg-preview-access-title-preview">
+        {title}
+      </h2>
+      <p className="mg-preview-access__body" id="mg-preview-access-body-preview">
+        {message}
+      </p>
       <form
         className="mg-preview-access__form"
         noValidate
@@ -113,12 +118,17 @@ export default function PreviewAccess({
             inputMode="numeric"
             autoComplete="off"
             spellCheck="false"
+            aria-describedby="mg-preview-access-error-preview"
           />
           <button className="mg-preview-access__submit" type="submit">
             {submitLabel}
           </button>
         </div>
-        <p className="mg-preview-access__error" role="status" aria-live="polite" />
+        <p
+          className="mg-preview-access__error"
+          id="mg-preview-access-error-preview"
+          role="alert"
+        />
       </form>
       <p className="mg-preview-access__contact">
         <a href={contactUrl}>{contactLabel}</a>
@@ -134,7 +144,7 @@ PreviewAccess.propTypes = {
   pin: PropTypes.string,
   /** sessionStorage scope key. Defaults to location.pathname when null. */
   id: PropTypes.string,
-  /** Small uppercase label above the title. */
+  /** Small label above the title. */
   eyebrow: PropTypes.string,
   /** Modal heading. */
   title: PropTypes.string,

--- a/stories/Components/PreviewAccess/PreviewAccess.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.jsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  mgPreviewAccess,
+  mgPreviewAccessDestroy,
+} from '../../assets/js/preview-access';
+
+const DEFAULT_MESSAGE =
+  'This page is in preview and is not yet ready for general distribution. ' +
+  'Please enter the access PIN provided by UNDRR to continue.';
+
+/**
+ * Storybook / docs preview of the preview-access modal panel.
+ *
+ * Renders a static visual preview of the modal markup — useful for previewing
+ * copy, RTL layout, and theme application without actually gating Storybook.
+ * To activate the real body-level gate behaviour, pass `live`. The live mode
+ * renders the trigger div and calls the vanilla mgPreviewAccess() runtime; on
+ * unmount it removes the overlay and restores body siblings.
+ *
+ * For production pages, prefer dropping `<div data-mg-preview-access>` directly
+ * into the HTML and loading js/preview-access.js — the gate is fundamentally a
+ * page-level concern, not a subtree component.
+ *
+ * @param {Object}  props
+ * @param {boolean} [props.live]            When true, mounts the real gate.
+ * @param {string}  [props.pin]             Unlock PIN.
+ * @param {string}  [props.id]              sessionStorage scope key.
+ * @param {string}  [props.eyebrow]         Small uppercase label above the title.
+ * @param {string}  [props.title]           Modal heading.
+ * @param {string}  [props.message]         Modal body copy.
+ * @param {string}  [props.contactUrl]      Help link URL.
+ * @param {string}  [props.contactLabel]    Help link visible text.
+ * @param {string}  [props.pinLabel]        Form label for the PIN input.
+ * @param {string}  [props.submitLabel]     Submit button label.
+ * @param {string}  [props.errorMessage]    Error message text on a wrong PIN.
+ */
+export default function PreviewAccess({
+  live = false,
+  pin = '5498',
+  id = null,
+  eyebrow = 'UNDRR · Preview',
+  title = 'Preview access required',
+  message = DEFAULT_MESSAGE,
+  contactUrl = 'https://www.undrr.org/contact-us',
+  contactLabel = 'Need help? Contact UNDRR',
+  pinLabel = 'Access PIN',
+  submitLabel = 'Unlock',
+  errorMessage = 'That PIN is not correct. Please try again.',
+}) {
+  const gateRef = useRef(null);
+
+  useEffect(() => {
+    if (!live) return undefined;
+    const gate = gateRef.current;
+    if (!gate) return undefined;
+    delete gate.dataset.mgPreviewAccessInitialized;
+    mgPreviewAccess([gate]);
+    return () => {
+      if (gate) mgPreviewAccessDestroy(gate);
+    };
+  }, [
+    live,
+    pin,
+    id,
+    eyebrow,
+    title,
+    message,
+    contactUrl,
+    contactLabel,
+    pinLabel,
+    submitLabel,
+    errorMessage,
+  ]);
+
+  if (live) {
+    return (
+      <div
+        ref={gateRef}
+        data-mg-preview-access=""
+        data-mg-preview-pin={pin}
+        {...(id && { 'data-mg-preview-id': id })}
+        data-mg-preview-eyebrow={eyebrow}
+        data-mg-preview-title={title}
+        data-mg-preview-message={message}
+        data-mg-preview-contact-url={contactUrl}
+        data-mg-preview-contact-label={contactLabel}
+        data-mg-preview-pin-label={pinLabel}
+        data-mg-preview-submit-label={submitLabel}
+        data-mg-preview-error-message={errorMessage}
+      />
+    );
+  }
+
+  return (
+    <div className="mg-preview-access__modal">
+      <p className="mg-preview-access__eyebrow">{eyebrow}</p>
+      <h2 className="mg-preview-access__title">{title}</h2>
+      <p className="mg-preview-access__body">{message}</p>
+      <form
+        className="mg-preview-access__form"
+        noValidate
+        onSubmit={e => e.preventDefault()}
+      >
+        <label className="mg-preview-access__label" htmlFor="mg-preview-access-pin-preview">
+          {pinLabel}
+        </label>
+        <div className="mg-preview-access__field">
+          <input
+            className="mg-preview-access__input"
+            id="mg-preview-access-pin-preview"
+            type="text"
+            inputMode="numeric"
+            autoComplete="off"
+            spellCheck="false"
+          />
+          <button className="mg-preview-access__submit" type="submit">
+            {submitLabel}
+          </button>
+        </div>
+        <p className="mg-preview-access__error" role="status" aria-live="polite" />
+      </form>
+      <p className="mg-preview-access__contact">
+        <a href={contactUrl}>{contactLabel}</a>
+      </p>
+    </div>
+  );
+}
+
+PreviewAccess.propTypes = {
+  /** When true, mount the real body-level gate (overlay + inert siblings). */
+  live: PropTypes.bool,
+  /** PIN that unlocks the page. */
+  pin: PropTypes.string,
+  /** sessionStorage scope key. Defaults to location.pathname when null. */
+  id: PropTypes.string,
+  /** Small uppercase label above the title. */
+  eyebrow: PropTypes.string,
+  /** Modal heading. */
+  title: PropTypes.string,
+  /** Modal body copy. */
+  message: PropTypes.string,
+  /** Help link URL. */
+  contactUrl: PropTypes.string,
+  /** Help link visible text. */
+  contactLabel: PropTypes.string,
+  /** Form label for the PIN input. */
+  pinLabel: PropTypes.string,
+  /** Submit button label. */
+  submitLabel: PropTypes.string,
+  /** Error message text on a wrong PIN. */
+  errorMessage: PropTypes.string,
+};

--- a/stories/Components/PreviewAccess/PreviewAccess.mdx
+++ b/stories/Components/PreviewAccess/PreviewAccess.mdx
@@ -1,0 +1,195 @@
+{/* PreviewAccess.mdx */}
+
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as PreviewAccessStories from './PreviewAccess.stories';
+
+<Meta of={PreviewAccessStories} />
+
+> If you are creating or modifying this component, see [docs/REVIEW-CHECKLIST.md](../../../docs/REVIEW-CHECKLIST.md) for Mangrove's component standards.
+
+# Preview access
+
+A soft "wet paint" gate for UNDRR pages that are not ready for general distribution. Drop a single `<div data-mg-preview-access>` into a page and a PIN-prompt modal covers the page until the right code is entered. Once unlocked, the gate stays unlocked for the rest of the browser session.
+
+**Not a security mechanism.** The PIN sits in the DOM and the unlock is held in sessionStorage. Anyone with devtools is through in seconds. The point is to give reviewers a clear, unmistakable signal that they are looking at a preview, not to prevent access. If a page genuinely must not be seen, gate it at the edge (e.g. Cloudflare Access).
+
+## When to use
+
+- Sharing in-progress dashboards or content with reviewers before public launch
+- Hiding partly-built pages from search engines and casual visitors
+- Marking a whole product preview (e.g. a DELTA preview site) with a single shared PIN
+
+For real access control, use server-side authentication. This component is for editorial signalling only.
+
+## How it works
+
+The gate is CSS-first. A `:has()` rule hides every direct child of `<body>` (except the overlay) the moment the parser sees a `[data-mg-preview-access]` element. There is no flash of unstyled content and no race with deferred scripts. JavaScript then layers a modal panel on top, asks for a PIN, and on success removes the overlay and adds an `--unlocked` class to the trigger so the gate rule stops applying.
+
+`visibility: hidden` (not `display: none`) preserves layout — the page does not reflow when the gate drops, and images load in the background so the page is ready to read the moment the modal goes away.
+
+While the modal is up, every direct child of `<body>` except the overlay receives `inert` and `aria-hidden="true"`. That gives a focus trap, screen-reader hiding, and pointer-event blocking in one attribute, with no focus-trap library needed.
+
+## Vanilla HTML usage
+
+Three things in the page:
+
+```html
+<!-- 1. CSS in <head> -->
+<link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.6.0/css/style.css" />
+
+<!-- 2. Trigger as the first element in <body> for zero flash -->
+<div data-mg-preview-access></div>
+
+<!-- 3. Script before </body> as type="module" (the file uses ESM exports) -->
+<script type="module" src="https://assets.undrr.org/static/mangrove/1.6.0/js/preview-access.js"></script>
+```
+
+That is the minimum. With nothing else set, the gate uses the default PIN `5498`, default UNDRR copy, and the contact link points to `undrr.org/contact-us`.
+
+### Realistic example
+
+```html
+<div data-mg-preview-access
+     data-mg-preview-pin="5498"
+     data-mg-preview-id="delta-2026-preview"
+     data-mg-preview-eyebrow="DELTA Resilience · Preview"
+     data-mg-preview-title="This page is a preview"
+     data-mg-preview-message="The DELTA Resilience country dashboard is in active development and is not yet ready for public review. Enter the preview PIN to continue, or contact UNDRR if you need access."></div>
+```
+
+Place the trigger as the first child of `<body>` so any content above it does not get a chance to paint before the `:has()` rule fires.
+
+## Data attributes
+
+All attributes go on the trigger element. All optional except the bare `data-mg-preview-access`.
+
+| Attribute | Default | Purpose |
+| --- | --- | --- |
+| `data-mg-preview-access` | — | Presence activates the gate. No value needed. |
+| `data-mg-preview-pin` | `5498` | The PIN that unlocks the page. |
+| `data-mg-preview-id` | `location.pathname` | Scope key for the sessionStorage unlock. Set the same id on multiple pages to share an unlock across them. |
+| `data-mg-preview-eyebrow` | `UNDRR · Preview` | Small uppercase label above the title. Useful for naming the product. |
+| `data-mg-preview-title` | `Preview access required` | Modal heading. |
+| `data-mg-preview-message` | Generic UNDRR preview copy | Body paragraph explaining what the page is and how to get in. |
+| `data-mg-preview-contact-url` | `https://www.undrr.org/contact-us` | Where the help link goes. |
+| `data-mg-preview-contact-label` | `Need help? Contact UNDRR` | Visible text of the help link. |
+| `data-mg-preview-pin-label` | `Access PIN` | Form label for the PIN input. Override for translation. |
+| `data-mg-preview-submit-label` | `Unlock` | Submit button label. Override for translation. |
+| `data-mg-preview-error-message` | `That PIN is not correct. Please try again.` | Error copy on a wrong PIN. Override for translation. |
+| `data-mg-preview-access-skip-auto-init` | — | Skips this gate during auto-init. Call `mgPreviewAccess([element])` manually when ready. |
+
+## CSS classes
+
+| Class | Element | Purpose |
+| --- | --- | --- |
+| `mg-preview-access--unlocked` | trigger `<div>` | Set on success; releases the `:has()` gate rule |
+| `mg-preview-access__overlay` | injected `<div>` | Fixed full-viewport scrim with the modal centred inside |
+| `mg-preview-access__modal` | injected `<div>` | The modal panel |
+| `mg-preview-access__eyebrow` | `<p>` | Small uppercase product label |
+| `mg-preview-access__title` | `<h1>` | Modal heading |
+| `mg-preview-access__body` | `<p>` | Modal body copy |
+| `mg-preview-access__form` | `<form>` | Form wrapper |
+| `mg-preview-access__label` | `<label>` | PIN input label |
+| `mg-preview-access__field` | `<div>` | Input + submit row |
+| `mg-preview-access__input` | `<input>` | PIN input |
+| `mg-preview-access__submit` | `<button>` | Submit button |
+| `mg-preview-access__error` | `<p>` | Live region for the wrong-PIN error |
+| `mg-preview-access__contact` | `<p>` | Contact link footer |
+
+## JavaScript API
+
+Auto-initialises on `DOMContentLoaded` (or immediately if the script loads after the DOM is ready). For dynamic content or manual init:
+
+```js
+import {
+  mgPreviewAccess,
+  mgPreviewAccessDestroy,
+} from 'path/to/preview-access.js';
+
+// Initialise the first [data-mg-preview-access] in the document
+mgPreviewAccess();
+
+// Initialise specific elements
+mgPreviewAccess([myGateElement]);
+
+// Tear down (removes the overlay, restores body siblings, clears init flag)
+mgPreviewAccessDestroy(myGateElement);
+```
+
+The runtime is also exposed as `window.mgPreviewAccess` for plain-script consumers.
+
+## Drupal integration sketch
+
+When this lands in the Drupal multidomain platform, the natural shape is:
+
+- A node-level boolean field `field_preview_mode` (or similar)
+- A site-level config setting holding the current PIN
+- A Twig template fragment that renders the trigger div with both, conditional on the boolean being true
+
+The data-attribute API was shaped to make that template trivial.
+
+## Usage with React
+
+This is a vanilla JS, body-level gate — fundamentally a page-level concern, not a subtree component. In a React app, prefer one of:
+
+```jsx
+// Option A: drop the trigger element in your root layout and let the
+// auto-init handle the rest.
+function RootLayout({ children }) {
+  return (
+    <>
+      <div data-mg-preview-access data-mg-preview-pin="5498" />
+      {children}
+    </>
+  );
+}
+```
+
+```jsx
+// Option B: call mgPreviewAccess() yourself in a top-level effect.
+import { useEffect, useRef } from 'react';
+import {
+  mgPreviewAccess,
+  mgPreviewAccessDestroy,
+} from '@undrr/undrr-mangrove/js/preview-access';
+
+function Gate() {
+  const ref = useRef(null);
+  useEffect(() => {
+    const gate = ref.current;
+    if (gate) mgPreviewAccess([gate]);
+    return () => { if (gate) mgPreviewAccessDestroy(gate); };
+  }, []);
+  return <div ref={ref} data-mg-preview-access data-mg-preview-pin="5498" />;
+}
+```
+
+The exported `<PreviewAccess>` React component is a static visual preview of the modal panel, used for Storybook. To activate the real body-level gate from React, pass `live`.
+
+## Accessibility
+
+- Renders as `role="dialog"` with `aria-modal="true"`, `aria-labelledby` pointing at the title, and `aria-describedby` pointing at the body
+- Body siblings receive `inert` + `aria-hidden="true"` so focus is trapped in the modal and the rest of the page is hidden from screen readers
+- Wrong-PIN error uses `role="alert"` and `aria-live="polite"` so the message is announced
+- Focus moves into the PIN input on mount (after `requestAnimationFrame` so layout has settled)
+- Submit button passes 4.5:1 contrast against `$mg-color-interactive` across all five themes
+- No Escape-to-close: the gate is meant to hold until a PIN is entered
+
+## RTL and internationalisation
+
+The component supports RTL automatically when `dir="rtl"` and `lang="ar"` are set on the document:
+
+- `:lang(ar)` swaps the heading and UI families to `$mg-font-family-arabic-headings` (Roboto Condensed has no Arabic glyph coverage)
+- Body, error, and contact copy swap to `$mg-font-family-arabic-body`
+- All visible copy comes from data attributes, so translations are a content-only change
+
+## Known limitations
+
+- **Single trigger per page.** The script honours one trigger per page. If you ever need multi-zone gating, that is a different pattern.
+- **No Escape-to-close.** Deliberate. The gate should hold until a PIN is entered.
+- **`:has()` is the entire anti-flash strategy.** Universally supported since late 2023, which is fine for our review audience. If you ever need to support an older browser, add a one-line inline `<script>` in `<head>` that sets a class on `<html>` and wire the CSS rule to that class as well.
+- **PIN in the DOM.** Not access control. Bears repeating because someone always asks.
+
+## Changelog
+
+- **1.0** — Initial release. Vanilla JS + CSS, body-level gate, sessionStorage-scoped unlock, RTL/Arabic font swap, `inert`-based focus trap, override-able copy via data attributes.

--- a/stories/Components/PreviewAccess/PreviewAccess.mdx
+++ b/stories/Components/PreviewAccess/PreviewAccess.mdx
@@ -1,6 +1,6 @@
 {/* PreviewAccess.mdx */}
 
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
 import * as PreviewAccessStories from './PreviewAccess.stories';
 
 <Meta of={PreviewAccessStories} />
@@ -9,25 +9,31 @@ import * as PreviewAccessStories from './PreviewAccess.stories';
 
 # Preview access
 
-A soft "wet paint" gate for UNDRR pages that are not ready for general distribution. Drop a single `<div data-mg-preview-access>` into a page and a PIN-prompt modal covers the page until the right code is entered. Once unlocked, the gate stays unlocked for the rest of the browser session.
+A page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Once unlocked, the page stays unlocked for the rest of the browser session.
 
-**Not a security mechanism.** The PIN sits in the DOM and the unlock is held in sessionStorage. Anyone with devtools is through in seconds. The point is to give reviewers a clear, unmistakable signal that they are looking at a preview, not to prevent access. If a page genuinely must not be seen, gate it at the edge (e.g. Cloudflare Access).
+> **Note:** This is not a security mechanism. The PIN sits in the DOM and the unlock is held in `sessionStorage`, so anyone with developer tools can bypass it. The component is editorial signalling for review audiences (a "wet paint" sign). For real access control, gate the page at the edge with a service like Cloudflare Access.
+
+## Examples
+
+The static preview below shows the modal panel inline so theme, copy, and RTL can be reviewed without locking the Storybook canvas. To see the real body-level overlay behaviour, run the **Live demo** story.
+
+<Canvas of={PreviewAccessStories.Default} />
+
+Override copy for a specific product preview:
+
+<Canvas of={PreviewAccessStories.ProductBranded} />
+
+Arabic + RTL with the Arabic font swap:
+
+<Canvas of={PreviewAccessStories.ArabicRtl} />
 
 ## When to use
 
 - Sharing in-progress dashboards or content with reviewers before public launch
 - Hiding partly-built pages from search engines and casual visitors
-- Marking a whole product preview (e.g. a DELTA preview site) with a single shared PIN
+- Marking a whole product preview (for example, a DELTA preview site) with a single shared PIN
 
 For real access control, use server-side authentication. This component is for editorial signalling only.
-
-## How it works
-
-The gate is CSS-first. A `:has()` rule hides every direct child of `<body>` (except the overlay) the moment the parser sees a `[data-mg-preview-access]` element. There is no flash of unstyled content and no race with deferred scripts. JavaScript then layers a modal panel on top, asks for a PIN, and on success removes the overlay and adds an `--unlocked` class to the trigger so the gate rule stops applying.
-
-`visibility: hidden` (not `display: none`) preserves layout — the page does not reflow when the gate drops, and images load in the background so the page is ready to read the moment the modal goes away.
-
-While the modal is up, every direct child of `<body>` except the overlay receives `inert` and `aria-hidden="true"`. That gives a focus trap, screen-reader hiding, and pointer-event blocking in one attribute, with no focus-trap library needed.
 
 ## Vanilla HTML usage
 
@@ -37,7 +43,7 @@ Three things in the page:
 <!-- 1. CSS in <head> -->
 <link rel="stylesheet" href="https://assets.undrr.org/static/mangrove/1.6.0/css/style.css" />
 
-<!-- 2. Trigger as the first element in <body> for zero flash -->
+<!-- 2. Trigger as the first element in <body> -->
 <div data-mg-preview-access></div>
 
 <!-- 3. Script before </body> as type="module" (the file uses ESM exports) -->
@@ -45,6 +51,8 @@ Three things in the page:
 ```
 
 That is the minimum. With nothing else set, the gate uses the default PIN `5498`, default UNDRR copy, and the contact link points to `undrr.org/contact-us`.
+
+> **Tip:** Place the trigger as the first child of `<body>` so any content above it does not get a chance to paint before the gate's CSS rule fires.
 
 ### Realistic example
 
@@ -57,8 +65,6 @@ That is the minimum. With nothing else set, the gate uses the default PIN `5498`
      data-mg-preview-message="The DELTA Resilience country dashboard is in active development and is not yet ready for public review. Enter the preview PIN to continue, or contact UNDRR if you need access."></div>
 ```
 
-Place the trigger as the first child of `<body>` so any content above it does not get a chance to paint before the `:has()` rule fires.
-
 ## Data attributes
 
 All attributes go on the trigger element. All optional except the bare `data-mg-preview-access`.
@@ -67,7 +73,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 | --- | --- | --- |
 | `data-mg-preview-access` | — | Presence activates the gate. No value needed. |
 | `data-mg-preview-pin` | `5498` | The PIN that unlocks the page. |
-| `data-mg-preview-id` | `location.pathname` | Scope key for the sessionStorage unlock. Set the same id on multiple pages to share an unlock across them. |
+| `data-mg-preview-id` | `location.pathname` | Scope key for the `sessionStorage` unlock. Set the same id on multiple pages to share an unlock across them. |
 | `data-mg-preview-eyebrow` | `UNDRR · Preview` | Small uppercase label above the title. Useful for naming the product. |
 | `data-mg-preview-title` | `Preview access required` | Modal heading. |
 | `data-mg-preview-message` | Generic UNDRR preview copy | Body paragraph explaining what the page is and how to get in. |
@@ -82,7 +88,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 
 | Class | Element | Purpose |
 | --- | --- | --- |
-| `mg-preview-access--unlocked` | trigger `<div>` | Set on success; releases the `:has()` gate rule |
+| `mg-preview-access--unlocked` | trigger `<div>` | Set on success; releases the gate's CSS rule |
 | `mg-preview-access__overlay` | injected `<div>` | Fixed full-viewport scrim with the modal centred inside |
 | `mg-preview-access__modal` | injected `<div>` | The modal panel |
 | `mg-preview-access__eyebrow` | `<p>` | Small uppercase product label |
@@ -90,7 +96,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 | `mg-preview-access__body` | `<p>` | Modal body copy |
 | `mg-preview-access__form` | `<form>` | Form wrapper |
 | `mg-preview-access__label` | `<label>` | PIN input label |
-| `mg-preview-access__field` | `<div>` | Input + submit row |
+| `mg-preview-access__field` | `<div>` | Input and submit row |
 | `mg-preview-access__input` | `<input>` | PIN input |
 | `mg-preview-access__submit` | `<button>` | Submit button |
 | `mg-preview-access__error` | `<p>` | Live region for the wrong-PIN error |
@@ -98,7 +104,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 
 ## JavaScript API
 
-Auto-initialises on `DOMContentLoaded` (or immediately if the script loads after the DOM is ready). For dynamic content or manual init:
+The component auto-initialises on `DOMContentLoaded` (or immediately if the script loads after the DOM is ready). For dynamic content or manual initialisation:
 
 ```js
 import {
@@ -118,19 +124,9 @@ mgPreviewAccessDestroy(myGateElement);
 
 The runtime is also exposed as `window.mgPreviewAccess` for plain-script consumers.
 
-## Drupal integration sketch
-
-When this lands in the Drupal multidomain platform, the natural shape is:
-
-- A node-level boolean field `field_preview_mode` (or similar)
-- A site-level config setting holding the current PIN
-- A Twig template fragment that renders the trigger div with both, conditional on the boolean being true
-
-The data-attribute API was shaped to make that template trivial.
-
 ## Usage with React
 
-This is a vanilla JS, body-level gate — fundamentally a page-level concern, not a subtree component. In a React app, prefer one of:
+> **Integration note:** This is a vanilla JS, body-level gate, fundamentally a page-level concern rather than a subtree component. The exported `<PreviewAccess>` React component renders a static visual preview of the modal panel for Storybook docs. To activate the real gate from a React app, prefer one of the patterns below.
 
 ```jsx
 // Option A: drop the trigger element in your root layout and let the
@@ -164,32 +160,50 @@ function Gate() {
 }
 ```
 
-The exported `<PreviewAccess>` React component is a static visual preview of the modal panel, used for Storybook. To activate the real body-level gate from React, pass `live`.
+To activate the real gate from the Storybook story, pass `live` to `<PreviewAccess>`. See the **Live demo** story.
+
+## Drupal integration
+
+> **Integration note:** When this lands in the Drupal multidomain platform, the natural shape is a node-level boolean field (for example, `field_preview_mode`), a site-level config setting holding the current PIN, and a Twig fragment that renders the trigger div with both, conditional on the boolean being true. The data-attribute API was shaped to make that template trivial.
 
 ## Accessibility
 
-- Renders as `role="dialog"` with `aria-modal="true"`, `aria-labelledby` pointing at the title, and `aria-describedby` pointing at the body
-- Body siblings receive `inert` + `aria-hidden="true"` so focus is trapped in the modal and the rest of the page is hidden from screen readers
-- Wrong-PIN error uses `role="alert"` and `aria-live="polite"` so the message is announced
-- Focus moves into the PIN input on mount (after `requestAnimationFrame` so layout has settled)
-- Submit button passes 4.5:1 contrast against `$mg-color-interactive` across all five themes
-- No Escape-to-close: the gate is meant to hold until a PIN is entered
+- The overlay renders as `role="dialog"` with `aria-modal="true"`, `aria-labelledby` pointing at the title, and `aria-describedby` pointing at the body
+- Body siblings receive `inert` and `aria-hidden="true"` so focus is trapped in the modal and the rest of the page is hidden from assistive technology
+- The wrong-PIN error uses `role="alert"` and `aria-live="polite"` so the message is announced
+- Focus moves into the PIN input on mount, after `requestAnimationFrame` so layout has settled
+- The submit button passes 4.5:1 contrast against `$mg-color-interactive` across all five themes
+- There is no Escape-to-close. The gate is meant to hold until a PIN is entered
 
 ## RTL and internationalisation
 
 The component supports RTL automatically when `dir="rtl"` and `lang="ar"` are set on the document:
 
-- `:lang(ar)` swaps the heading and UI families to `$mg-font-family-arabic-headings` (Roboto Condensed has no Arabic glyph coverage)
+- `:lang(ar)` swaps the heading and UI families to `$mg-font-family-arabic-headings`, because Roboto Condensed has no Arabic glyph coverage
 - Body, error, and contact copy swap to `$mg-font-family-arabic-body`
 - All visible copy comes from data attributes, so translations are a content-only change
 
+## Implementation notes
+
+> **Implementation note (for contributors):** This section explains the design decisions behind the gate. Skip it if you are integrating the component; it exists to prevent future contributors from "fixing" things that were intentional.
+
+**CSS-first anti-flash via `:has()`.** The gate hides page content with a CSS rule, not JavaScript. The rule is `body:has([data-mg-preview-access]:not(.mg-preview-access--unlocked)) > *:not(.mg-preview-access__overlay) { visibility: hidden }`. The moment the parser sees the trigger element, the rule fires and everything else is hidden. There is no flash of unstyled content and no race with deferred scripts. The cost is that the trigger should be the first child of `<body>` so any content above it does not get to paint first. `:has()` is universally supported since late 2023.
+
+**`visibility: hidden`, not `display: none`.** Layout is preserved. The page stays in its final shape behind the modal, and on unlock there is no reflow. Side effect: images and iframes still load in the background, so the page is ready to read the moment the gate drops.
+
+**`inert` on body siblings.** While the modal is up, every direct child of `<body>` except the overlay gets `inert` and `aria-hidden="true"`. That gives a focus trap, screen-reader hiding, and pointer-event blocking in one attribute. No focus-trap library is needed.
+
+**Session persistence.** Once unlocked, the gate sets `sessionStorage["mg-preview-access:<id>"] = "unlocked"`. The id defaults to `location.pathname` but is overridable via `data-mg-preview-id`, so a single PIN can cover a whole product preview (set the same id on every page in the preview).
+
+**Bespoke modal shell.** Mangrove does not yet have a dialog/modal primitive. The styles use Mangrove tokens where they exist (`$mg-z-index-modal`, `$mg-color-interactive`, `$mg-spacing-*`, `$mg-font-family-headings`, the Arabic font swap via `:lang(ar)`) but the panel itself is bespoke. When a modal primitive lands in Mangrove, this component should be refactored to consume it.
+
 ## Known limitations
 
-- **Single trigger per page.** The script honours one trigger per page. If you ever need multi-zone gating, that is a different pattern.
-- **No Escape-to-close.** Deliberate. The gate should hold until a PIN is entered.
-- **`:has()` is the entire anti-flash strategy.** Universally supported since late 2023, which is fine for our review audience. If you ever need to support an older browser, add a one-line inline `<script>` in `<head>` that sets a class on `<html>` and wire the CSS rule to that class as well.
+- **Single trigger per page.** The script honours one trigger per page (the first match). Multi-zone gating (a preview block inside an otherwise public page) is a different pattern.
+- **No Escape-to-close.** Deliberate. The gate should hold until a PIN is entered. A dismissible variant would be a separate prop.
+- **`:has()` is the entire anti-flash strategy.** If support for an older browser is ever needed, add a one-line inline `<script>` in `<head>` that sets a class on `<html>` and wire the CSS rule to that class as well.
 - **PIN in the DOM.** Not access control. Bears repeating because someone always asks.
 
 ## Changelog
 
-- **1.0** — Initial release. Vanilla JS + CSS, body-level gate, sessionStorage-scoped unlock, RTL/Arabic font swap, `inert`-based focus trap, override-able copy via data attributes.
+- **1.0** — 2026-04-30: Initial release. Vanilla JS and CSS, body-level gate, `sessionStorage`-scoped unlock, RTL and Arabic font swap, `inert`-based focus trap, override-able copy via data attributes.

--- a/stories/Components/PreviewAccess/PreviewAccess.mdx
+++ b/stories/Components/PreviewAccess/PreviewAccess.mdx
@@ -23,9 +23,7 @@ Override copy for a specific product preview:
 
 <Canvas of={PreviewAccessStories.ProductBranded} />
 
-Arabic + RTL with the Arabic font swap:
-
-<Canvas of={PreviewAccessStories.ArabicRtl} />
+Use the locale toolbar to preview the modal in other languages, including Arabic with RTL.
 
 ## When to use
 

--- a/stories/Components/PreviewAccess/PreviewAccess.mdx
+++ b/stories/Components/PreviewAccess/PreviewAccess.mdx
@@ -11,11 +11,11 @@ import * as PreviewAccessStories from './PreviewAccess.stories';
 
 A page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Once unlocked, the page stays unlocked for the rest of the browser session.
 
-> **Note:** This is not a security mechanism. The PIN sits in the DOM and the unlock is held in `sessionStorage`, so anyone with developer tools can bypass it. The component is editorial signalling for review audiences (a "wet paint" sign). For real access control, gate the page at the edge with a service like Cloudflare Access.
+> **Note:** This is not a security mechanism. The PIN sits in the DOM and the unlock is held in `sessionStorage`, so anyone with developer tools can bypass it. The component is editorial signalling for review audiences only.
 
 ## Examples
 
-The static preview below shows the modal panel inline so theme, copy, and RTL can be reviewed without locking the Storybook canvas. To see the real body-level overlay behaviour, run the **Live demo** story.
+The static preview below shows the modal panel inline so theme and copy can be reviewed without locking the Storybook canvas. To see the real body-level overlay behaviour, run the **Live demo** story.
 
 <Canvas of={PreviewAccessStories.Default} />
 
@@ -27,15 +27,15 @@ Use the locale toolbar to preview the modal in other languages, including Arabic
 
 ## When to use
 
-- Sharing in-progress dashboards or content with reviewers before public launch
-- Hiding partly-built pages from search engines and casual visitors
+- Sharing unfinished dashboards or content with reviewers before public launch
+- Hiding unfinished pages from search engines and casual visitors
 - Marking a whole product preview (for example, a DELTA preview site) with a single shared PIN
 
-For real access control, use server-side authentication. This component is for editorial signalling only.
+For real access control, gate the page at the edge with a service like Cloudflare Access. This component is for editorial signalling only.
 
 ## Vanilla HTML usage
 
-Three things in the page:
+You need three things in the page:
 
 ```html
 <!-- 1. CSS in <head> -->
@@ -48,9 +48,9 @@ Three things in the page:
 <script type="module" src="https://assets.undrr.org/static/mangrove/1.6.0/js/preview-access.js"></script>
 ```
 
-That is the minimum. With nothing else set, the gate uses the default PIN `5498`, default UNDRR copy, and the contact link points to `undrr.org/contact-us`.
+That is the minimum: with nothing else set, the gate uses the default PIN `5498`, default UNDRR copy, and the contact link points to `undrr.org/contact-us`.
 
-> **Tip:** Place the trigger as the first child of `<body>` so any content above it does not get a chance to paint before the gate's CSS rule fires.
+> **Tip:** Place the trigger as the first child of `<body>` so any content above it does not paint before the gate hides it.
 
 ### Realistic example
 
@@ -72,7 +72,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 | `data-mg-preview-access` | — | Presence activates the gate. No value needed. |
 | `data-mg-preview-pin` | `5498` | The PIN that unlocks the page. |
 | `data-mg-preview-id` | `location.pathname` | Scope key for the `sessionStorage` unlock. Set the same id on multiple pages to share an unlock across them. |
-| `data-mg-preview-eyebrow` | `UNDRR · Preview` | Small uppercase label above the title. Useful for naming the product. |
+| `data-mg-preview-eyebrow` | `UNDRR · Preview` | Small label above the title. Useful for naming the product. |
 | `data-mg-preview-title` | `Preview access required` | Modal heading. |
 | `data-mg-preview-message` | Generic UNDRR preview copy | Body paragraph explaining what the page is and how to get in. |
 | `data-mg-preview-contact-url` | `https://www.undrr.org/contact-us` | Where the help link goes. |
@@ -89,7 +89,7 @@ All attributes go on the trigger element. All optional except the bare `data-mg-
 | `mg-preview-access--unlocked` | trigger `<div>` | Set on success; releases the gate's CSS rule |
 | `mg-preview-access__overlay` | injected `<div>` | Fixed full-viewport scrim with the modal centred inside |
 | `mg-preview-access__modal` | injected `<div>` | The modal panel |
-| `mg-preview-access__eyebrow` | `<p>` | Small uppercase product label |
+| `mg-preview-access__eyebrow` | `<p>` | Small product label above the title |
 | `mg-preview-access__title` | `<h1>` | Modal heading |
 | `mg-preview-access__body` | `<p>` | Modal body copy |
 | `mg-preview-access__form` | `<form>` | Form wrapper |
@@ -183,24 +183,26 @@ The component supports RTL automatically when `dir="rtl"` and `lang="ar"` are se
 
 ## Implementation notes
 
-> **Implementation note (for contributors):** This section explains the design decisions behind the gate. Skip it if you are integrating the component; it exists to prevent future contributors from "fixing" things that were intentional.
+> **Implementation note (for contributors):** Design decisions behind the gate. These choices were intentional — read before "fixing" them.
 
-**CSS-first anti-flash via `:has()`.** The gate hides page content with a CSS rule, not JavaScript. The rule is `body:has([data-mg-preview-access]:not(.mg-preview-access--unlocked)) > *:not(.mg-preview-access__overlay) { visibility: hidden }`. The moment the parser sees the trigger element, the rule fires and everything else is hidden. There is no flash of unstyled content and no race with deferred scripts. The cost is that the trigger should be the first child of `<body>` so any content above it does not get to paint first. `:has()` is universally supported since late 2023.
+**CSS-first anti-flash via `:has()`.** The gate hides page content with a CSS rule, not JavaScript. The rule is `body:has([data-mg-preview-access]:not(.mg-preview-access--unlocked)) > *:not(.mg-preview-access__overlay) { visibility: hidden }`. The moment the parser sees the trigger element, the rule applies and the rest of the page is hidden. There is no flash of unstyled content and no race with deferred scripts. The cost is that the trigger should be the first child of `<body>` so any content above it does not paint first. `:has()` is supported in all current evergreen browsers since late 2023.
 
 **`visibility: hidden`, not `display: none`.** Layout is preserved. The page stays in its final shape behind the modal, and on unlock there is no reflow. Side effect: images and iframes still load in the background, so the page is ready to read the moment the gate drops.
 
-**`inert` on body siblings.** While the modal is up, every direct child of `<body>` except the overlay gets `inert` and `aria-hidden="true"`. That gives a focus trap, screen-reader hiding, and pointer-event blocking in one attribute. No focus-trap library is needed.
+**`inert` on body siblings.** While the modal is up, every direct child of `<body>` except the overlay gets `inert`. That gives a focus trap, assistive-technology hiding, and pointer-event blocking in one attribute. No focus-trap library is needed. ARIA 1.2 says `aria-hidden` is redundant when `inert` is set, so `aria-hidden` is intentionally omitted to avoid an axe-flagged "focused element inside aria-hidden ancestor" pattern.
 
 **Session persistence.** Once unlocked, the gate sets `sessionStorage["mg-preview-access:<id>"] = "unlocked"`. The id defaults to `location.pathname` but is overridable via `data-mg-preview-id`, so a single PIN can cover a whole product preview (set the same id on every page in the preview).
 
-**Bespoke modal shell.** Mangrove does not yet have a dialog/modal primitive. The styles use Mangrove tokens where they exist (`$mg-z-index-modal`, `$mg-color-interactive`, `$mg-spacing-*`, `$mg-font-family-headings`, the Arabic font swap via `:lang(ar)`) but the panel itself is bespoke. When a modal primitive lands in Mangrove, this component should be refactored to consume it.
+**Contact URL allow-list.** The runtime validates `data-mg-preview-contact-url` against an `http:`/`https:`/`mailto:` allow-list before rendering the link. Anything else (for example, `javascript:`) is replaced with the default UNDRR contact page. This is defence-in-depth in case a Drupal template ever interpolates an unsanitised editor field into the attribute.
+
+**Bespoke modal shell.** Mangrove does not yet have a dialog/modal primitive. The styles use Mangrove tokens (`$mg-z-index-modal`, `$mg-color-modal-scrim`, `$mg-color-interactive`, `$mg-spacing-*`, `$mg-font-family-headings`, the Arabic font swap via `:lang(ar)`) but the panel itself is bespoke. When a modal primitive lands in Mangrove, this component should be refactored to consume it.
 
 ## Known limitations
 
 - **Single trigger per page.** The script honours one trigger per page (the first match). Multi-zone gating (a preview block inside an otherwise public page) is a different pattern.
 - **No Escape-to-close.** Deliberate. The gate should hold until a PIN is entered. A dismissible variant would be a separate prop.
 - **`:has()` is the entire anti-flash strategy.** If support for an older browser is ever needed, add a one-line inline `<script>` in `<head>` that sets a class on `<html>` and wire the CSS rule to that class as well.
-- **PIN in the DOM.** Not access control. Bears repeating because someone always asks.
+- **PIN in the DOM.** This is editorial signalling, not access control. Anyone with developer tools can read the PIN and bypass the gate.
 
 ## Changelog
 

--- a/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          'A soft preview gate for unfinished UNDRR pages. Drop `<div data-mg-preview-access>` into a page and a PIN-prompt modal covers the content until someone enters the right code. Vanilla JS, body-level — see the docs tab for the HTML usage. Not a security mechanism: the PIN sits in the DOM.',
+          'Page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Vanilla JS, body-level. Not a security mechanism: the PIN sits in the DOM. See the Docs tab for the HTML usage.',
       },
     },
   },

--- a/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react';
+import PreviewAccess from './PreviewAccess';
+import {
+  mgPreviewAccess,
+  mgPreviewAccessDestroy,
+} from '../../assets/js/preview-access';
+
+export default {
+  title: 'Components/Preview access',
+  component: PreviewAccess,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A soft preview gate for unfinished UNDRR pages. Drop `<div data-mg-preview-access>` into a page and a PIN-prompt modal covers the content until someone enters the right code. Vanilla JS, body-level — see the docs tab for the HTML usage. Not a security mechanism: the PIN sits in the DOM.',
+      },
+    },
+  },
+};
+
+/**
+ * Static visual preview of the modal panel. Renders the markup without
+ * activating the body-level gate, so the docs page is not locked down.
+ */
+export const Default = {
+  args: {
+    eyebrow: 'UNDRR · Preview',
+    title: 'Preview access required',
+    message:
+      'This page is in preview and is not yet ready for general distribution. Please enter the access PIN provided by UNDRR to continue.',
+    pin: '5498',
+    contactUrl: 'https://www.undrr.org/contact-us',
+    contactLabel: 'Need help? Contact UNDRR',
+  },
+};
+
+/**
+ * Override copy for a specific product preview (DELTA Resilience example).
+ */
+export const ProductBranded = {
+  name: 'Product-branded copy',
+  args: {
+    eyebrow: 'DELTA Resilience · Preview',
+    title: 'This page is a preview',
+    message:
+      'The DELTA Resilience country dashboard is in active development and is not yet ready for public review. Enter the preview PIN to continue, or contact UNDRR if you need access.',
+    pin: '5498',
+    id: 'delta-2026-preview',
+    contactUrl: 'https://www.undrr.org/contact-us',
+    contactLabel: 'Need help? Contact UNDRR',
+  },
+};
+
+/**
+ * RTL preview with Arabic copy. Verifies the Arabic font swap and direction.
+ */
+export const ArabicRtl = {
+  name: 'Arabic (RTL)',
+  render: args => (
+    <div lang="ar" dir="rtl">
+      <PreviewAccess {...args} />
+    </div>
+  ),
+  args: {
+    eyebrow: 'UNDRR · معاينة',
+    title: 'يلزم رمز الوصول للمعاينة',
+    message:
+      'هذه الصفحة قيد المعاينة وغير جاهزة للتوزيع العام بعد. يرجى إدخال رمز الوصول المقدم من UNDRR للمتابعة.',
+    pinLabel: 'رمز الوصول',
+    submitLabel: 'فتح',
+    contactUrl: 'https://www.undrr.org/contact-us',
+    contactLabel: 'هل تحتاج إلى مساعدة؟ تواصل مع UNDRR',
+  },
+};
+
+/**
+ * Live demo. Activates the real body-level gate inside an iframe-scoped
+ * Storybook canvas. Reset to relock for testing the unlock flow again.
+ */
+export const LiveDemo = {
+  name: 'Live demo (activates the gate)',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Activates the actual body-level gate. The overlay covers the Storybook canvas iframe; a successful PIN entry persists for the session. Use the Reset button to clear the unlock and try again.',
+      },
+    },
+  },
+  render: () => {
+    const [armed, setArmed] = useState(false);
+    const id = 'storybook-live-demo';
+
+    useEffect(() => {
+      if (!armed) return undefined;
+      const gate = document.createElement('div');
+      gate.setAttribute('data-mg-preview-access', '');
+      gate.setAttribute('data-mg-preview-id', id);
+      gate.setAttribute('data-mg-preview-pin', '5498');
+      gate.setAttribute('data-mg-preview-title', 'This page is a preview');
+      gate.setAttribute(
+        'data-mg-preview-message',
+        'Enter the preview PIN (default: 5498) to continue.'
+      );
+      document.body.insertBefore(gate, document.body.firstChild);
+      mgPreviewAccess([gate]);
+      return () => {
+        mgPreviewAccessDestroy(gate);
+        gate.remove();
+      };
+    }, [armed]);
+
+    const reset = () => {
+      try {
+        sessionStorage.removeItem(`mg-preview-access:${id}`);
+      } catch (e) {
+        // best effort
+      }
+      setArmed(false);
+    };
+
+    return (
+      <div style={{ padding: '1rem' }}>
+        <p>
+          The gate covers the entire canvas when activated. PIN:{' '}
+          <code>5498</code>.
+        </p>
+        <button
+          type="button"
+          onClick={() => setArmed(true)}
+          style={{ marginInlineEnd: '0.5rem' }}
+          disabled={armed}
+        >
+          Activate gate
+        </button>
+        <button type="button" onClick={reset}>
+          Reset session
+        </button>
+      </div>
+    );
+  },
+};

--- a/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
@@ -12,7 +12,7 @@ export default {
     docs: {
       description: {
         component:
-          'Page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Vanilla JS, body-level. Not a security mechanism: the PIN sits in the DOM. See the Docs tab for the HTML usage.',
+          'Page-level gate that hides an unfinished page behind a PIN-prompt modal until a reviewer enters the right code. Vanilla JS only — not a security mechanism, since the PIN sits in the DOM. See the Docs tab for HTML usage.',
       },
     },
   },

--- a/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
+++ b/stories/Components/PreviewAccess/PreviewAccess.stories.jsx
@@ -52,28 +52,6 @@ export const ProductBranded = {
 };
 
 /**
- * RTL preview with Arabic copy. Verifies the Arabic font swap and direction.
- */
-export const ArabicRtl = {
-  name: 'Arabic (RTL)',
-  render: args => (
-    <div lang="ar" dir="rtl">
-      <PreviewAccess {...args} />
-    </div>
-  ),
-  args: {
-    eyebrow: 'UNDRR · معاينة',
-    title: 'يلزم رمز الوصول للمعاينة',
-    message:
-      'هذه الصفحة قيد المعاينة وغير جاهزة للتوزيع العام بعد. يرجى إدخال رمز الوصول المقدم من UNDRR للمتابعة.',
-    pinLabel: 'رمز الوصول',
-    submitLabel: 'فتح',
-    contactUrl: 'https://www.undrr.org/contact-us',
-    contactLabel: 'هل تحتاج إلى مساعدة؟ تواصل مع UNDRR',
-  },
-};
-
-/**
  * Live demo. Activates the real body-level gate inside an iframe-scoped
  * Storybook canvas. Reset to relock for testing the unlock flow again.
  */

--- a/stories/Components/PreviewAccess/__tests__/PreviewAccess.test.jsx
+++ b/stories/Components/PreviewAccess/__tests__/PreviewAccess.test.jsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import PreviewAccess from '../PreviewAccess';
+import {
+  mgPreviewAccess,
+  mgPreviewAccessDestroy,
+} from '../../../assets/js/preview-access';
+
+beforeAll(() => {
+  // jsdom lacks rAF in some environments; route it to a microtask.
+  if (typeof window.requestAnimationFrame !== 'function') {
+    window.requestAnimationFrame = cb => setTimeout(cb, 0);
+  }
+});
+
+afterEach(() => {
+  // Clean up any lingering overlays and unlocks between tests.
+  document.body.innerHTML = '';
+  try {
+    sessionStorage.clear();
+  } catch (e) {
+    // ignore
+  }
+});
+
+describe('PreviewAccess (static preview)', () => {
+  it('renders the modal markup with default copy', () => {
+    render(<PreviewAccess />);
+    expect(screen.getByText('Preview access required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Access PIN')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Unlock' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Need help/i })).toHaveAttribute(
+      'href',
+      'https://www.undrr.org/contact-us',
+    );
+  });
+
+  it('renders custom copy from props', () => {
+    render(
+      <PreviewAccess
+        eyebrow="DELTA · Preview"
+        title="This page is a preview"
+        message="Custom body copy."
+        contactLabel="Email DELTA team"
+      />,
+    );
+    expect(screen.getByText('DELTA · Preview')).toBeInTheDocument();
+    expect(screen.getByText('This page is a preview')).toBeInTheDocument();
+    expect(screen.getByText('Custom body copy.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Email DELTA team' })).toBeInTheDocument();
+  });
+
+  it('has no axe violations in the static preview', async () => {
+    const { container } = render(<PreviewAccess />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+
+describe('mgPreviewAccess (vanilla runtime)', () => {
+  function mountGate(attrs = {}) {
+    const gate = document.createElement('div');
+    gate.setAttribute('data-mg-preview-access', '');
+    Object.entries(attrs).forEach(([k, v]) => gate.setAttribute(k, v));
+    document.body.appendChild(gate);
+    return gate;
+  }
+
+  it('builds an overlay with the configured copy', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-1',
+      'data-mg-preview-title': 'Custom title',
+      'data-mg-preview-eyebrow': 'Custom · Preview',
+    });
+    mgPreviewAccess([gate]);
+    const overlay = document.querySelector('.mg-preview-access__overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay.getAttribute('role')).toBe('dialog');
+    expect(overlay.getAttribute('aria-modal')).toBe('true');
+    expect(
+      overlay.querySelector('.mg-preview-access__title').textContent,
+    ).toBe('Custom title');
+    expect(
+      overlay.querySelector('.mg-preview-access__eyebrow').textContent,
+    ).toBe('Custom · Preview');
+  });
+
+  it('marks the gate unlocked when the correct PIN is submitted', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-unlock',
+      'data-mg-preview-pin': '1234',
+    });
+    mgPreviewAccess([gate]);
+    const overlay = document.querySelector('.mg-preview-access__overlay');
+    const input = overlay.querySelector('.mg-preview-access__input');
+    const form = overlay.querySelector('.mg-preview-access__form');
+
+    input.value = '1234';
+    fireEvent.submit(form);
+
+    expect(gate.classList.contains('mg-preview-access--unlocked')).toBe(true);
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
+    expect(sessionStorage.getItem('mg-preview-access:test-unlock')).toBe(
+      'unlocked',
+    );
+  });
+
+  it('shows an error and keeps the overlay on a wrong PIN', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-wrong',
+      'data-mg-preview-pin': '1234',
+    });
+    mgPreviewAccess([gate]);
+    const overlay = document.querySelector('.mg-preview-access__overlay');
+    const input = overlay.querySelector('.mg-preview-access__input');
+    const form = overlay.querySelector('.mg-preview-access__form');
+    const error = overlay.querySelector('.mg-preview-access__error');
+
+    input.value = 'wrong';
+    fireEvent.submit(form);
+
+    expect(error.textContent).toBe('That PIN is not correct. Please try again.');
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+    expect(gate.classList.contains('mg-preview-access--unlocked')).toBe(false);
+  });
+
+  it('clears the error when the user edits the input', () => {
+    const gate = mountGate({ 'data-mg-preview-id': 'test-clear', 'data-mg-preview-pin': '1' });
+    mgPreviewAccess([gate]);
+    const overlay = document.querySelector('.mg-preview-access__overlay');
+    const input = overlay.querySelector('.mg-preview-access__input');
+    const form = overlay.querySelector('.mg-preview-access__form');
+    const error = overlay.querySelector('.mg-preview-access__error');
+
+    input.value = '0';
+    fireEvent.submit(form);
+    expect(error.textContent).not.toBe('');
+
+    fireEvent.input(input, { target: { value: '01' } });
+    expect(error.textContent).toBe('');
+  });
+
+  it('skips the modal when sessionStorage already has an unlock', () => {
+    sessionStorage.setItem('mg-preview-access:test-skip', 'unlocked');
+    const gate = mountGate({ 'data-mg-preview-id': 'test-skip' });
+    mgPreviewAccess([gate]);
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
+    expect(gate.classList.contains('mg-preview-access--unlocked')).toBe(true);
+  });
+
+  it('applies inert and aria-hidden to body siblings while the overlay is up', () => {
+    const sibling = document.createElement('main');
+    document.body.appendChild(sibling);
+    const gate = mountGate({ 'data-mg-preview-id': 'test-inert', 'data-mg-preview-pin': '1' });
+    mgPreviewAccess([gate]);
+    expect(sibling.hasAttribute('inert')).toBe(true);
+    expect(sibling.getAttribute('aria-hidden')).toBe('true');
+
+    const form = document.querySelector('.mg-preview-access__form');
+    document.querySelector('.mg-preview-access__input').value = '1';
+    fireEvent.submit(form);
+
+    expect(sibling.hasAttribute('inert')).toBe(false);
+    expect(sibling.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('mgPreviewAccessDestroy removes the overlay and clears init', () => {
+    const gate = mountGate({ 'data-mg-preview-id': 'test-destroy' });
+    mgPreviewAccess([gate]);
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+
+    act(() => mgPreviewAccessDestroy(gate));
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
+    expect(gate.dataset.mgPreviewAccessInitialized).toBeUndefined();
+  });
+
+  it('does not auto-init an element flagged with skip-auto-init', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-skip-auto',
+      'data-mg-preview-access-skip-auto-init': '',
+    });
+    // Auto-init path: no scope passed.
+    mgPreviewAccess();
+    // Auto-init queries the first matching element; with the skip flag, no
+    // overlay should be created.
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
+    // Explicit init still works.
+    mgPreviewAccess([gate]);
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+  });
+});

--- a/stories/Components/PreviewAccess/__tests__/PreviewAccess.test.jsx
+++ b/stories/Components/PreviewAccess/__tests__/PreviewAccess.test.jsx
@@ -8,14 +8,12 @@ import {
 } from '../../../assets/js/preview-access';
 
 beforeAll(() => {
-  // jsdom lacks rAF in some environments; route it to a microtask.
   if (typeof window.requestAnimationFrame !== 'function') {
     window.requestAnimationFrame = cb => setTimeout(cb, 0);
   }
 });
 
 afterEach(() => {
-  // Clean up any lingering overlays and unlocks between tests.
   document.body.innerHTML = '';
   try {
     sessionStorage.clear();
@@ -34,6 +32,22 @@ describe('PreviewAccess (static preview)', () => {
       'href',
       'https://www.undrr.org/contact-us',
     );
+  });
+
+  it('uses h2 (not h1) for the modal title to avoid host-page heading conflicts', () => {
+    render(<PreviewAccess title="Preview" />);
+    const heading = screen.getByText('Preview');
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('places dialog semantics on the modal panel, not a wrapper scrim', () => {
+    const { container } = render(<PreviewAccess />);
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog).toHaveClass('mg-preview-access__modal');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    expect(dialog).toHaveAttribute('aria-describedby');
   });
 
   it('renders custom copy from props', () => {
@@ -74,16 +88,27 @@ describe('mgPreviewAccess (vanilla runtime)', () => {
       'data-mg-preview-eyebrow': 'Custom · Preview',
     });
     mgPreviewAccess([gate]);
-    const overlay = document.querySelector('.mg-preview-access__overlay');
-    expect(overlay).toBeTruthy();
-    expect(overlay.getAttribute('role')).toBe('dialog');
-    expect(overlay.getAttribute('aria-modal')).toBe('true');
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog).toHaveClass('mg-preview-access__modal');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
     expect(
-      overlay.querySelector('.mg-preview-access__title').textContent,
+      dialog.querySelector('.mg-preview-access__title').textContent,
     ).toBe('Custom title');
     expect(
-      overlay.querySelector('.mg-preview-access__eyebrow').textContent,
+      dialog.querySelector('.mg-preview-access__title').tagName,
+    ).toBe('H2');
+    expect(
+      dialog.querySelector('.mg-preview-access__eyebrow').textContent,
     ).toBe('Custom · Preview');
+  });
+
+  it('uses role=alert without aria-live on the error region', () => {
+    const gate = mountGate({ 'data-mg-preview-id': 'test-alert' });
+    mgPreviewAccess([gate]);
+    const error = document.querySelector('.mg-preview-access__error');
+    expect(error.getAttribute('role')).toBe('alert');
+    expect(error.hasAttribute('aria-live')).toBe(false);
   });
 
   it('marks the gate unlocked when the correct PIN is submitted', () => {
@@ -125,7 +150,7 @@ describe('mgPreviewAccess (vanilla runtime)', () => {
     expect(gate.classList.contains('mg-preview-access--unlocked')).toBe(false);
   });
 
-  it('clears the error when the user edits the input', () => {
+  it('clears the error when the user types a non-empty value', () => {
     const gate = mountGate({ 'data-mg-preview-id': 'test-clear', 'data-mg-preview-pin': '1' });
     mgPreviewAccess([gate]);
     const overlay = document.querySelector('.mg-preview-access__overlay');
@@ -137,6 +162,7 @@ describe('mgPreviewAccess (vanilla runtime)', () => {
     fireEvent.submit(form);
     expect(error.textContent).not.toBe('');
 
+    input.value = '01';
     fireEvent.input(input, { target: { value: '01' } });
     expect(error.textContent).toBe('');
   });
@@ -149,20 +175,35 @@ describe('mgPreviewAccess (vanilla runtime)', () => {
     expect(gate.classList.contains('mg-preview-access--unlocked')).toBe(true);
   });
 
-  it('applies inert and aria-hidden to body siblings while the overlay is up', () => {
+  it('still mounts the overlay when sessionStorage throws (private mode)', () => {
+    const original = Storage.prototype.getItem;
+    Storage.prototype.getItem = function throwingGetItem() {
+      throw new Error('SecurityError: private mode');
+    };
+    try {
+      const gate = mountGate({ 'data-mg-preview-id': 'test-storage-err' });
+      mgPreviewAccess([gate]);
+      expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+    } finally {
+      Storage.prototype.getItem = original;
+    }
+  });
+
+  it('applies inert (without aria-hidden) to body siblings while the overlay is up', () => {
     const sibling = document.createElement('main');
     document.body.appendChild(sibling);
     const gate = mountGate({ 'data-mg-preview-id': 'test-inert', 'data-mg-preview-pin': '1' });
     mgPreviewAccess([gate]);
     expect(sibling.hasAttribute('inert')).toBe(true);
-    expect(sibling.getAttribute('aria-hidden')).toBe('true');
+    // ARIA 1.2: aria-hidden is redundant when inert is set; we deliberately
+    // don't write it. axe also flags aria-hidden on focused-ancestor.
+    expect(sibling.hasAttribute('aria-hidden')).toBe(false);
 
     const form = document.querySelector('.mg-preview-access__form');
     document.querySelector('.mg-preview-access__input').value = '1';
     fireEvent.submit(form);
 
     expect(sibling.hasAttribute('inert')).toBe(false);
-    expect(sibling.hasAttribute('aria-hidden')).toBe(false);
   });
 
   it('mgPreviewAccessDestroy removes the overlay and clears init', () => {
@@ -180,13 +221,62 @@ describe('mgPreviewAccess (vanilla runtime)', () => {
       'data-mg-preview-id': 'test-skip-auto',
       'data-mg-preview-access-skip-auto-init': '',
     });
-    // Auto-init path: no scope passed.
     mgPreviewAccess();
-    // Auto-init queries the first matching element; with the skip flag, no
-    // overlay should be created.
     expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
-    // Explicit init still works.
     mgPreviewAccess([gate]);
     expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+  });
+
+  it('is idempotent — initialising the same gate twice does not stack overlays', () => {
+    const gate = mountGate({ 'data-mg-preview-id': 'test-idem' });
+    mgPreviewAccess([gate]);
+    mgPreviewAccess([gate]);
+    expect(document.querySelectorAll('.mg-preview-access__overlay').length).toBe(1);
+  });
+
+  it('rejects javascript: contact URLs and falls back to the UNDRR contact page', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-xss',
+      // eslint-disable-next-line no-script-url
+      'data-mg-preview-contact-url': 'javascript:alert(1)',
+    });
+    mgPreviewAccess([gate]);
+    const link = document.querySelector('.mg-preview-access__contact a');
+    expect(link.getAttribute('href')).toBe('https://www.undrr.org/contact-us');
+  });
+
+  it('rejects data: contact URLs', () => {
+    const gate = mountGate({
+      'data-mg-preview-id': 'test-data-uri',
+      'data-mg-preview-contact-url': 'data:text/html,<script>alert(1)</script>',
+    });
+    mgPreviewAccess([gate]);
+    const link = document.querySelector('.mg-preview-access__contact a');
+    expect(link.getAttribute('href')).toBe('https://www.undrr.org/contact-us');
+  });
+
+  it('accepts http, https, and mailto contact URLs', () => {
+    ['https://example.org/help', 'http://example.org/help', 'mailto:help@undrr.org'].forEach(
+      (url, i) => {
+        document.body.innerHTML = '';
+        const gate = mountGate({
+          'data-mg-preview-id': `test-scheme-${i}`,
+          'data-mg-preview-contact-url': url,
+        });
+        mgPreviewAccess([gate]);
+        const link = document.querySelector('.mg-preview-access__contact a');
+        expect(link.getAttribute('href')).toBe(url);
+      },
+    );
+  });
+});
+
+describe('PreviewAccess (live mode)', () => {
+  it('mounts the overlay on document.body when live and removes it on unmount', () => {
+    const { unmount } = render(<PreviewAccess live id="rtl-live" pin="42" />);
+    // Overlay is appended to document.body, not the React tree.
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeTruthy();
+    unmount();
+    expect(document.querySelector('.mg-preview-access__overlay')).toBeNull();
   });
 });

--- a/stories/Components/PreviewAccess/preview-access.scss
+++ b/stories/Components/PreviewAccess/preview-access.scss
@@ -1,0 +1,171 @@
+// Preview access
+// Soft preview gate for unfinished UNDRR pages. CSS hides the page on parse
+// (via :has()); the runtime layers a modal over it and asks for a PIN.
+// Not a security mechanism — see preview-access.js header.
+
+// 1. The gate. While a [data-mg-preview-access] element exists in the document
+//    and has not been marked unlocked, hide all direct children of <body>
+//    except the overlay. visibility (not display) preserves layout so the
+//    page does not reflow on unlock.
+body:has([data-mg-preview-access]:not(.mg-preview-access--unlocked))
+  > *:not(.mg-preview-access__overlay) {
+  visibility: hidden !important;
+}
+
+html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
+  overflow: hidden;
+}
+
+.mg-preview-access {
+  // Trigger element itself is invisible; presence is the activation signal.
+  &__overlay {
+    position: fixed;
+    inset: 0;
+    z-index: $mg-z-index-modal;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: $mg-spacing-200;
+    background: rgb(13 30 50 / 0.92);
+
+    // Re-assert visibility in case the gate rule's specificity ever shifts.
+    visibility: visible !important;
+  }
+
+  &__modal {
+    width: 100%;
+    max-width: mg-rem(480);
+    padding: $mg-spacing-350;
+    background: $mg-color-white;
+    border-radius: mg-rem(4);
+    border-top: mg-rem(4) solid $mg-color-interactive;
+    box-shadow: 0 mg-rem(8) mg-rem(32) rgb(0 0 0 / 0.25);
+  }
+
+  &__eyebrow {
+    margin: 0 0 $mg-spacing-50;
+    font-family: $mg-font-family-headings;
+    font-size: $mg-font-size-200;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: $mg-color-interactive;
+  }
+
+  &__title {
+    margin: 0 0 $mg-spacing-150;
+    font-family: $mg-font-family-headings;
+    font-size: $mg-font-size-500;
+    line-height: 1.2;
+    color: $mg-color-neutral-800;
+  }
+
+  &__body {
+    margin: 0 0 $mg-spacing-250;
+    font-family: $mg-font-family;
+    font-size: $mg-font-size-300;
+    line-height: 1.5;
+    color: $mg-color-neutral-700;
+  }
+
+  &__form {
+    margin: 0;
+  }
+
+  &__label {
+    display: block;
+    margin: 0 0 mg-rem(6);
+    font-family: $mg-font-family-headings;
+    font-size: $mg-font-size-250;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: $mg-color-neutral-700;
+  }
+
+  &__field {
+    display: flex;
+    gap: $mg-spacing-50;
+    margin: 0 0 $mg-spacing-50;
+  }
+
+  &__input {
+    flex: 1;
+    min-width: 0;
+    padding: mg-rem(10) mg-rem(12);
+    font-family: $mg-font-family;
+    font-size: $mg-font-size-300;
+    color: $mg-color-neutral-800;
+    background: $mg-color-white;
+    border: 1px solid $mg-color-neutral-200;
+    border-radius: mg-rem(4);
+
+    &:focus {
+      outline: 2px solid $mg-color-interactive;
+      outline-offset: 2px;
+      border-color: $mg-color-interactive;
+    }
+  }
+
+  &__submit {
+    padding: mg-rem(10) $mg-spacing-200;
+    font-family: $mg-font-family-headings;
+    font-size: $mg-font-size-250;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: $mg-color-white;
+    background: $mg-color-interactive;
+    border: 0;
+    border-radius: mg-rem(4);
+    cursor: pointer;
+
+    &:hover {
+      background: $mg-color-interactive-active;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $mg-color-interactive;
+      outline-offset: 2px;
+    }
+  }
+
+  &__error {
+    min-height: $mg-spacing-200;
+    margin: 0 0 $mg-spacing-150;
+    font-family: $mg-font-family;
+    font-size: $mg-font-size-250;
+    color: $mg-color-red-900;
+  }
+
+  &__contact {
+    margin: 0;
+    padding-top: $mg-spacing-150;
+    font-family: $mg-font-family;
+    font-size: $mg-font-size-250;
+    color: $mg-color-neutral-600;
+    border-top: 1px solid $mg-color-neutral-100;
+
+    a {
+      color: $mg-color-interactive;
+      text-decoration: underline;
+    }
+  }
+}
+
+// RTL / Arabic font swap. Roboto Condensed has no Arabic glyph coverage,
+// so swap heading/UI families when lang="ar" is set on the page.
+:lang(ar) {
+  .mg-preview-access__eyebrow,
+  .mg-preview-access__title,
+  .mg-preview-access__label,
+  .mg-preview-access__submit {
+    font-family: $mg-font-family-arabic-headings;
+  }
+
+  .mg-preview-access__body,
+  .mg-preview-access__error,
+  .mg-preview-access__contact {
+    font-family: $mg-font-family-arabic-body;
+  }
+}

--- a/stories/Components/PreviewAccess/preview-access.scss
+++ b/stories/Components/PreviewAccess/preview-access.scss
@@ -45,10 +45,8 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
   &__eyebrow {
     margin: 0 0 $mg-spacing-50;
     font-family: $mg-font-family-headings;
-    font-size: $mg-font-size-200;
+    font-size: $mg-font-size-250;
     font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
     color: $mg-color-interactive;
   }
 
@@ -76,10 +74,8 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
     display: block;
     margin: 0 0 mg-rem(6);
     font-family: $mg-font-family-headings;
-    font-size: $mg-font-size-250;
+    font-size: $mg-font-size-300;
     font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
     color: $mg-color-neutral-700;
   }
 
@@ -110,10 +106,8 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
   &__submit {
     padding: mg-rem(10) $mg-spacing-200;
     font-family: $mg-font-family-headings;
-    font-size: $mg-font-size-250;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    font-size: $mg-font-size-300;
+    font-weight: 600;
     color: $mg-color-white;
     background: $mg-color-interactive;
     border: 0;

--- a/stories/Components/PreviewAccess/preview-access.scss
+++ b/stories/Components/PreviewAccess/preview-access.scss
@@ -1,7 +1,7 @@
 // Preview access
 // Soft preview gate for unfinished UNDRR pages. CSS hides the page on parse
 // (via :has()); the runtime layers a modal over it and asks for a PIN.
-// Not a security mechanism — see preview-access.js header.
+// Not a security mechanism (see preview-access.js header).
 
 // 1. The gate. While a [data-mg-preview-access] element exists in the document
 //    and has not been marked unlocked, hide all direct children of <body>
@@ -17,7 +17,7 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
 }
 
 .mg-preview-access {
-  // Trigger element itself is invisible; presence is the activation signal.
+  // The trigger element itself is invisible; presence is the activation signal.
   &__overlay {
     position: fixed;
     inset: 0;
@@ -26,9 +26,10 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
     align-items: center;
     justify-content: center;
     padding: $mg-spacing-200;
-    background: rgb(13 30 50 / 0.92);
+    background: $mg-color-modal-scrim;
 
-    // Re-assert visibility in case the gate rule's specificity ever shifts.
+    // Re-assert visibility against the gate rule above, which uses !important
+    // to win over any component-level visibility overrides on body siblings.
     visibility: visible !important;
   }
 
@@ -37,17 +38,21 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
     max-width: mg-rem(480);
     padding: $mg-spacing-350;
     background: $mg-color-white;
-    border-radius: mg-rem(4);
+
+    // Sharp-cornered to match Mangrove chrome (Hero, PageHeader, Cards).
+    border-radius: 0;
     border-top: mg-rem(4) solid $mg-color-interactive;
     box-shadow: 0 mg-rem(8) mg-rem(32) rgb(0 0 0 / 0.25);
   }
 
+  // Eyebrow uses a neutral colour so it passes 4.5:1 across all five themes.
+  // Brand identity is carried by the top accent border and the submit button.
   &__eyebrow {
     margin: 0 0 $mg-spacing-50;
     font-family: $mg-font-family-headings;
     font-size: $mg-font-size-250;
     font-weight: 700;
-    color: $mg-color-interactive;
+    color: $mg-color-neutral-700;
   }
 
   &__title {
@@ -72,7 +77,7 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
 
   &__label {
     display: block;
-    margin: 0 0 mg-rem(6);
+    margin: 0 0 $mg-spacing-50;
     font-family: $mg-font-family-headings;
     font-size: $mg-font-size-300;
     font-weight: 700;
@@ -88,38 +93,42 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
   &__input {
     flex: 1;
     min-width: 0;
-    padding: mg-rem(10) mg-rem(12);
+    padding: $mg-spacing-100 $mg-spacing-150;
     font-family: $mg-font-family;
     font-size: $mg-font-size-300;
     color: $mg-color-neutral-800;
     background: $mg-color-white;
     border: 1px solid $mg-color-neutral-200;
-    border-radius: mg-rem(4);
+    border-radius: 0;
 
     &:focus {
-      outline: 2px solid $mg-color-interactive;
+      outline: 2px solid $mg-color-form-focus;
       outline-offset: 2px;
-      border-color: $mg-color-interactive;
+      border-color: $mg-color-form-focus;
     }
   }
 
   &__submit {
-    padding: mg-rem(10) $mg-spacing-200;
+    padding: $mg-spacing-100 $mg-spacing-200;
     font-family: $mg-font-family-headings;
     font-size: $mg-font-size-300;
     font-weight: 600;
     color: $mg-color-white;
     background: $mg-color-interactive;
     border: 0;
-    border-radius: mg-rem(4);
+    border-radius: 0;
     cursor: pointer;
 
+    // $mg-color-interactive-active equals $mg-color-interactive in several
+    // themes (PW, IRP, MCR, DELTA), so layer a brightness shift to ensure
+    // the hover affordance is visible everywhere.
     &:hover {
       background: $mg-color-interactive-active;
+      filter: brightness(0.92);
     }
 
     &:focus-visible {
-      outline: 2px solid $mg-color-interactive;
+      outline: 2px solid $mg-color-form-focus;
       outline-offset: 2px;
     }
   }
@@ -150,13 +159,13 @@ html:has(body [data-mg-preview-access]:not(.mg-preview-access--unlocked)) {
 // RTL / Arabic font swap. Roboto Condensed has no Arabic glyph coverage,
 // so swap heading/UI families when lang="ar" is set on the page.
 :lang(ar) {
-  .mg-preview-access__eyebrow,
   .mg-preview-access__title,
   .mg-preview-access__label,
   .mg-preview-access__submit {
     font-family: $mg-font-family-arabic-headings;
   }
 
+  .mg-preview-access__eyebrow,
   .mg-preview-access__body,
   .mg-preview-access__error,
   .mg-preview-access__contact {

--- a/stories/assets/js/preview-access.js
+++ b/stories/assets/js/preview-access.js
@@ -1,0 +1,237 @@
+// mg-preview-access
+// Soft preview gate for unfinished UNDRR pages.
+//
+// The presence of an element with [data-mg-preview-access] in the body
+// activates the gate. CSS hides the page on parse via :has(); this script
+// layers a modal on top asking for a PIN. On success, the gate is marked
+// unlocked and the unlock is persisted in sessionStorage.
+//
+// Not a security mechanism. The PIN lives in the DOM. Treat this as a
+// "wet paint" sign — strong, unmissable, but trivial to bypass for anyone
+// who wants to. If a page genuinely must not be seen, gate it at the edge
+// (e.g., Cloudflare Access).
+
+const DEFAULTS = {
+  pin: '5498',
+  eyebrow: 'UNDRR · Preview',
+  title: 'Preview access required',
+  message:
+    'This page is in preview and is not yet ready for general distribution. ' +
+    'Please enter the access PIN provided by UNDRR to continue.',
+  contactUrl: 'https://www.undrr.org/contact-us',
+  contactLabel: 'Need help? Contact UNDRR',
+  pinLabel: 'Access PIN',
+  submitLabel: 'Unlock',
+  errorMessage: 'That PIN is not correct. Please try again.',
+};
+
+const STORAGE_PREFIX = 'mg-preview-access:';
+const TITLE_ID = 'mg-preview-access-title';
+const BODY_ID = 'mg-preview-access-body';
+const ERROR_ID = 'mg-preview-access-error';
+const INPUT_ID = 'mg-preview-access-pin';
+
+function readConfig(el) {
+  return {
+    id:
+      el.getAttribute('data-mg-preview-id') ||
+      (typeof window !== 'undefined' ? window.location.pathname : 'default'),
+    pin: el.getAttribute('data-mg-preview-pin') || DEFAULTS.pin,
+    eyebrow: el.getAttribute('data-mg-preview-eyebrow') || DEFAULTS.eyebrow,
+    title: el.getAttribute('data-mg-preview-title') || DEFAULTS.title,
+    message: el.getAttribute('data-mg-preview-message') || DEFAULTS.message,
+    contactUrl:
+      el.getAttribute('data-mg-preview-contact-url') || DEFAULTS.contactUrl,
+    contactLabel:
+      el.getAttribute('data-mg-preview-contact-label') || DEFAULTS.contactLabel,
+    pinLabel: el.getAttribute('data-mg-preview-pin-label') || DEFAULTS.pinLabel,
+    submitLabel:
+      el.getAttribute('data-mg-preview-submit-label') || DEFAULTS.submitLabel,
+    errorMessage:
+      el.getAttribute('data-mg-preview-error-message') ||
+      DEFAULTS.errorMessage,
+  };
+}
+
+function isUnlocked(id) {
+  try {
+    return sessionStorage.getItem(STORAGE_PREFIX + id) === 'unlocked';
+  } catch (e) {
+    return false;
+  }
+}
+
+function persistUnlock(id) {
+  try {
+    sessionStorage.setItem(STORAGE_PREFIX + id, 'unlocked');
+  } catch (e) {
+    // Private mode etc. — best effort.
+  }
+}
+
+function markUnlocked(gate) {
+  gate.classList.add('mg-preview-access--unlocked');
+}
+
+function escapeText(value) {
+  return String(value).replace(/[&<>"']/g, c => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[c]);
+}
+
+function buildOverlay(config) {
+  const overlay = document.createElement('div');
+  overlay.className = 'mg-preview-access__overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', TITLE_ID);
+  overlay.setAttribute('aria-describedby', BODY_ID);
+
+  overlay.innerHTML =
+    `<div class="mg-preview-access__modal">` +
+      `<p class="mg-preview-access__eyebrow">${escapeText(config.eyebrow)}</p>` +
+      `<h1 class="mg-preview-access__title" id="${TITLE_ID}">${escapeText(config.title)}</h1>` +
+      `<p class="mg-preview-access__body" id="${BODY_ID}">${escapeText(config.message)}</p>` +
+      `<form class="mg-preview-access__form" novalidate>` +
+        `<label class="mg-preview-access__label" for="${INPUT_ID}">${escapeText(config.pinLabel)}</label>` +
+        `<div class="mg-preview-access__field">` +
+          `<input class="mg-preview-access__input" id="${INPUT_ID}" ` +
+            `type="text" inputmode="numeric" autocomplete="off" ` +
+            `autocapitalize="off" spellcheck="false" ` +
+            `aria-describedby="${ERROR_ID}" />` +
+          `<button class="mg-preview-access__submit" type="submit">${escapeText(config.submitLabel)}</button>` +
+        `</div>` +
+        `<p class="mg-preview-access__error" id="${ERROR_ID}" role="alert" aria-live="polite"></p>` +
+      `</form>` +
+      `<p class="mg-preview-access__contact">` +
+        `<a href="${escapeText(config.contactUrl)}">${escapeText(config.contactLabel)}</a>` +
+      `</p>` +
+    `</div>`;
+
+  return overlay;
+}
+
+/**
+ * Set/unset `inert` on every direct child of <body> except the overlay.
+ * Gives focus-trapping, screen-reader hiding, and pointer-blocking in one.
+ */
+function setSiblingsInert(overlay, on) {
+  const children = document.body.children;
+  for (let i = 0; i < children.length; i += 1) {
+    const child = children[i];
+    if (child === overlay) continue;
+    if (on) {
+      child.setAttribute('inert', '');
+      child.setAttribute('aria-hidden', 'true');
+    } else {
+      child.removeAttribute('inert');
+      child.removeAttribute('aria-hidden');
+    }
+  }
+}
+
+function unlockGate(gate, overlay, config) {
+  persistUnlock(config.id);
+  markUnlocked(gate);
+  setSiblingsInert(overlay, false);
+  overlay.remove();
+}
+
+function bindHandlers(overlay, gate, config) {
+  const form = overlay.querySelector('.mg-preview-access__form');
+  const input = overlay.querySelector('.mg-preview-access__input');
+  const error = overlay.querySelector('.mg-preview-access__error');
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const value = (input.value || '').trim();
+    if (value === String(config.pin)) {
+      unlockGate(gate, overlay, config);
+    } else {
+      error.textContent = config.errorMessage;
+      input.select();
+    }
+  });
+
+  input.addEventListener('input', () => {
+    if (error.textContent) error.textContent = '';
+  });
+}
+
+/**
+ * Initialise preview-access gates.
+ *
+ * @param {NodeList|HTMLElement[]|HTMLElement} [scope] - Elements to init.
+ *   Accepts a NodeList, array, or single HTMLElement. Defaults to the first
+ *   [data-mg-preview-access] in the document.
+ */
+export function mgPreviewAccess(scope) {
+  let gates;
+  if (scope) {
+    gates = scope instanceof HTMLElement ? [scope] : Array.from(scope);
+  } else {
+    const first = document.querySelector('[data-mg-preview-access]');
+    gates = first ? [first] : [];
+  }
+
+  gates.forEach(gate => {
+    if (!scope && gate.hasAttribute('data-mg-preview-access-skip-auto-init')) return;
+    if (gate.dataset.mgPreviewAccessInitialized) return;
+    gate.dataset.mgPreviewAccessInitialized = 'true';
+
+    const config = readConfig(gate);
+
+    if (isUnlocked(config.id)) {
+      markUnlocked(gate);
+      return;
+    }
+
+    const overlay = buildOverlay(config);
+    document.body.appendChild(overlay);
+    setSiblingsInert(overlay, true);
+    bindHandlers(overlay, gate, config);
+    gate._mgPreviewAccessOverlay = overlay;
+
+    // Move focus into the modal once layout settles.
+    requestAnimationFrame(() => {
+      const input = overlay.querySelector('.mg-preview-access__input');
+      if (input) input.focus();
+    });
+  });
+}
+
+/**
+ * Tear down a preview-access gate. Removes the overlay (if still mounted),
+ * restores body siblings, and clears the init flag.
+ *
+ * @param {HTMLElement} gate - The [data-mg-preview-access] element.
+ */
+export function mgPreviewAccessDestroy(gate) {
+  if (!gate) return;
+  const overlay = gate._mgPreviewAccessOverlay;
+  if (overlay && overlay.parentNode) {
+    setSiblingsInert(overlay, false);
+    overlay.remove();
+  }
+  gate._mgPreviewAccessOverlay = null;
+  delete gate.dataset.mgPreviewAccessInitialized;
+  gate.classList.remove('mg-preview-access--unlocked');
+}
+
+// Expose for manual re-init (e.g., SPA route changes), matching the
+// mgShowMore / mgOnThisPageNav vanilla utility pattern.
+if (typeof window !== 'undefined') {
+  window.mgPreviewAccess = mgPreviewAccess;
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => mgPreviewAccess());
+  } else {
+    mgPreviewAccess();
+  }
+}

--- a/stories/assets/js/preview-access.js
+++ b/stories/assets/js/preview-access.js
@@ -3,13 +3,13 @@
 //
 // The presence of an element with [data-mg-preview-access] in the body
 // activates the gate. CSS hides the page on parse via :has(); this script
-// layers a modal on top asking for a PIN. On success, the gate is marked
+// layers a modal over it and asks for a PIN. On success, the gate is marked
 // unlocked and the unlock is persisted in sessionStorage.
 //
 // Not a security mechanism. The PIN lives in the DOM. Treat this as a
-// "wet paint" sign — strong, unmissable, but trivial to bypass for anyone
+// "wet paint" sign: strong, unmissable, but trivial to bypass for anyone
 // who wants to. If a page genuinely must not be seen, gate it at the edge
-// (e.g., Cloudflare Access).
+// (for example, Cloudflare Access).
 
 const DEFAULTS = {
   pin: '5498',
@@ -31,6 +31,31 @@ const BODY_ID = 'mg-preview-access-body';
 const ERROR_ID = 'mg-preview-access-error';
 const INPUT_ID = 'mg-preview-access-pin';
 
+// Schemes allowed for the contact URL. Anything else (javascript:, data:, etc.)
+// is rejected to the default UNDRR contact page.
+const SAFE_URL_SCHEMES = ['http:', 'https:', 'mailto:'];
+
+// Module-scoped registry of overlays and the elements that previously held focus.
+// WeakMap keyed by gate avoids stashing DOM-side expandos and lets the entries
+// drop when a gate is detached and unreferenced.
+const overlays = new WeakMap();
+const previousFocus = new WeakMap();
+
+/**
+ * Validate that a contact URL uses an allow-listed scheme. Returns the URL
+ * string when safe; falls back to the default contact page otherwise.
+ */
+function safeContactUrl(value) {
+  if (!value) return DEFAULTS.contactUrl;
+  try {
+    const url = new URL(value, window.location.href);
+    if (SAFE_URL_SCHEMES.includes(url.protocol)) return value;
+  } catch (e) {
+    // Fall through to default.
+  }
+  return DEFAULTS.contactUrl;
+}
+
 function readConfig(el) {
   return {
     id:
@@ -40,8 +65,7 @@ function readConfig(el) {
     eyebrow: el.getAttribute('data-mg-preview-eyebrow') || DEFAULTS.eyebrow,
     title: el.getAttribute('data-mg-preview-title') || DEFAULTS.title,
     message: el.getAttribute('data-mg-preview-message') || DEFAULTS.message,
-    contactUrl:
-      el.getAttribute('data-mg-preview-contact-url') || DEFAULTS.contactUrl,
+    contactUrl: safeContactUrl(el.getAttribute('data-mg-preview-contact-url')),
     contactLabel:
       el.getAttribute('data-mg-preview-contact-label') || DEFAULTS.contactLabel,
     pinLabel: el.getAttribute('data-mg-preview-pin-label') || DEFAULTS.pinLabel,
@@ -86,15 +110,14 @@ function escapeText(value) {
 function buildOverlay(config) {
   const overlay = document.createElement('div');
   overlay.className = 'mg-preview-access__overlay';
-  overlay.setAttribute('role', 'dialog');
-  overlay.setAttribute('aria-modal', 'true');
-  overlay.setAttribute('aria-labelledby', TITLE_ID);
-  overlay.setAttribute('aria-describedby', BODY_ID);
 
+  // role="dialog" and the labelling/description references live on the modal
+  // panel, not the overlay scrim — the scrim is presentational.
   overlay.innerHTML =
-    `<div class="mg-preview-access__modal">` +
+    `<div class="mg-preview-access__modal" role="dialog" aria-modal="true" ` +
+      `aria-labelledby="${TITLE_ID}" aria-describedby="${BODY_ID}">` +
       `<p class="mg-preview-access__eyebrow">${escapeText(config.eyebrow)}</p>` +
-      `<h1 class="mg-preview-access__title" id="${TITLE_ID}">${escapeText(config.title)}</h1>` +
+      `<h2 class="mg-preview-access__title" id="${TITLE_ID}">${escapeText(config.title)}</h2>` +
       `<p class="mg-preview-access__body" id="${BODY_ID}">${escapeText(config.message)}</p>` +
       `<form class="mg-preview-access__form" novalidate>` +
         `<label class="mg-preview-access__label" for="${INPUT_ID}">${escapeText(config.pinLabel)}</label>` +
@@ -105,7 +128,9 @@ function buildOverlay(config) {
             `aria-describedby="${ERROR_ID}" />` +
           `<button class="mg-preview-access__submit" type="submit">${escapeText(config.submitLabel)}</button>` +
         `</div>` +
-        `<p class="mg-preview-access__error" id="${ERROR_ID}" role="alert" aria-live="polite"></p>` +
+        // role="alert" implies aria-live="assertive" + aria-atomic="true"; do
+        // not also set aria-live, that creates undefined behaviour.
+        `<p class="mg-preview-access__error" id="${ERROR_ID}" role="alert"></p>` +
       `</form>` +
       `<p class="mg-preview-access__contact">` +
         `<a href="${escapeText(config.contactUrl)}">${escapeText(config.contactLabel)}</a>` +
@@ -117,21 +142,19 @@ function buildOverlay(config) {
 
 /**
  * Set/unset `inert` on every direct child of <body> except the overlay.
- * Gives focus-trapping, screen-reader hiding, and pointer-blocking in one.
+ * Snapshots the children up front so subsequent DOM mutations cannot skew
+ * the iteration. `inert` already implies aria-hidden for assistive tech,
+ * so the redundant aria-hidden writes are intentionally omitted (ARIA 1.2).
  */
 function setSiblingsInert(overlay, on) {
-  const children = document.body.children;
-  for (let i = 0; i < children.length; i += 1) {
-    const child = children[i];
-    if (child === overlay) continue;
+  Array.from(document.body.children).forEach(child => {
+    if (child === overlay) return;
     if (on) {
       child.setAttribute('inert', '');
-      child.setAttribute('aria-hidden', 'true');
     } else {
       child.removeAttribute('inert');
-      child.removeAttribute('aria-hidden');
     }
-  }
+  });
 }
 
 function unlockGate(gate, overlay, config) {
@@ -139,6 +162,24 @@ function unlockGate(gate, overlay, config) {
   markUnlocked(gate);
   setSiblingsInert(overlay, false);
   overlay.remove();
+  overlays.delete(gate);
+
+  // Return focus to a known landmark so keyboard and screen reader users are
+  // not dropped on document.body with no announcement of the state change.
+  // The previously focused element (often body itself before mount) is the
+  // safest fallback; otherwise focus the now-revealed <main> or first heading.
+  const restore =
+    previousFocus.get(gate) ||
+    document.querySelector('main, [role="main"]') ||
+    document.querySelector('h1, h2') ||
+    document.body;
+  previousFocus.delete(gate);
+  if (restore && typeof restore.focus === 'function') {
+    if (restore === document.body && !restore.hasAttribute('tabindex')) {
+      restore.setAttribute('tabindex', '-1');
+    }
+    restore.focus({ preventScroll: true });
+  }
 }
 
 function bindHandlers(overlay, gate, config) {
@@ -157,8 +198,10 @@ function bindHandlers(overlay, gate, config) {
     }
   });
 
+  // Clear the error only when the input has a value; avoids flicker while the
+  // user is mid-correction and re-entering the same first character.
   input.addEventListener('input', () => {
-    if (error.textContent) error.textContent = '';
+    if (error.textContent && input.value) error.textContent = '';
   });
 }
 
@@ -190,11 +233,19 @@ export function mgPreviewAccess(scope) {
       return;
     }
 
+    // Capture whoever currently has focus so we can restore it on unlock.
+    previousFocus.set(
+      gate,
+      document.activeElement && document.activeElement !== document.body
+        ? document.activeElement
+        : null,
+    );
+
     const overlay = buildOverlay(config);
     document.body.appendChild(overlay);
     setSiblingsInert(overlay, true);
     bindHandlers(overlay, gate, config);
-    gate._mgPreviewAccessOverlay = overlay;
+    overlays.set(gate, overlay);
 
     // Move focus into the modal once layout settles.
     requestAnimationFrame(() => {
@@ -212,26 +263,40 @@ export function mgPreviewAccess(scope) {
  */
 export function mgPreviewAccessDestroy(gate) {
   if (!gate) return;
-  const overlay = gate._mgPreviewAccessOverlay;
+  const overlay = overlays.get(gate);
   if (overlay && overlay.parentNode) {
     setSiblingsInert(overlay, false);
     overlay.remove();
   }
-  gate._mgPreviewAccessOverlay = null;
+  overlays.delete(gate);
+  previousFocus.delete(gate);
   delete gate.dataset.mgPreviewAccessInitialized;
   gate.classList.remove('mg-preview-access--unlocked');
 }
 
-// Expose for manual re-init (e.g., SPA route changes), matching the
+// Expose for manual re-init (for example, SPA route changes), matching the
 // mgShowMore / mgOnThisPageNav vanilla utility pattern.
 if (typeof window !== 'undefined') {
   window.mgPreviewAccess = mgPreviewAccess;
 }
 
+// Auto-init only when a gate is already in the document. The guard prevents
+// the side effect of attaching an overlay if the module is imported by a
+// React/Storybook consumer that has not yet rendered (or may never render) a
+// real gate.
+function autoInit() {
+  if (
+    typeof document !== 'undefined' &&
+    document.querySelector('[data-mg-preview-access]')
+  ) {
+    mgPreviewAccess();
+  }
+}
+
 if (typeof document !== 'undefined') {
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => mgPreviewAccess());
+    document.addEventListener('DOMContentLoaded', autoInit);
   } else {
-    mgPreviewAccess();
+    autoInit();
   }
 }

--- a/stories/assets/scss/_components.scss
+++ b/stories/assets/scss/_components.scss
@@ -66,6 +66,7 @@
 // CSS+vanilla-JS component — Drupal integration via Gutenberg block, not a React export.
 @import "../../Components/TableOfContents/table-of-contents";
 @import "../../Components/OnThisPageNav/on-this-page-nav";
+@import "../../Components/PreviewAccess/preview-access";
 @import "../../Components/SyndicationSearchWidget/syndication-search-widget";
 
 // CSS+static-HTML component — not a React export. Static pages in dist/assets/error-pages/.

--- a/stories/assets/scss/_variables.scss
+++ b/stories/assets/scss/_variables.scss
@@ -418,6 +418,10 @@ $mg-z-index-dropdown: 2500; // Dropdowns and inline menus (above drawers)
 $mg-z-index-modal: 5000; // Modal and dialog (backdrop uses modal - 1 = 4999)
 $mg-z-index-toast: 5500; // Toast notifications (Snackbar), above modals
 
+// Modal scrim. Neutral-tinted by default so it reads as backdrop across all
+// themes; child themes can override for a branded scrim if desired.
+$mg-color-modal-scrim: rgba($mg-color-neutral-900, 0.85) !default;
+
 /**
   * @tokens-end
   */


### PR DESCRIPTION
## Summary

Adds a new vanilla JS + CSS preview-access component that drops onto any UNDRR page to gate it with a PIN-prompt modal until a reviewer enters the right code. Once unlocked, the gate stays unlocked for the rest of the browser session (`sessionStorage`-scoped). Implementation follows the spec handoff.

This is a **soft "wet paint" gate**, not access control. The PIN sits in the DOM and `sessionStorage`. The point is to give reviewers an unmistakable signal they're looking at a preview, not to prevent access. If a page genuinely must not be seen, gate it at the edge.

## What's in

- **`stories/assets/js/preview-access.js`** — vanilla JS runtime, ESM exports (`mgPreviewAccess`, `mgPreviewAccessDestroy`). Auto-inits on `DOMContentLoaded`. Honours a `data-mg-preview-access-skip-auto-init` opt-out. Builds the overlay, applies `inert` + `aria-hidden` to body siblings, persists the unlock in `sessionStorage`. Matches the `mgShowMore` / `mgOnThisPageNav` utility pattern.
- **`stories/Components/PreviewAccess/preview-access.scss`** — uses Mangrove tokens throughout (`$mg-z-index-modal`, `$mg-color-interactive`, `$mg-spacing-*`, `$mg-font-family-headings`). The `$mg-z-index-modal` token (5000) replaces the spec's hardcoded 9999. Includes a `:lang(ar)` block routing to `$mg-font-family-arabic-headings` / `$mg-font-family-arabic-body`.
- **`stories/Components/PreviewAccess/PreviewAccess.jsx`** — thin React wrapper. Renders a **static visual preview** of the modal panel by default (so Storybook docs aren't locked down). Pass `live` to mount the real body-level gate.
- **`stories/Components/PreviewAccess/PreviewAccess.stories.jsx`** — CSF3 stories: Default, Product-branded copy, Arabic (RTL), Live demo.
- **`stories/Components/PreviewAccess/PreviewAccess.mdx`** — full docs (when to use, how it works, vanilla HTML usage, data attributes table, CSS classes table, JS API, React usage, accessibility, RTL, known limitations, changelog).
- **`stories/Components/PreviewAccess/__tests__/PreviewAccess.test.jsx`** — 11 tests covering React preview rendering, runtime overlay construction, unlock flow, wrong-PIN error, error clearing on input, sessionStorage skip, sibling `inert` lifecycle, destroy cleanup, skip-auto-init flag. `jest-axe` on the static preview.
- Registered SCSS import in `stories/assets/scss/_components.scss`.
- AI manifest entry in `scripts/ai-manifest/component-data.js`.

## Out of scope

- **Drupal Twig template**: a node-level boolean field + site-level PIN config + a Twig fragment that renders the trigger div is the natural next step. Tracked separately for the multidomain platform.
- **Multi-zone gating**: the script honours one trigger per page (uses the first match). Multi-zone gating is a different pattern.
- **Dismissible variant**: no Escape-to-close. Deliberate — the gate should hold until a PIN is entered.
- **Edge-level access control**: out of scope by design. Use Cloudflare Access or similar if a page truly must not be seen.

## Test plan

- [x] `yarn lint:check` clean
- [x] `yarn test` — 738/738 passing (11 new tests in PreviewAccess)
- [x] `yarn build` — vanilla JS emitted to `dist/assets/js/preview-access.js`; SCSS rolled into all five theme CSS files (`style.css`, `style-preventionweb.css`, `style-irp.css`, `style-mcr.css`, `style-delta.css`)
- [ ] Visual check in Storybook: Default, Product-branded copy, Arabic (RTL) stories render the modal panel inline without locking the canvas
- [ ] Live demo story: clicking "Activate gate" overlays the canvas, correct PIN unlocks, wrong PIN shows error, Reset clears `sessionStorage` and re-arms
- [ ] Theme switcher: panel uses the active theme's `$mg-color-interactive` accent across all five themes
- [ ] RTL: `dir="rtl"` + Arabic copy renders with the Arabic font swap